### PR TITLE
Home card photo prominence, nav glass redesign, sticky CTA fix

### DIFF
--- a/src/components/FixedNavigation/FixedNavigation.style.scss
+++ b/src/components/FixedNavigation/FixedNavigation.style.scss
@@ -13,9 +13,11 @@
   /* Lock height for consistency */
   position: sticky;
   top: 0;
-  background-color: var(--kalawala-darker-green);
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
+  background-color: rgba(0, 0, 0, 0.2);
+  -webkit-backdrop-filter: blur(20px) saturate(200%) brightness(1.2);
+  backdrop-filter: blur(20px) saturate(200%) brightness(1.2);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 8px 30px rgba(0, 0, 0, 0.2);
 
   &.navbar {
     border-radius: 0;
@@ -29,17 +31,21 @@
   .navMenu {
     .navText {
       font-size: 16px;
-      color: var(--kalawala-text-gray);
-      /* Color del texto principal */
+      // Light text for the dark glass bar — .navText is reused inside the
+      // mobile dropdown panel below, which is light and overrides this back
+      // to a dark color there. Shadow keeps it legible now that the glass
+      // is transparent enough for bright backdrops to show through.
+      color: var(--kalawala-light-cream);
+      text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
       line-height: 1.2;
 
       /* Consistent line height */
       &.active {
-        color: $primary-color;
+        color: $kalawala-vivid-beige;
       }
 
       &:hover {
-        color: $primary-color;
+        color: $kalawala-vivid-beige;
       }
     }
   }
@@ -105,15 +111,16 @@
     /* Show mobile flag */
   }
 
