### PR TITLE
fix(deps): drop the mkdirp override that broke npm ci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8434,6 +8434,19 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/extract-zip/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/extract-zip/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -11958,18 +11971,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -14973,6 +14974,20 @@
         "mime": "cli.js"
       }
     },
+    "node_modules/react-snap/node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/react-snap/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -16780,6 +16795,18 @@
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/svgo/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/svgo/node_modules/nth-check": {

--- a/package.json
+++ b/package.json
@@ -85,8 +85,7 @@
   "overrides": {
     "serialize-javascript": "6.0.2",
     "underscore": "1.13.8",
-    "minimist": "^1.2.8",
-    "mkdirp": "^1.0.4"
+    "minimist": "^1.2.8"
   },
   "reactSnap": {
     "source": "build",


### PR DESCRIPTION
My previous commit pinned `mkdirp` to `^1.0.4` alongside `minimist`. That broke installation outright:

```
TypeError: invalid options argument
  at optsArg (node_modules/mkdirp/lib/opts-arg.js:13:11)
  at module.exports (node_modules/extract-zip/index.js:15:3)
  at BrowserFetcher.download (node_modules/puppeteer/...)
```

`extract-zip` — reached through puppeteer, which react-snap depends on — calls mkdirp with the 0.5.x callback signature. mkdirp 1.x rejects it, so puppeteer's postinstall failed and **every job running `npm ci` died**, including Type Check, which had been passing.

The override was never needed. `mkdirp` was only flagged *via minimist*, so pinning minimist alone resolves it: **0 critical** with mkdirp left at the version react-snap expects.

## Verified properly this time

`node_modules` deleted → `npm ci` from scratch → tsc clean → CI-mode build compiles → 280 tests / 22 suites.

The original mistake was checking the audit result without ever testing a clean install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)