### PR TITLE
fix(ci): point the smoke test at the deployed API and accept a 204 preflight

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -337,6 +337,7 @@ jobs:
           echo "migration_lambda_name=$(terraform output -raw migration_lambda_name)" >> $GITHUB_OUTPUT
           echo "hold_expiry_lambda_name=$(terraform output -raw hold_expiry_lambda_name)" >> $GITHUB_OUTPUT
           echo "payment_reconciliation_lambda_name=$(terraform output -raw payment_reconciliation_lambda_name)" >> $GITHUB_OUTPUT
+          echo "api_gateway_invoke_url=$(terraform output -raw api_gateway_invoke_url)" >> $GITHUB_OUTPUT
 
     outputs:
       booking_api_lambda_name: ${{ steps.tf_outputs.outputs.booking_api_lambda_name }}
@@ -344,6 +345,7 @@ jobs:
       migration_lambda_name: ${{ steps.tf_outputs.outputs.migration_lambda_name }}
       hold_expiry_lambda_name: ${{ steps.tf_outputs.outputs.hold_expiry_lambda_name }}
       payment_reconciliation_lambda_name: ${{ steps.tf_outputs.outputs.payment_reconciliation_lambda_name }}
+      api_gateway_invoke_url: ${{ steps.tf_outputs.outputs.api_gateway_invoke_url }}
 
   # ---------------------------------------------------------------------------
   # Lambda packaging and deployment
@@ -461,8 +463,14 @@ jobs:
 
       - name: Smoke test — post-deploy checks
         env:
-          BOOKING_API_BASE_URL: ${{ secrets.BOOKING_API_BASE_URL }}
-          SMOKE_ORIGIN: https://kalawala.com
+          # Taken from terraform, not from a secret. The BOOKING_API_BASE_URL
+          # secret still held a us-east-1 staging URL that no longer resolves, so
+          # every smoke check returned curl status 000000 (could not connect) and
+          # failed a deploy that had in fact succeeded.
+          BOOKING_API_BASE_URL: ${{ needs.terraform-apply.outputs.api_gateway_invoke_url }}
+          # Must be one of booking_api_allowed_origins in the tfvars, or the CORS
+          # preflight check fails against a perfectly healthy API.
+          SMOKE_ORIGIN: https://www.reservaskalawala.com
         run: |
           sleep 5
           bash scripts/smoke-test.sh

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -102,7 +102,17 @@ STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
   -H "Origin: $ORIGIN" \
   -H "Access-Control-Request-Method: POST" \
   "$BASE_URL/api/search" || echo "000")
-check "OPTIONS /api/search (CORS preflight)" "200" "$STATUS" ""
+# 200 and 204 are both valid preflight responses; API Gateway answers 204. Assert
+# on the CORS header instead, which is what actually has to be right.
+ACAO=$(curl -s -o /dev/null -w "%{http_code}"   --max-time "$TIMEOUT"   -X OPTIONS   -H "Origin: $ORIGIN"   -H "Access-Control-Request-Method: POST"   -D /tmp/smoke-preflight-headers.txt   "$BASE_URL/api/search" >/dev/null 2>&1; grep -ci "access-control-allow-origin" /tmp/smoke-preflight-headers.txt 2>/dev/null || echo 0)
+
+if [[ "$STATUS" == "200" || "$STATUS" == "204" ]] && [[ "$ACAO" -ge 1 ]]; then
+  green "OPTIONS /api/search (CORS preflight) (HTTP $STATUS, Access-Control-Allow-Origin present)"
+  PASS=$(( PASS + 1 ))
+else
+  red "OPTIONS /api/search (CORS preflight) — status $STATUS, Access-Control-Allow-Origin count $ACAO"
+  FAIL=$(( FAIL + 1 ))
+fi
 
 # ── summary ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
The deploy succeeded — all five Lambdas took the new code at 23:28 — but the final smoke step failed it for two unrelated reasons.

**1. Dead URL.** `BOOKING_API_BASE_URL` came from a repo secret last set in April, still holding a us-east-1 staging URL that no longer resolves. Every check returned curl status `000000` (could not connect). It now comes from the terraform output for the gateway we just deployed to, so it can't drift again.

**2. Wrong origin.** `SMOKE_ORIGIN` was `https://kalawala.com`, which isn't in `booking_api_allowed_origins` — the CORS preflight would have failed against a perfectly healthy API. Now `www.reservaskalawala.com`.

Also relaxed the preflight assertion: 200 and 204 are both valid and API Gateway answers 204. It now accepts either **and** asserts `Access-Control-Allow-Origin` is actually present — a stricter check than before, not a looser one.

Verified against live prod: **4 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)