-  /* Fix navbar positioning - use radial gradient from top-left corner */
+  /* Fix navbar positioning - use sticky but ensure proper z-index */
   .navigation {
     position: sticky !important;
     top: 0 !important;
     z-index: 1000;
-    background: radial-gradient(ellipse at top left, var(--kalawala-light-green) 0%, #FFFEF7 70%) !important;
-    /* Radial gradient from green in top-left corner to cream */
-    -webkit-backdrop-filter: none !important;
-    backdrop-filter: none !important;
+    background-color: rgba(0, 0, 0, 0.2);
+    -webkit-backdrop-filter: blur(20px) saturate(200%) brightness(1.2);
+    backdrop-filter: blur(20px) saturate(200%) brightness(1.2);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 8px 30px rgba(0, 0, 0, 0.2);
   }
 
   /* Fix hamburger menu positioning and margins */
@@ -134,15 +141,13 @@
   .navigation .navbar-collapse.show,
   .navbar-collapse,
   .navbar-collapse.show {
-    background-color: #FFFEF7 !important;
-    /* Use light cream color for mobile menu */
-    backdrop-filter: none !important;
-    -webkit-backdrop-filter: none !important;
+    background-color: rgba(255, 255, 255, 0.65) !important;
+    backdrop-filter: blur(20px) saturate(180%) !important;
+    -webkit-backdrop-filter: blur(20px) saturate(180%) !important;
     border-radius: 8px !important;
     padding: 20px 15px !important;
     /* Increased padding for better spacing */
-    box-shadow: 0 4px 12px rgba(11, 48, 40, 0.2) !important;
-    /* Shadow using brand darker green */
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15) !important;
     position: absolute !important;
     top: 100% !important;
     left: 10px !important;

--- a/src/components/OurHomes/Components/HomeCard.component.tsx
+++ b/src/components/OurHomes/Components/HomeCard.component.tsx
@@ -27,7 +27,7 @@ const HomeCard: FC<IHomeCard> = ({ guestNumber, parking, name, image, houseLangC
         <div className="home-card-item" data-wow-duration="500ms" onClick={handleClick}>
             <div className="block">
                 <div className="icon-box d-block mx-auto">
-                    <img src={image} alt={name} className="img-fluid rounded our-homes-img-m" width={1000} height={667} loading="lazy" decoding="async" srcSet={cdnSrcSet(image)} sizes="160px" />
+                    <img src={image} alt={name} className="img-fluid rounded our-homes-img-m" width={1000} height={667} loading="lazy" decoding="async" srcSet={cdnSrcSet(image)} sizes="(max-width: 767px) 90vw, (max-width: 1199px) 45vw, 350px" />
                 </div>
                 <div className="content text-center">
                     <h3 className="highlight">{name}</h3>

--- a/src/components/OurHomes/Components/HomeCard.style.scss
+++ b/src/components/OurHomes/Components/HomeCard.style.scss
@@ -118,91 +118,51 @@
       margin-bottom:20px;
       position: relative;
       z-index: 1;
-      
+
       // Mobile-specific styling to make cards bigger
       @media (max-width: 768px) {
         padding: 20px 15px; // Reduce padding on mobile to make more room for image
       }
-      
+
       &:hover {
         border-bottom:2px solid $primary-color;
       }
       &:hover .icon-box {
         transform: translateY(-10px);
       }
+      // !important throughout: this same `.about .block .icon-box` selector is
+      // also defined, at equal specificity, in styles/style.css and the legacy
+      // templates/about_us.scss (fixed 160x92 icon frame + diamond corners for
+      // what was originally a small template icon, not a full photo) — without
+      // !important, whichever of those loads last in the CSS-splitting order
+      // wins per-property instead of this one.
       .icon-box {
         position: relative;
-        width: 160px; 
-        height: 92.38px;
+        width: 100% !important;
+        aspect-ratio: 3 / 2;
+        height: auto !important;
         background-color: transparent;
-        margin: 46.19px auto 60px;
-        padding: 20px 0;
-        border-left: 2px solid $border-color;
-        border-right: 2px solid $border-color;
-        font-size: 50px;
+        margin: 0 auto 24px !important;
+        padding: 0 !important;
+        border: none !important;
         transform: translateZ(0px);
         transition-duration: 0.3s;
         transition-property: transform;
-        
-        // Make icon-box bigger on mobile
-        @media (max-width: 768px) {
-          width: 250px; // Increase width significantly for bigger image
-          height: 140px; // Increase height for bigger image
-          margin: 30px auto 50px; // Reduce top/bottom margins to save space
+
+        &::before, &::after {
+          content: none !important; // kill the legacy diamond icon frame
         }
-        
-        &:after, &:before {
-          content: "";
-          position: absolute;
-          z-index: 1;
-          width: 113.14px;
-          height: 113.14px;
-          background-color: inherit;
-          left: 20.4315px;
-          transform: scaleY(0.5774) rotate(-45deg);
-          
-          // Adjust positioning for mobile
-          @media (max-width: 768px) {
-            width: 177px; // Proportionally increase for larger icon-box
-            height: 177px;
-            left: 32px; // Adjust positioning for larger width
-          }
-        }
-        &:before {
-          top: -56.5685px;
-          border-top: 2px solid rgba(236, 239, 241, 0.07);
-          border-right: 2px solid rgba(236, 239, 241, 0.07);
-          
-          @media (max-width: 768px) {
-            top: -88px; // Adjust for larger size
-          }
-        }
-        &:after {
-          bottom: -56.5685px;
-          border-bottom: 2px solid rgba(236, 239, 241, 0.07);
-          border-left: 2px solid rgba(236, 239, 241, 0.07);
-          
-          @media (max-width: 768px) {
-            bottom: -88px; // Adjust for larger size
-          }
-        }
-        h3 {
-          color: $kalawala-text-gray; // was #afbac4 — a dark-theme leftover
-        }
-        
-        // Make images bigger on mobile
+
+        // Photo fills the box edge-to-edge — no more diamond icon frame
         .our-homes-img-m {
-          @media (max-width: 768px) {
-            width: 100%;
-            height: auto;
-            min-height: 160px; // Increase minimum height significantly
-            max-height: 180px; // Set max height to prevent overflow
-            object-fit: cover;
-            border-radius: 8px; // Add some rounding like HelpMeChoose
-          }
+          width: 100% !important;
+          height: 100% !important;
+          margin: 0 !important;
+          object-fit: cover;
+          border-radius: 12px;
         }
       }
-      
+
       // Make content text bigger on mobile
       .content {
         h3 {

--- a/src/components/OurHomes/Components/NamCard.component.tsx
+++ b/src/components/OurHomes/Components/NamCard.component.tsx
@@ -27,7 +27,7 @@ const NamCard: FC<IHomeCard> = ({ guestNumber, name, image, houseLangCode }) => 
         <div className="col-lg-3 col-md-6 col-sm-6 col-12" data-wow-duration="500ms" onClick={handleClick}>
             <div className="block">
                 <div className="icon-box d-block mx-auto">
-                    <img src={image} alt={name} className="img-fluid rounded our-homes-img-m" width={1000} height={667} loading="lazy" decoding="async" srcSet={cdnSrcSet(image)} sizes="160px" />
+                    <img src={image} alt={name} className="img-fluid rounded our-homes-img-m" width={1000} height={667} loading="lazy" decoding="async" srcSet={cdnSrcSet(image)} sizes="(max-width: 767px) 90vw, (max-width: 1199px) 45vw, 350px" />
                 </div>
                 <div className="content text-center">
                     <h3 className="highlight">{name}</h3>

--- a/src/components/OurHomes/Components/VillaCard.component.tsx
+++ b/src/components/OurHomes/Components/VillaCard.component.tsx
@@ -27,11 +27,12 @@ const VillaCard: FC<IHomeCard> = ({ guestNumber, name, image, houseLangCode }) =
         <div className="col-lg-3 col-md-6 col-sm-6 col-12" data-wow-duration="500ms" onClick={handleClick}>
             <div className="block">
                 <div className="icon-box d-block mx-auto">
-                    {/* Laid out at 156px at every breakpoint (measured with
-                        scripts/image-audit.mjs), so `sizes` says so rather than
-                        letting the browser assume full width and fetch w960. */}
+                    {/* Card now shows a full-width photo (see HomeCard.style.scss
+                        .icon-box), so `sizes` tracks the card width per breakpoint
+                        instead of the old fixed 156px icon frame — re-measure with
+                        scripts/image-audit.mjs if the grid layout changes. */}
                     <img
-                        src={cdnImage(image, 320)}
+                        src={cdnImage(image, 640)}
                         alt={name}
                         className="img-fluid rounded our-homes-img-m"
                         width="300"
@@ -39,7 +40,7 @@ const VillaCard: FC<IHomeCard> = ({ guestNumber, name, image, houseLangCode }) =
                         loading="lazy"
                         decoding="async"
                         srcSet={cdnSrcSet(image)}
-                        sizes="160px"
+                        sizes="(max-width: 767px) 90vw, (max-width: 1199px) 45vw, 350px"
                     />
                 </div>
                 <div className="content text-center">

--- a/src/components/OurHomes/OurHomes.style.scss
+++ b/src/components/OurHomes/OurHomes.style.scss
@@ -1,64 +1,12 @@
 @use '../../styles/mixins';
 @import  '../../styles//styles.scss';
 
-.about {
-    .block {
-      background: $kalawala-light-cream; // was #242930 — a dark-theme leftover
-      padding:30px;
-      border-bottom:2px solid transparent;
-      transition: .5s all;
-      margin-bottom:0px;
-      &:hover {
-        border-bottom:2px solid $primary-color;
-      }
-      &:hover .icon-box {
-        transform: translateY(-10px);
-      }
-      .icon-box {
-        position: relative;
-        width: 160px; 
-        height: 92.38px;
-        background-color: transparent;
-        margin: 46.19px auto 60px;
-        padding: 20px 0;
-        border-left: 2px solid $border-color;
-        border-right: 2px solid $border-color;
-        font-size: 50px;
-        transform: translateZ(0px);
-        transition-duration: 0.3s;
-        transition-property: transform;
-        &:after, &:before {
-          content: "";
-          position: absolute;
-          z-index: 1;
-          width: 113.14px;
-          height: 113.14px;
-          background-color: inherit;
-          left: 20.4315px;
-          transform: scaleY(0.5774) rotate(-45deg);
-        }
-        &:before {
-          top: -56.5685px;
-          border-top: 2px solid rgba(236, 239, 241, 0.07);
-          border-right: 2px solid rgba(236, 239, 241, 0.07);
-        }
-        &:after {
-          bottom: -56.5685px;
-          border-bottom: 2px solid rgba(236, 239, 241, 0.07);
-          border-left: 2px solid rgba(236, 239, 241, 0.07);
-        }
-        h3 {
-          color: $kalawala-text-gray; // was #afbac4 — a dark-theme leftover
-        }
-  
-      }
-      
-    }
-    
-  }
-  
-  
-  
+// .about .block styling (including .icon-box, the home photo frame) lives in
+// HomeCard.style.scss now — it's coupled to the card component that renders
+// the markup, and a second copy here was fighting it depending on CSS order.
+
+
+
   
   /*=================================================================
     About us 2 section

--- a/src/pages/Listing/Listing.style.scss
+++ b/src/pages/Listing/Listing.style.scss
@@ -158,6 +158,25 @@ html,
 
     // Sticky CTA button for mobile
     .sticky-cta-mobile {
+        // The bar pins itself rather than borrowing Bootstrap's .fixed-bottom.
+        // Every listing page carried that utility class except Tucano EN, where
+        // it was dropped and the markup moved inside `.heading`: the bar then
+        // laid out inline, `.info .button-hold`'s 50px clamped the box, and the
+        // button spilled out over the photo gallery. Owning the positioning
+        // here means losing the utility class cannot reproduce that.
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 1030; // same layer .fixed-bottom used; still under the modals
+
+        // Beats `.info .button-hold` on source order if the bar is ever nested
+        // back inside the info column.
+        &.button-hold {
+            height: auto;
+            margin: 0;
+        }
+
         background: rgba(255, 255, 255, 0.98); // More opaque background
         backdrop-filter: blur(15px);
         padding: 20px;

--- a/src/pages/Listing/staticPages/ListingTucano.page.tsx
+++ b/src/pages/Listing/staticPages/ListingTucano.page.tsx
@@ -51,6 +51,9 @@ const ListingTucano = () => {
                 <link rel="alternate" hrefLang="x-default" href="https://www.reservaskalawala.com/Tucano" />
             </Helmet>
             <FixedNavigation isBlog={false}/>
+            {isScreenSmall && (
+                <div className="button-hold fixed-bottom sticky-cta-mobile" style={{ paddingBottom: "env(safe-area-inset-bottom);" }}><Button className='btn-darker sticky-cta-button' href="#smoobuComp">Check Availability</Button></div>)}
+
             <Row className="subContainer">
                 <Col className="info col" lg={{ order: 'first', span: 10 }} md={{ order: 'first', span: 12 }} sm={12} xs={12}>
                     <div className="heading">
@@ -62,8 +65,6 @@ const ListingTucano = () => {
                         </p>
                         {/* Add marketing section after title */}
                         <ListingMarketingSection propertyKey="Tucano" isSpanish={false} />
-                        {isScreenSmall && (
-                            <div className="button-hold sticky-cta-mobile"><Button className='btn-darker sticky-cta-button' href="#smoobuComp">Check Availability</Button></div>)}
                     </div>
                     <ImagesContainer showModal={handleShow} houseName={listing!} />
                     {/* Add social statement after images */}

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -578,18 +578,6 @@ a:hover {
   Navigation
 ==================================================================*/
 
-.navigation {
-    background-color: rgba(189, 169, 109, 0);
-    /* Light cream color with 50% transparency */
-    width: 100%;
-    z-index: 99;
-    margin-bottom: 0;
-    padding-bottom: 40px;
-    padding-top: 20px;
-    background-image: linear-gradient(to bottom right, var(--kalawala-opaque-beige) 20%, rgba(255, 248, 240, 0) 50%, rgba(255, 248, 240, 0) 100%);
-    /*gradient of the menu*/
-}
-
 .navbar-toggler {
     color: var(--kalawala-darker-green) !important;
 }

--- a/tests/e2e/sticky-cta.spec.ts
+++ b/tests/e2e/sticky-cta.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect, devices } from '@playwright/test';
+
+/**
+ * The mobile "Check Availability" bar.
+ *
+ * A PostHog replay caught it laid out inline on /Tucano, halfway up the page
+ * and painting over the photo gallery: that page had lost the `fixed-bottom`
+ * class the other nineteen listing pages carry, and `.info .button-hold`'s
+ * 50px height then clipped the button out of its own box.
+ *
+ * Twenty near-identical listing pages are easy to let drift apart, so this
+ * checks the bar on every one of them rather than on a sample.
+ */
+
+const EN_SLUGS = [
+  'Geco',
+  'Rana',
+  'Tucano',
+  'Pappagallo',
+  'Delfin',
+  'Giulia',
+  'Areka',
+  'Plumeria',
+  'VillaCoral',
+  'VillaMar',
+];
+
+test.use({ ...devices['Pixel 5'] });
+
+for (const slug of [...EN_SLUGS, ...EN_SLUGS.map((s) => `${s}ES`)]) {
+  test(`/${slug} pins the mobile CTA to the bottom of the viewport`, async ({ page }) => {
+    await page.goto(`/${slug}`);
+
+    const bar = page.locator('.sticky-cta-mobile');
+    await expect(bar).toBeVisible();
+
+    // Pinned, not scrolled with the document.
+    await expect(bar).toHaveCSS('position', 'fixed');
+
+    const viewport = page.viewportSize()!;
+    const atTop = await bar.boundingBox();
+    expect(atTop).not.toBeNull();
+    expect(Math.round(atTop!.y + atTop!.height)).toBeCloseTo(viewport.height, -1);
+
+    // The button has to fit inside the bar — the original bug was a 50px box
+    // holding a ~98px button, which is what overlapped the gallery.
+    const button = bar.locator('.sticky-cta-button');
+    const buttonBox = (await button.boundingBox())!;
+    expect(buttonBox.y).toBeGreaterThanOrEqual(atTop!.y - 1);
+    expect(buttonBox.y + buttonBox.height).toBeLessThanOrEqual(
+      atTop!.y + atTop!.height + 1,
+    );
+
+    // Still pinned after scrolling down the page.
+    await page.evaluate(() => window.scrollBy(0, 1500));
+    const afterScroll = (await bar.boundingBox())!;
+    expect(Math.round(afterScroll.y)).toBe(Math.round(atTop!.y));
+
+    // And it still points at the booking widget.
+    await expect(button).toHaveAttribute('href', '#smoobuComp');
+  });
+}


### PR DESCRIPTION
## Summary
- Home cards (Nuestras Casas grid + Villa/Nam variants): photos now fill the card edge-to-edge at a 3:2 aspect ratio instead of a tiny 160x92px icon frame with decorative diamond corners left over from the original template. Fixed a 3-way CSS specificity conflict (`style.css`, legacy `templates/about_us.scss`, `OurHomes.style.scss`) that made the box size depend on unpredictable load order.
- Fixed navigation bar: redesigned to a dark, blurred glass effect (backdrop-filter blur/saturate/brightness) with light text, replacing the solid dark-green bar and mobile radial gradient.
- Listing pages: the mobile "Check Availability" bar now pins itself with its own `position: fixed` instead of depending on the `fixed-bottom` utility class — Tucano had lost that class and the button was spilling out over the photo gallery. Added a Playwright regression test covering the bar across all twenty listing pages (EN + ES).

## Test plan
- [x] Manually verified the home card grid (2-column, 5-item checkerboard, and single-card layouts) and the Villa cards section in a live dev server — photos render full-size with no gaps or leftover diamond artifacts.
- [ ] `npm run test:e2e` — run the new `tests/e2e/sticky-cta.spec.ts` suite (and the rest of the e2e suite) in CI.
- [ ] `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)