### PR TITLE
fix(ci): install Chromium system deps via playwright, not a hardcoded apt list

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,8 +140,16 @@ jobs:
         run: npm ci
       - name: Install Puppeteer dependencies for react-snap
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libgbm-dev libnss3 libatk-bridge2.0-0 libxkbcommon0 libgtk-3-0 libasound2
+          # Let Playwright resolve Chromium's system libraries instead of naming
+          # them by hand. The hardcoded list broke when ubuntu-latest moved to
+          # 24.04: the time_t transition renamed libasound2 -> libasound2t64
+          # (and libgtk-3-0, libatk-bridge2.0-0 likewise), so apt failed with
+          # "Package 'libasound2' has no installation candidate" and took the
+          # deploy with it. install-deps tracks the runner image for us.
+          #
+          # react-snap drives puppeteer's bundled Chromium, which needs the same
+          # shared libraries Playwright's chromium does.
+          npx playwright install-deps chromium
       - name: Build React App
         run: npm run build
         env:


### PR DESCRIPTION
`Build & Deploy` ran for the first time since April and died immediately:

```
E: Package 'libasound2' has no installation candidate
```

`ubuntu-latest` is now 24.04, where the 64-bit time_t transition renamed `libasound2` → `libasound2t64`. `libgtk-3-0` and `libatk-bridge2.0-0` moved the same way, so fixing the one name would just surface the next.

`npx playwright install-deps chromium` resolves the correct package names for whatever the runner image is. react-snap drives puppeteer's bundled Chromium, which needs the same shared libraries Playwright's does — and the E2E job already installs them this way successfully.

**This is very likely why the site stopped deploying.** Last green run was 2026-04-13; every run since failed here or at a gate in front of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)