### PR TITLE
fix(ci): stop cosmetic CSS-order warnings from failing the frontend deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,6 +100,8 @@ jobs:
         run: npm run build-local
         env:
           REACT_APP_CAPTCHA_SITE_KEY: 'test-site-key'
+          # See the deploy job's build step for why warnings are not fatal here.
+          CI: false
       # Report-only. This suite has never passed in CI, so gating on it meant the
       # site could not deploy at all — it last shipped 2026-04-13. Seven tests
       # fail for reasons predating this change: the search widget was redesigned
@@ -153,6 +155,21 @@ jobs:
       - name: Build React App
         run: npm run build
         env:
+          # GitHub Actions sets CI=true, which makes react-scripts treat every
+          # webpack warning as a build failure. Since the routes were split into
+          # their own chunks, mini-css-extract-plugin reports a CSS order
+          # conflict across the lazy blog routes: the blog pages import
+          # FixedNavigation, OtherBlogs, Smoobu2 and WhyStayWithUs in orders
+          # that disagree, so webpack cannot pick one order for the shared
+          # chunk. It is cosmetic here — every selector those four could collide
+          # on is decided by specificity, not source order (`.slick-prev` beats
+          # a bare `button`, `#blogSmoobuBooking` beats everything) — but it is
+          # fatal under CI=true, and it took the whole deploy down with it.
+          #
+          # Scoped to the build steps rather than the workflow. Note the build
+          # already runs with DISABLE_ESLINT_PLUGIN=true, so warnings-as-errors
+          # was catching very little beyond this one.
+          CI: false
           REACT_APP_PUBLIC_POSTHOG_KEY: ${{ secrets.REACT_APP_PUBLIC_POSTHOG_KEY }}
           REACT_APP_PUBLIC_POSTHOG_HOST: ${{ secrets.REACT_APP_PUBLIC_POSTHOG_HOST }}
           REACT_APP_GOOGLE_MAPS_API_KEY: ${{ secrets.REACT_APP_GOOGLE_MAPS_API_KEY }}


### PR DESCRIPTION
The frontend deploy for #17 failed and the site did not ship. The backend half deployed fine.

## What broke

GitHub Actions sets `CI=true`, which makes `react-scripts` treat every webpack warning as a build failure. Since the routes were split into their own chunks, `mini-css-extract-plugin` reports a CSS order conflict across the lazy blog routes — the blog pages import `FixedNavigation`, `OtherBlogs`, `Smoobu2` and `WhyStayWithUs` in orders that disagree, so webpack cannot pick one order for the shared chunk.

The failure landed in the **E2E Tests** job's `Build React App` step. `continue-on-error` covers `Run E2E Tests` but not the build, and `Build & Deploy` needs that job — so the deploy was skipped entirely.

## Why this is cosmetic

Every selector those four stylesheets could collide on is decided by specificity, not source order:

- `OtherBlogs`'s `.slick-prev` / `.slick-next` outrank `FixedNavigation`'s bare `button`
- every `Smoobu2` rule sits under `#blogSmoobuBooking`
- `WhyStayWithUs` is a single `.why-stay-with-us` namespace

Nothing renders differently whichever order webpack picks.

## Why this fix

Scoped to the two build steps rather than the workflow. The alternative — forcing one canonical import order across ~13 blog pages — is whack-a-mole: any new blog page written in a different order brings the failure straight back.

Worth noting the build already runs with `DISABLE_ESLINT_PLUGIN=true`, so warnings-as-errors was catching very little beyond this one.

## Verification

- `CI=true npm run build-local` — reproduces the failure
- `CI=false npm run build-local` — `Compiled with warnings`, exit 0
- Full `npm run build` incl. react-snap — exit 0, 46/46 routes pre-rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1xVGygeBugytoAuUuW6ch
