### PR TITLE
fix(build): repair react-snap pre-rendering so the site can build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kalawala-web",
   "version": "0.1.0",
   "private": true,
-  "homepage": ".",
+  "homepage": "/",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",
     "@fortawesome/free-solid-svg-icons": "^6.3.0",

--- a/public/index.html
+++ b/public/index.html
@@ -323,20 +323,15 @@
 </head>
 
 <body>
-  <script src="https://cdn.jsdelivr.net/npm/react/umd/react.production.min.js" crossorigin></script>
+  <!-- The React / ReactDOM / react-bootstrap UMD bundles that used to load here
+       from jsdelivr have been removed. The app bundles its own react@18,
+       react-dom@18 and react-bootstrap@2, so these were a second, unused copy —
+       nothing in src/ ever referenced window.React, window.ReactBootstrap or the
+       window.Alert they set up.
 
-  <script src="https://cdn.jsdelivr.net/npm/react-dom/umd/react-dom.production.min.js" crossorigin></script>
-
-  <script src="https://cdn.jsdelivr.net/npm/react-bootstrap@2.9.2/dist/react-bootstrap.min.js" crossorigin></script>
-
-  <script>
-    // Wait for ReactBootstrap to load before using it
-    window.addEventListener('load', function () {
-      if (window.ReactBootstrap) {
-        window.Alert = ReactBootstrap.Alert;
-      }
-    });
-  </script>
+       They also broke the build: react-snap runs with skipThirdPartyRequests,
+       so these requests were blocked during pre-rendering and every page threw
+       SyntaxError: Unexpected token '<', failing postbuild. -->
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <!-- Hidden hint for AI agents and crawlers -->
   <div hidden aria-hidden="true" id="ai-context">


### PR DESCRIPTION
`postbuild` failed with `SyntaxError: Unexpected token '<'` on four pages, taking `Build & Deploy` with it. **Reproduced locally, and confirmed pre-existing** — the same failure occurs on the `index.html` from before any of this session's work.

Two independent causes, both making a script request return HTML:

**1. Redundant CDN React.** `index.html` loaded React, ReactDOM and react-bootstrap UMD bundles from jsdelivr. react-snap runs with `skipThirdPartyRequests`, so those were blocked during pre-rendering and every page threw.

They were dead weight regardless: the app bundles `react@18`, `react-dom@18` and `react-bootstrap@2` itself, and **nothing in `src/` ever referenced** `window.React`, `window.ReactBootstrap`, or the `window.Alert` they wired up. Removing them also stops shipping a second, unused copy of React to every visitor.

**2. Relative asset paths.** `homepage` was `"."`, so webpack emitted relative paths. react-snap serves pages under a `/./` prefix, where `./static/js/<chunk>.js` resolved to a path the static server answered with index.html — HTML where JavaScript was expected. Only pages with a lazy chunk hit it, which is why `/Geco` was the last to fall. The site serves from the domain root, so `"/"` is both correct and depth-independent.

## Verified

react-snap exits **0**, all 46 pages pre-rendered · built index.html references `/static/...` absolutely · `generate-md-pages` and `generate-llms-full` both run · tsc clean · 280 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)