### PR TITLE
Fix findings from the site audit: broken CTAs, dead-end links, soft 404s, duplicate SEO tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "cross-env DISABLE_ESLINT_PLUGIN=true GENERATE_SOURCEMAP=false react-scripts build",
-    "postbuild": "react-snap && node scripts/inject-route-preloads.js && node scripts/generate-sitemap.js && node scripts/generate-md-pages.js && node scripts/generate-llms-full.js",
+    "postbuild": "react-snap && node scripts/generate-404.js && node scripts/inject-route-preloads.js && node scripts/generate-sitemap.js && node scripts/generate-md-pages.js && node scripts/generate-llms-full.js",
     "build-local": "cross-env DISABLE_ESLINT_PLUGIN=true react-scripts build",
     "booking-api:build": "npm --prefix booking-api run build",
     "booking-api:migrate": "npm --prefix booking-api run migrate",
@@ -109,6 +109,7 @@
     "crawl": false,
     "include": [
       "/",
+      "/404",
       "/Geco",
       "/Rana",
       "/Tucano",
@@ -134,6 +135,8 @@
       "/HomeNamES",
       "/HomeVillas",
       "/HomeVillasES",
+      "/blog",
+      "/blogES",
       "/twodaysinpuertoviejo",
       "/gettingtogandoca",
       "/travellingtopuertoviejo",

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,4 +1,14 @@
 # ============================================================================
+# 404 handling
+#
+# 404.html is copied from the pre-rendered build/404/index.html by
+# scripts/generate-404.js (runs in the postbuild chain, after react-snap).
+# ErrorDocument doesn't need mod_rewrite — it's what makes the mod_rewrite
+# catch-all's [R=404] below serve this page instead of the host's default.
+# ============================================================================
+ErrorDocument 404 /404.html
+
+# ============================================================================
 # Compression
 #
 # There were no compression directives here at all. Whether anything was
@@ -105,12 +115,29 @@
     RewriteRule ^llms\.txt$ - [L]
     RewriteRule ^llms-full\.txt$ - [L]
 
-    # Standard SPA fallback
     RewriteRule ^index\.html$ - [L]
+
+    # Client-side-only routes with no pre-rendered file: the booking engine,
+    # the guest portal, and the PayPal return page. Their content depends on
+    # server-side session state or query params, so react-snap never
+    # pre-renders them (see package.json's reactSnap.include) — they exist
+    # only once the SPA's own JS takes over. Send them to the SPA shell
+    # before the catch-all below turns them into false 404s.
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-l
-    RewriteRule . /index.html [L]
+    RewriteRule ^(book|bookES|portal|portalES|Success)(/.*)?$ /index.html [L]
+
+    # Everything else that isn't a real file, directory, or one of the routes
+    # above is genuinely unknown. This used to fall through to index.html
+    # with an HTTP 200 — a soft 404 that told search engines and any
+    # status-aware crawler an unrecognised URL was a real, indexable page.
+    # ErrorDocument (above) serves the branded 404 page; this just makes the
+    # status code honest.
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_FILENAME} !-l
+    RewriteRule . - [R=404,L]
 </IfModule>
 
 # Log AI crawler access for analytics (if mod_log_config available)

--- a/public/index.html
+++ b/public/index.html
@@ -75,8 +75,6 @@
   <link rel="icon" type="image/png" sizes="64x64" href="%PUBLIC_URL%/logo64.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#000000" />
-  <meta name="description"
-    content="Discover our homes, cheaper than any other platform! Welcome to Kalawala, we offer fully equipped vacation homes nestled in the heart of Puerto Viejo de Talamanca, Costa Rica. Our houses offer space for up to 5 people, 2 A/C units, fully equipped private bathroom and kitchen and free Wi-Fi internet connection." />
   <link rel="apple-touch-icon" sizes="192x192" href="%PUBLIC_URL%/logo192.png" />
   <!--
       manifest.json provides metadata used when your web app is installed on a
@@ -128,14 +126,21 @@
   <!-- LLM-friendly content link -->
   <link rel="alternate" type="text/markdown" href="/llms.txt" title="LLM-friendly site summary" />
 
-  <!-- No <link rel="canonical"> here.
-       Every routed page sets its own canonical via react-helmet, and
-       react-snap bakes that into the pre-rendered HTML. This file's copy was
-       appended too, so all 45 non-root pages shipped TWO conflicting
-       canonicals — the first of them pointing at the homepage. That is what
-       failed Lighthouse's `canonical` audit on every page except `/`.
-       Anything that varies per route (canonical, og:url, og:title,
-       og:description, og:locale) belongs in the page's <Helmet>, not here. -->
+  <!-- No <link rel="canonical"> and no <meta name="description"> here.
+       Every routed page sets both via react-helmet, and react-snap bakes
+       that into the pre-rendered HTML. This file's copies were appended
+       alongside them rather than replaced — react-helmet only manages tags
+       it added itself, so a tag already sitting in the static HTML before
+       React mounts is invisible to it and never gets removed. All 45+
+       non-root pages ended up shipping TWO of each: a page-specific one from
+       Helmet, and this file's generic one right before it in <head> order —
+       which most crawlers treat as authoritative, since it appears first.
+       That's what failed Lighthouse's `canonical` audit on every page except
+       `/`, and why every page's meta description looked identical regardless
+       of what its own <Helmet> declared.
+       Anything that varies per route (canonical, description, og:url,
+       og:title, og:description, og:locale) belongs in the page's <Helmet>,
+       not here. -->
 
   <!-- Open Graph defaults. Only genuinely site-wide values live here; the
        per-page overrides come from each page's <Helmet>. -->
@@ -149,131 +154,292 @@
 
   <!-- Schema.org JSON-LD structured data for AI and search engines -->
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "VacationRental",
-    "name": "Reservas Kalawala",
-    "description": "Family-run vacation rental company offering fully equipped houses and villas in Puerto Viejo de Talamanca, Costa Rica. 10 properties sleeping 2-8 guests with private kitchens, bathrooms, A/C, and free WiFi. Book direct for the best rates.",
-    "url": "https://www.reservaskalawala.com",
-    "image": "https://www.reservaskalawala.com/logo.png",
-    "address": {
-      "@type": "PostalAddress",
-      "addressLocality": "Puerto Viejo de Talamanca",
-      "addressRegion": "Limón",
-      "addressCountry": "CR"
+{
+  "@context": "https://schema.org",
+  "@type": "VacationRental",
+  "name": "Reservas Kalawala",
+  "description": "Family-run vacation rental company offering fully equipped houses and villas in Puerto Viejo de Talamanca, Costa Rica. 10 properties sleeping 2-8 guests with private kitchens, bathrooms, A/C, and free WiFi. Book direct for the best rates.",
+  "url": "https://www.reservaskalawala.com",
+  "image": "https://www.reservaskalawala.com/logo.png",
+  "address": {
+    "@type": "PostalAddress",
+    "addressLocality": "Puerto Viejo de Talamanca",
+    "addressRegion": "Limón",
+    "addressCountry": "CR"
+  },
+  "geo": {
+    "@type": "GeoCoordinates",
+    "latitude": 9.6561,
+    "longitude": -82.7539
+  },
+  "amenityFeature": [
+    {
+      "@type": "LocationFeatureSpecification",
+      "name": "Free WiFi",
+      "value": true
     },
-    "geo": {
-      "@type": "GeoCoordinates",
-      "latitude": 9.6561,
-      "longitude": -82.7539
+    {
+      "@type": "LocationFeatureSpecification",
+      "name": "Air Conditioning",
+      "value": true
     },
-    "amenityFeature": [
-      { "@type": "LocationFeatureSpecification", "name": "Free WiFi", "value": true },
-      { "@type": "LocationFeatureSpecification", "name": "Air Conditioning", "value": true },
-      { "@type": "LocationFeatureSpecification", "name": "Fully Equipped Kitchen", "value": true },
-      { "@type": "LocationFeatureSpecification", "name": "Private Bathroom", "value": true },
-      { "@type": "LocationFeatureSpecification", "name": "Pet Friendly", "value": true },
-      { "@type": "LocationFeatureSpecification", "name": "Free Parking", "value": true },
-      { "@type": "LocationFeatureSpecification", "name": "Towels and Toiletries", "value": true },
-      { "@type": "LocationFeatureSpecification", "name": "Bed Linens", "value": true }
-    ],
-    "numberOfRooms": 10,
-    "petsAllowed": true,
-    "checkinTime": "15:00",
-    "checkoutTime": "11:00",
-    "availableLanguage": ["English", "Spanish"],
-    "containsPlace": [
-      {
-        "@type": "Accommodation",
-        "name": "Casa Geco",
-        "url": "https://www.reservaskalawala.com/Geco",
-        "description": "2-bedroom house in the heart of Puerto Viejo, sleeps 5, private fenced parking, pet friendly, fully equipped kitchen, 2 A/C units, 100Mbps WiFi.",
-        "occupancy": { "@type": "QuantitativeValue", "maxValue": 5 },
-        "numberOfBedrooms": 2,
-        "numberOfBathroomsTotal": 1,
-        "petsAllowed": true
+    {
+      "@type": "LocationFeatureSpecification",
+      "name": "Fully Equipped Kitchen",
+      "value": true
+    },
+    {
+      "@type": "LocationFeatureSpecification",
+      "name": "Private Bathroom",
+      "value": true
+    },
+    {
+      "@type": "LocationFeatureSpecification",
+      "name": "Pet Friendly",
+      "value": true
+    },
+    {
+      "@type": "LocationFeatureSpecification",
+      "name": "Free Parking",
+      "value": true
+    },
+    {
+      "@type": "LocationFeatureSpecification",
+      "name": "Towels and Toiletries",
+      "value": true
+    },
+    {
+      "@type": "LocationFeatureSpecification",
+      "name": "Bed Linens",
+      "value": true
+    }
+  ],
+  "numberOfRooms": 10,
+  "petsAllowed": true,
+  "checkinTime": "15:00",
+  "checkoutTime": "11:00",
+  "availableLanguage": [
+    "English",
+    "Spanish"
+  ],
+  "containsPlace": [
+    {
+      "@type": "Accommodation",
+      "name": "Casa Geco",
+      "url": "https://www.reservaskalawala.com/Geco",
+      "description": "2-bedroom house in the heart of Puerto Viejo, sleeps 5, private fenced parking, pet friendly, fully equipped kitchen, 2 A/C units, 100Mbps WiFi.",
+      "occupancy": {
+        "@type": "QuantitativeValue",
+        "maxValue": 5
       },
-      {
-        "@type": "Accommodation",
-        "name": "Casa Rana",
-        "url": "https://www.reservaskalawala.com/Rana",
-        "description": "2-bedroom house in the heart of Puerto Viejo, sleeps 5, private fenced parking, pet friendly with fenced garden, fully equipped kitchen, 2 A/C units.",
-        "occupancy": { "@type": "QuantitativeValue", "maxValue": 5 },
-        "numberOfBedrooms": 2,
-        "numberOfBathroomsTotal": 1,
-        "petsAllowed": true
-      },
-      {
-        "@type": "Accommodation",
-        "name": "Casa Tucano",
-        "url": "https://www.reservaskalawala.com/Tucano",
-        "description": "2-bedroom wooden apartment above Italian bakery, sleeps 5, terrace, pet friendly, fully equipped kitchen, 2 A/C units.",
-        "occupancy": { "@type": "QuantitativeValue", "maxValue": 5 },
-        "numberOfBedrooms": 2,
-        "numberOfBathroomsTotal": 1,
-        "petsAllowed": true
-      },
-      {
-        "@type": "Accommodation",
-        "name": "Casa Pappagallo",
-        "url": "https://www.reservaskalawala.com/Pappagallo",
-        "description": "2-bedroom wooden apartment above Italian bakery, sleeps 5, terrace, pet friendly, remodeled 2021, fully equipped kitchen, 2 A/C units.",
-        "occupancy": { "@type": "QuantitativeValue", "maxValue": 5 },
-        "numberOfBedrooms": 2,
-        "numberOfBathroomsTotal": 1,
-        "petsAllowed": true
-      },
-      {
-        "@type": "Accommodation",
-        "name": "Casa Delfin",
-        "url": "https://www.reservaskalawala.com/Delfin",
-        "description": "3-bedroom house, sleeps 6, 2 bathrooms, private parking, flexible check-out with lockbox, fully equipped kitchen, 2 A/C units.",
-        "occupancy": { "@type": "QuantitativeValue", "maxValue": 6 },
-        "numberOfBedrooms": 3,
-        "numberOfBathroomsTotal": 2,
-        "petsAllowed": false
-      },
-      {
-        "@type": "Accommodation",
-        "name": "Casa Areka",
-        "url": "https://www.reservaskalawala.com/Areka",
-        "description": "Vacation rental in Playa Negra area, near black sand beach, Puerto Viejo."
-      },
-      {
-        "@type": "Accommodation",
-        "name": "Casa Giulia",
-        "url": "https://www.reservaskalawala.com/Giulia",
-        "description": "Vacation rental in Playa Negra area, near black sand beach, Puerto Viejo."
-      },
-      {
-        "@type": "Accommodation",
-        "name": "Casa Plumeria",
-        "url": "https://www.reservaskalawala.com/Plumeria",
-        "description": "Vacation rental in Playa Negra area, near black sand beach, Puerto Viejo."
-      },
-      {
-        "@type": "Accommodation",
-        "name": "Villa Mar",
-        "url": "https://www.reservaskalawala.com/VillaMar",
-        "description": "Villa with private pool, king-size bed, dedicated workspace with ethernet, fully equipped kitchen.",
-        "amenityFeature": [
-          { "@type": "LocationFeatureSpecification", "name": "Private Pool", "value": true },
-          { "@type": "LocationFeatureSpecification", "name": "Dedicated Workspace", "value": true }
-        ]
-      },
-      {
-        "@type": "Accommodation",
-        "name": "Villa Coral",
-        "url": "https://www.reservaskalawala.com/VillaCoral",
-        "description": "Villa with private pool, king-size bed, dedicated workspace with ethernet, fully equipped kitchen.",
-        "amenityFeature": [
-          { "@type": "LocationFeatureSpecification", "name": "Private Pool", "value": true },
-          { "@type": "LocationFeatureSpecification", "name": "Dedicated Workspace", "value": true }
-        ]
+      "numberOfBedrooms": 2,
+      "numberOfBathroomsTotal": 1,
+      "petsAllowed": true,
+      "offers": {
+        "@type": "Offer",
+        "priceCurrency": "USD",
+        "price": 160,
+        "availability": "https://schema.org/InStock"
       }
-    ],
-    "tourBookingPage": "https://www.reservaskalawala.com"
+    },
+    {
+      "@type": "Accommodation",
+      "name": "Casa Rana",
+      "url": "https://www.reservaskalawala.com/Rana",
+      "description": "2-bedroom house in the heart of Puerto Viejo, sleeps 5, private fenced parking, pet friendly with fenced garden, fully equipped kitchen, 2 A/C units.",
+      "occupancy": {
+        "@type": "QuantitativeValue",
+        "maxValue": 5
+      },
+      "numberOfBedrooms": 2,
+      "numberOfBathroomsTotal": 1,
+      "petsAllowed": true,
+      "offers": {
+        "@type": "Offer",
+        "priceCurrency": "USD",
+        "price": 160,
+        "availability": "https://schema.org/InStock"
+      }
+    },
+    {
+      "@type": "Accommodation",
+      "name": "Casa Tucano",
+      "url": "https://www.reservaskalawala.com/Tucano",
+      "description": "2-bedroom wooden apartment above Italian bakery, sleeps 5, terrace, pet friendly, fully equipped kitchen, 2 A/C units.",
+      "occupancy": {
+        "@type": "QuantitativeValue",
+        "maxValue": 5
+      },
+      "numberOfBedrooms": 2,
+      "numberOfBathroomsTotal": 1,
+      "petsAllowed": true,
+      "offers": {
+        "@type": "Offer",
+        "priceCurrency": "USD",
+        "price": 169,
+        "availability": "https://schema.org/InStock"
+      }
+    },
+    {
+      "@type": "Accommodation",
+      "name": "Casa Pappagallo",
+      "url": "https://www.reservaskalawala.com/Pappagallo",
+      "description": "2-bedroom wooden apartment above Italian bakery, sleeps 5, terrace, pet friendly, remodeled 2021, fully equipped kitchen, 2 A/C units.",
+      "occupancy": {
+        "@type": "QuantitativeValue",
+        "maxValue": 5
+      },
+      "numberOfBedrooms": 2,
+      "numberOfBathroomsTotal": 1,
+      "petsAllowed": true,
+      "offers": {
+        "@type": "Offer",
+        "priceCurrency": "USD",
+        "price": 169,
+        "availability": "https://schema.org/InStock"
+      }
+    },
+    {
+      "@type": "Accommodation",
+      "name": "Casa Delfines",
+      "url": "https://www.reservaskalawala.com/Delfin",
+      "description": "2-bedroom house, sleeps 6, 2 bathrooms, private parking, flexible check-out with lockbox, fully equipped kitchen, 2 A/C units.",
+      "occupancy": {
+        "@type": "QuantitativeValue",
+        "maxValue": 6
+      },
+      "numberOfBedrooms": 2,
+      "numberOfBathroomsTotal": 2,
+      "petsAllowed": false,
+      "offers": {
+        "@type": "Offer",
+        "priceCurrency": "USD",
+        "price": 199,
+        "availability": "https://schema.org/InStock"
+      }
+    },
+    {
+      "@type": "Accommodation",
+      "name": "Casa Areka",
+      "url": "https://www.reservaskalawala.com/Areka",
+      "description": "Fully equipped bungalow with A/C, 200m from Playa Chiquita beach, a few minutes from Puerto Viejo and Manzanillo.",
+      "occupancy": {
+        "@type": "QuantitativeValue",
+        "maxValue": 2
+      },
+      "numberOfBedrooms": 1,
+      "numberOfBathroomsTotal": 1,
+      "offers": {
+        "@type": "Offer",
+        "priceCurrency": "USD",
+        "price": 99,
+        "availability": "https://schema.org/InStock"
+      }
+    },
+    {
+      "@type": "Accommodation",
+      "name": "Casa Giulia",
+      "url": "https://www.reservaskalawala.com/Giulia",
+      "description": "Fully equipped bungalow with A/C, 200m from Playa Chiquita beach. Perfect for families up to 4 people.",
+      "occupancy": {
+        "@type": "QuantitativeValue",
+        "maxValue": 4
+      },
+      "numberOfBedrooms": 2,
+      "numberOfBathroomsTotal": 2,
+      "offers": {
+        "@type": "Offer",
+        "priceCurrency": "USD",
+        "price": 169,
+        "availability": "https://schema.org/InStock"
+      }
+    },
+    {
+      "@type": "Accommodation",
+      "name": "Casa Plumeria",
+      "url": "https://www.reservaskalawala.com/Plumeria",
+      "description": "Fully equipped bungalow with A/C, 200m from Playa Chiquita beach, a few minutes from Puerto Viejo and Manzanillo.",
+      "occupancy": {
+        "@type": "QuantitativeValue",
+        "maxValue": 2
+      },
+      "numberOfBedrooms": 1,
+      "numberOfBathroomsTotal": 1,
+      "offers": {
+        "@type": "Offer",
+        "priceCurrency": "USD",
+        "price": 99,
+        "availability": "https://schema.org/InStock"
+      }
+    },
+    {
+      "@type": "Accommodation",
+      "name": "Villa Mar",
+      "url": "https://www.reservaskalawala.com/VillaMar",
+      "description": "Villa with private pool, king-size bed, dedicated workspace with ethernet, fully equipped kitchen.",
+      "occupancy": {
+        "@type": "QuantitativeValue",
+        "maxValue": 2
+      },
+      "numberOfBedrooms": 1,
+      "numberOfBathroomsTotal": 1,
+      "amenityFeature": [
+        {
+          "@type": "LocationFeatureSpecification",
+          "name": "Private Pool",
+          "value": true
+        },
+        {
+          "@type": "LocationFeatureSpecification",
+          "name": "Dedicated Workspace",
+          "value": true
+        }
+      ],
+      "offers": {
+        "@type": "Offer",
+        "priceCurrency": "USD",
+        "price": 199,
+        "availability": "https://schema.org/InStock"
+      }
+    },
+    {
+      "@type": "Accommodation",
+      "name": "Villa Coral",
+      "url": "https://www.reservaskalawala.com/VillaCoral",
+      "description": "Villa with private pool, king-size bed, dedicated workspace with ethernet, fully equipped kitchen.",
+      "occupancy": {
+        "@type": "QuantitativeValue",
+        "maxValue": 2
+      },
+      "numberOfBedrooms": 1,
+      "numberOfBathroomsTotal": 1,
+      "amenityFeature": [
+        {
+          "@type": "LocationFeatureSpecification",
+          "name": "Private Pool",
+          "value": true
+        },
+        {
+          "@type": "LocationFeatureSpecification",
+          "name": "Dedicated Workspace",
+          "value": true
+        }
+      ],
+      "offers": {
+        "@type": "Offer",
+        "priceCurrency": "USD",
+        "price": 199,
+        "availability": "https://schema.org/InStock"
+      }
+    }
+  ],
+  "tourBookingPage": "https://www.reservaskalawala.com",
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "5.0",
+    "reviewCount": 31
   }
+}
   </script>
 
   <!-- Organization structured data -->

--- a/scripts/generate-404.js
+++ b/scripts/generate-404.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Copies the pre-rendered build/404/index.html to build/404.html.
+ *
+ * react-snap only prerenders the routes listed in package.json's
+ * reactSnap.include, and it snapshots "/404" as a directory
+ * (build/404/index.html), same as every other route. .htaccess's
+ * `ErrorDocument 404 /404.html` needs a plain file at that exact path, not a
+ * directory — this is the one place that mismatch has to be bridged.
+ *
+ * Without this, unknown URLs fell through the SPA rewrite to index.html with
+ * an HTTP 200 (a soft 404): visually a 404 page once React hydrated, but the
+ * status code told search engines and any status-aware crawler it was a real,
+ * indexable page.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const BUILD = path.join(ROOT, 'build');
+const SOURCE = path.join(BUILD, '404', 'index.html');
+const DEST = path.join(BUILD, '404.html');
+
+function main() {
+  if (!fs.existsSync(SOURCE)) {
+    console.error(`[404] ${SOURCE} does not exist — is "/404" in reactSnap.include and did react-snap run?`);
+    process.exit(1);
+  }
+
+  fs.copyFileSync(SOURCE, DEST);
+  console.log(`[404] wrote ${path.relative(ROOT, DEST)} from ${path.relative(ROOT, SOURCE)}`);
+}
+
+main();

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -23,7 +23,7 @@ const BUILD = path.join(ROOT, 'build');
 const ORIGIN = 'https://www.reservaskalawala.com';
 
 /** Routes that exist for internal flows and should not be indexed. */
-const EXCLUDE = new Set(['/Success']);
+const EXCLUDE = new Set(['/Success', '/404']);
 
 function esCounterpart(route, all) {
   if (route.endsWith('ES')) return null; // handled from the EN side

--- a/src/Router/Router.tsx
+++ b/src/Router/Router.tsx
@@ -5,7 +5,6 @@ import * as PostHog from '../services/PostHog.service';
 import MessageTipContainer from '../components/MessageTip/MessageTipContainer.component';
 import { useRandomPopup } from '../hooks/useRandomPopup';
 import PortalGuard from '../components/PortalGuard/PortalGuard.component';
-import NotFound from '../pages/NotFound.page';
 
 /*
  * Every routed page is code-split.
@@ -71,6 +70,9 @@ const HomeNam = lazy(() => import(/* webpackChunkName: "route-homenam" */ '../pa
 const HomeNamES = lazy(() => import(/* webpackChunkName: "route-homenames" */ '../pages/Home/Home.pageES.nam'));
 const HomeRib = lazy(() => import(/* webpackChunkName: "route-homevillas" */ '../pages/Home/Home.page.rib'));
 const HomeRibES = lazy(() => import(/* webpackChunkName: "route-homevillases" */ '../pages/Home/Home.pageES.rib'));
+const NotFound = lazy(() => import(/* webpackChunkName: "route-404" */ '../pages/NotFound.page'));
+const BlogIndex = lazy(() => import(/* webpackChunkName: "route-blog" */ '../pages/Blog/BlogIndex.page'));
+const BlogIndexES = lazy(() => import(/* webpackChunkName: "route-bloges" */ '../pages/Blog/BlogIndex.page_ES'));
 // import About from './About';
 // import Contact from './Contact';
 
@@ -205,6 +207,8 @@ const AppRouter = () => {
       <Route path='/Tucano'  element={<ListingTucano />}/>
       <Route path='/Pappagallo'  element={<ListingPappagallo />}/>
       <Route path='/Delfin'  element={<ListingDelfin />}/>
+      <Route path='/blog' element={<BlogIndex />} />
+      <Route path='/blogES' element={<BlogIndexES />} />
       <Route path='/twodaysinpuertoviejo' element={<TwoDaysInPV />} />
       <Route path='/gettingtogandoca' element={<GettingToGandoca />} />
       <Route path='/travellingtopuertoviejo' element={<TravellingToPuerto />} />
@@ -257,6 +261,16 @@ const AppRouter = () => {
       </Route> */} 
       {/* <Route path="/about" component={About} />
       <Route path="/contact" component={Contact} /> */}
+        {/*
+          A dedicated route, separate from the "*" catch-all below, so
+          react-snap (which navigates to explicit paths, not wildcards — see
+          package.json's reactSnap.include) can prerender a static 404.html.
+          scripts/generate-404.js copies the resulting build/404/index.html
+          to build/404.html, and .htaccess serves it with a real HTTP 404
+          status via ErrorDocument, instead of the soft-404 (200 + blank/
+          generic page) unknown URLs used to get.
+        */}
+        <Route path="/404" element={<NotFound />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
       </Suspense>

--- a/src/components/BookingCtaBanner/BookingCtaBanner.component.tsx
+++ b/src/components/BookingCtaBanner/BookingCtaBanner.component.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import './BookingCtaBanner.style.scss';
+
+interface IBookingCtaBanner {
+  isSpanish: boolean;
+}
+
+/**
+ * A repeated mid-page conversion point. The audit found exactly one CTA
+ * across the entire homepage (the hero search) — every visitor who scrolled
+ * past it had to scroll all the way back up to act. This banner is meant to
+ * be dropped in after a section a visitor has just finished reading (Our
+ * Homes, the reviews) so the ask is never more than one section away.
+ */
+const BookingCtaBanner: React.FC<IBookingCtaBanner> = ({ isSpanish }) => {
+  const navigate = useNavigate();
+  const bookPath = isSpanish ? '/bookES' : '/book';
+
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+      return;
+    }
+    event.preventDefault();
+    navigate(bookPath);
+    window.scrollTo(0, 0);
+  };
+
+  return (
+    <section className="booking-cta-banner">
+      <div className="container">
+        <p className="booking-cta-banner__text">
+          {isSpanish
+            ? '4.9/5 · reserva directo, sin comisiones de plataforma'
+            : '4.9/5 · book direct, no platform fees'}
+        </p>
+        <a href={bookPath} className="booking-cta-banner__btn" onClick={handleClick}>
+          {isSpanish ? 'Ver disponibilidad' : 'Check availability'}
+        </a>
+      </div>
+    </section>
+  );
+};
+
+export default BookingCtaBanner;

--- a/src/components/BookingCtaBanner/BookingCtaBanner.style.scss
+++ b/src/components/BookingCtaBanner/BookingCtaBanner.style.scss
@@ -1,0 +1,40 @@
+@import '../../styles/_variables.scss';
+
+.booking-cta-banner {
+  background: $kalawala-darker-green;
+  padding: 28px 0;
+
+  .container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 24px;
+    flex-wrap: wrap;
+    text-align: center;
+  }
+
+  &__text {
+    color: #fff;
+    font-size: 16px;
+    font-weight: 600;
+    margin: 0;
+  }
+
+  &__btn {
+    display: inline-block;
+    background: $kalawala-light-green;
+    color: $kalawala-darker-green;
+    font-weight: 700;
+    padding: 12px 28px;
+    border-radius: 6px;
+    text-decoration: none;
+    white-space: nowrap;
+
+    &:hover,
+    &:focus-visible {
+      background: #fff;
+      color: $kalawala-darker-green;
+      text-decoration: none;
+    }
+  }
+}

--- a/src/components/ContactUs/ContactUs.component.tsx
+++ b/src/components/ContactUs/ContactUs.component.tsx
@@ -16,8 +16,8 @@ const ContactUs: React.FC = () => {
 
           {/* Contact Details */}
           <div className="text-center contact-info col-md-12 wow fadeInUp" data-wow-duration="500ms">
-            <h3>Interested?</h3>
-            <p>Contact us!</p>
+            <h3>Ask us anything</h3>
+            <p>We usually reply within an hour on WhatsApp.</p>
             <div className="contact-details">
               <div className="con-info clearfix">
                 <i className="tf-map-pin"></i>
@@ -26,12 +26,12 @@ const ContactUs: React.FC = () => {
 
               <div className="con-info clearfix">
                 <i className="tf-ion-ios-telephone-outline"></i>
-                <span>Phone, Whatsapp: +506 8463-2276</span>
+                <span>Phone, Whatsapp: <a href="tel:+50684632276">+506 8463-2276</a> · <a href="https://wa.me/50684632276" target="_blank" rel="noopener noreferrer">chat on WhatsApp</a></span>
               </div>
 
               <div className="con-info clearfix">
                 <i className="tf-ion-ios-email-outline"></i>
-                <span>Email: reservas.kalawala@gmail.com</span>
+                <span>Email: <a href="mailto:reservas.kalawala@gmail.com">reservas.kalawala@gmail.com</a></span>
               </div>
             </div>
           </div>

--- a/src/components/ContactUs/ContactUs.componentES.tsx
+++ b/src/components/ContactUs/ContactUs.componentES.tsx
@@ -16,8 +16,8 @@ const ContactUsES: React.FC = () => {
 
           {/* Contact Details */}
           <div className="text-center contact-info col-md-12 wow fadeInUp" data-wow-duration="500ms">
-            <h3>Interesado?</h3>
-            <p>Contactanos!</p>
+            <h3>Escríbenos</h3>
+            <p>Normalmente respondemos en menos de una hora por WhatsApp.</p>
             <div className="contact-details">
               <div className="con-info clearfix">
                 <i className="tf-map-pin"></i>
@@ -26,12 +26,12 @@ const ContactUsES: React.FC = () => {
 
               <div className="con-info clearfix">
                 <i className="tf-ion-ios-telephone-outline"></i>
-                <span>Telefono, Whatsapp: +506 8463-2276</span>
+                <span>Teléfono, Whatsapp: <a href="tel:+50684632276">+506 8463-2276</a> · <a href="https://wa.me/50684632276" target="_blank" rel="noopener noreferrer">chatear por WhatsApp</a></span>
               </div>
 
               <div className="con-info clearfix">
                 <i className="tf-ion-ios-email-outline"></i>
-                <span>Correo: reservas.kalawala@gmail.com</span>
+                <span>Correo: <a href="mailto:reservas.kalawala@gmail.com">reservas.kalawala@gmail.com</a></span>
               </div>
             </div>
           </div>

--- a/src/components/Discover/Discover.component.tsx
+++ b/src/components/Discover/Discover.component.tsx
@@ -4,6 +4,7 @@ import './Discover.style.scss';
 import { Image } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faConciergeBell, faCalendarCheck, faCancel, faDollarSign } from '@fortawesome/free-solid-svg-icons';
+import { PORTFOLIO_PROPERTY_COUNT, PORTFOLIO_BEDROOM_RANGE, PORTFOLIO_GUEST_RANGE } from '../../utils/constants';
 
 const DISCOVER_IMAGE =
   'https://lh3.googleusercontent.com/d/1RIAdGXizO6a6cCoL8ErA881olP-9YGNW=w1000';
@@ -22,7 +23,7 @@ const Discover = () => {
           <div className="col-md-6">
             <div className="content-block">
               <h2>Discover Puerto Viejo from the comfort of our homes.</h2>
-              <p>Reservas Kalawala offers 4 remodeled homes, <b>with fully equipped, private kitchen and bathroom</b>. Each house has 2 bedrooms and <b>2 Air Conditioning units</b>.</p>
+              <p>Reservas Kalawala offers {PORTFOLIO_PROPERTY_COUNT} remodeled homes and villas, <b>each with a fully equipped private kitchen and bathroom</b>. Houses sleep {PORTFOLIO_GUEST_RANGE.min} to {PORTFOLIO_GUEST_RANGE.max} guests, with {PORTFOLIO_BEDROOM_RANGE.min} to {PORTFOLIO_BEDROOM_RANGE.max} bedrooms and <b>air conditioning throughout</b>.</p>
               <p>Located in the center of Puerto Viejo, all the bars and restaurants are within <b>walking distance</b>. Cocles beach can be reached by car in 2 minutes, and there are closeby bike and motorbike rentals so that also Punta Uva, Cahuita and Manzanillo are within reach, even without a car!</p>
               <p><b>Working from home?</b> We offer <b>free WIFI</b>, with a maximum speed of <b>100Mbps</b>. We stipulated two different contracts with our internet provider, so your internet connection will be shared between fewer devices, achieving less latency during meetings.</p>
               <p><b>Pet Friendly!</b> In all our spaces. Casa Rana and Casa Gecko are the perfect options for your pet, as they come with a garden. But a small house pet could comfortably stay in the other houses too!</p>

--- a/src/components/Discover/Discover.componentES.tsx
+++ b/src/components/Discover/Discover.componentES.tsx
@@ -4,6 +4,7 @@ import './Discover.style.scss';
 import { Image } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faConciergeBell, faCalendarCheck, faCancel, faDollarSign } from '@fortawesome/free-solid-svg-icons';
+import { PORTFOLIO_PROPERTY_COUNT, PORTFOLIO_BEDROOM_RANGE, PORTFOLIO_GUEST_RANGE } from '../../utils/constants';
 
 const DISCOVER_IMAGE =
   'https://lh3.googleusercontent.com/d/1RIAdGXizO6a6cCoL8ErA881olP-9YGNW=w1000';
@@ -22,9 +23,9 @@ const DiscoverES = () => {
           <div className="col-md-6">
             <div className="content-block">
               <h2>Descubre Puerto Viejo desde el confort de nuestras casas.</h2>
-              <p>Reservas Kalawala ofrece 4 casas remodeladas, <b>con una cocina y baño totalmente equipados</b>. Cada casa cuenta con 2 habitaciones y <b>2 unidades de aire acondicionado</b>.</p>
-              <p>Ubicado en el centro de Puerto Viejo, todos los bares y restaurantes estan una a <b>distancia comodamente caminable </b>. Se puede llegar a Playa Cocles en auto en 2 minutos. Tambien hay lugares de renta de bicicletas y motocicletas para que tambien Punta Uva, Cahuita y Manzanillo estén a tu alcance, incluso sin un auto!</p>
-              <p><b>Trabajas desde casa?</b> Ofrecemos <b>WIFI gratis</b>, con una velocidad de hasta <b>100Mbps</b>. Estipulamos dos contratos diferentes con nuestro proveedor de internet, por lo que tu conexión a internet será compartida entre menos dispositivos, logrando una menor latencia durante tus reuniones.</p>
+              <p>Reservas Kalawala ofrece {PORTFOLIO_PROPERTY_COUNT} casas y villas remodeladas, <b>cada una con cocina y baño privados totalmente equipados</b>. Las casas alojan de {PORTFOLIO_GUEST_RANGE.min} a {PORTFOLIO_GUEST_RANGE.max} huéspedes, con {PORTFOLIO_BEDROOM_RANGE.min} a {PORTFOLIO_BEDROOM_RANGE.max} habitaciones y <b>aire acondicionado en todas</b>.</p>
+              <p>Ubicado en el centro de Puerto Viejo, todos los bares y restaurantes están a <b>distancia cómodamente caminable</b>. Se puede llegar a Playa Cocles en auto en 2 minutos. También hay lugares de renta de bicicletas y motocicletas para que también Punta Uva, Cahuita y Manzanillo estén a tu alcance, ¡incluso sin un auto!</p>
+              <p><b>¿Trabajas desde casa?</b> Ofrecemos <b>WIFI gratis</b>, con una velocidad de hasta <b>100Mbps</b>. Estipulamos dos contratos diferentes con nuestro proveedor de internet, por lo que tu conexión a internet será compartida entre menos dispositivos, logrando una menor latencia durante tus reuniones.</p>
               <p><b>Pet Friendly!</b> En todos nuestros espacios. Casa Rana y Casa Gecko son las opciones perfectas para tu mascota, ya que cuentan con jardín. ¡Pero una pequeña mascota doméstica también podría alojarse cómodamente en las otras casas</p>
               <div className="row">
                 <div className="col-md-6">
@@ -33,8 +34,8 @@ const DiscoverES = () => {
                       <FontAwesomeIcon icon={faConciergeBell} color='#57cbcc' fontSize={"30px"} />
                     </div>
                     <div className="media-body flex-grow-1" style={{ verticalAlign: "middle" }}>
-                      <h3 className="media-heading mt-0 mb-1">Check-in Automatico</h3>
-                      <p>Facil de seguir, check-in sin necesidad de contactar!.</p>
+                      <h3 className="media-heading mt-0 mb-1">Check-in Automático</h3>
+                      <p>Fácil de seguir, ¡check-in sin necesidad de contactar!</p>
                     </div>
                   </div>
                 </div>

--- a/src/components/FixedNavigation/FixedNavigation.component.tsx
+++ b/src/components/FixedNavigation/FixedNavigation.component.tsx
@@ -73,6 +73,9 @@ const FixedNavigation = ({ isBlog }: IFixedNavigation) => {
           />
         </Navbar.Brand>
         <div className="mobile-controls">
+          <a href="/book" className="nav-cta-btn" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("book") }}>
+            Book now
+          </a>
           <div className="mobile-flag">
             <LanguageSwitcher />
           </div>
@@ -92,8 +95,9 @@ const FixedNavigation = ({ isBlog }: IFixedNavigation) => {
             <Nav.Link href="/book" className="navText" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("book") }}>Availability</Nav.Link>
             <Nav.Link href="/#portfolio" className="navText" onClick={() => { handleLinkClick("#portfolio") }}>Photos</Nav.Link>
             <Nav.Link href="/#contact-us" className="navText" onClick={() => { handleLinkClick("#contact-us") }}>Contact</Nav.Link>
-            <Nav.Link href="/twodaysinpuertoviejo" className={`navText${(isActive && isBlog) ? ' active' : ''}`} onClick={closeMenu}>Blog</Nav.Link>
+            <Nav.Link href="/blog" className={`navText${(isActive && isBlog) ? ' active' : ''}`} onClick={closeMenu}>Blog</Nav.Link>
             <Nav.Link href="/portal" className="navText" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("portal") }}>My Booking</Nav.Link>
+            <Nav.Link href="https://wa.me/50684632276" className="navText" target="_blank" rel="noopener noreferrer">WhatsApp</Nav.Link>
           </Nav>
         <div className="navbar-flag">
             <LanguageSwitcher />

--- a/src/components/FixedNavigation/FixedNavigation.componentES.tsx
+++ b/src/components/FixedNavigation/FixedNavigation.componentES.tsx
@@ -73,6 +73,9 @@ const FixedNavigationES = ({ isBlog }: IFixedNavigationES) => {
           />
         </Navbar.Brand>
         <div className="mobile-controls">
+          <a href="/bookES" className="nav-cta-btn" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("bookES") }}>
+            Reservar
+          </a>
           <div className="mobile-flag">
             <LanguageSwitcher />
           </div>
@@ -86,8 +89,9 @@ const FixedNavigationES = ({ isBlog }: IFixedNavigationES) => {
             <Nav.Link href="/bookES" className="navText" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("bookES") }}>Disponibilidad</Nav.Link>
             <Nav.Link href="HomeES#portfolioES" className="navText" onClick={() => { handleLinkClick("HomeES#portfolio") }}>Fotos</Nav.Link>
             <Nav.Link href="HomeES#contact-usES" className="navText" onClick={() => { handleLinkClick("HomeES#contact-us") }}>Contactanos</Nav.Link>
-            <Nav.Link href="/twodaysinpuertoviejoES" className={`navText${(isActive && isBlog) ? ' active' : ''}`} onClick={closeMenu}>Blog</Nav.Link>
+            <Nav.Link href="/blogES" className={`navText${(isActive && isBlog) ? ' active' : ''}`} onClick={closeMenu}>Blog</Nav.Link>
             <Nav.Link href="/portalES" className="navText" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("portalES") }}>Mi Reserva</Nav.Link>
+            <Nav.Link href="https://wa.me/50684632276" className="navText" target="_blank" rel="noopener noreferrer">WhatsApp</Nav.Link>
           </Nav>
         <div className="navbar-flag">
             <LanguageSwitcher/>

--- a/src/components/FixedNavigation/FixedNavigation.componentNam.tsx
+++ b/src/components/FixedNavigation/FixedNavigation.componentNam.tsx
@@ -52,6 +52,9 @@ const FixedNavigationNam = ({ isBlog }: IFixedNavigation) => {
           />
         </Navbar.Brand>
         <div className="mobile-controls">
+          <a href="HomeNam#body" className="nav-cta-btn" onClick={() => { handleLinkClick("HomeNam#body") }}>
+            Book now
+          </a>
           <div className="mobile-flag">
             <LanguageSwitcher />
           </div>
@@ -65,7 +68,8 @@ const FixedNavigationNam = ({ isBlog }: IFixedNavigation) => {
             <Nav.Link href="HomeNam#body" className="navText" onClick={() => { handleLinkClick("HomeNam#body") }}>Availability</Nav.Link>
             <Nav.Link href="HomeNam#portfolio" className="navText" onClick={() => { handleLinkClick("HomeNam#portfolio") }}>Photos</Nav.Link>
             <Nav.Link href="HomeNam#contact-us" className="navText" onClick={() => { handleLinkClick("HomeNam#contact-us") }}>Contact</Nav.Link>
-            <Nav.Link href="twodaysinpuertoviejo" className={`navText${(isActive && isBlog) ? ' active' : ''}`} onClick={closeMenu}>Blog</Nav.Link>
+            <Nav.Link href="/blog" className={`navText${(isActive && isBlog) ? ' active' : ''}`} onClick={closeMenu}>Blog</Nav.Link>
+            <Nav.Link href="https://wa.me/50684632276" className="navText" target="_blank" rel="noopener noreferrer">WhatsApp</Nav.Link>
           </Nav>
         <div className="navbar-flag">
             <LanguageSwitcher />

--- a/src/components/FixedNavigation/FixedNavigation.componentNamES.tsx
+++ b/src/components/FixedNavigation/FixedNavigation.componentNamES.tsx
@@ -52,6 +52,9 @@ const FixedNavigationNamES = ({ isBlog }: IFixedNavigation) => {
           />
         </Navbar.Brand>
         <div className="mobile-controls">
+          <a href="HomeNamES#body" className="nav-cta-btn" onClick={() => { handleLinkClick("HomeNamES#body") }}>
+            Reservar
+          </a>
           <div className="mobile-flag">
             <LanguageSwitcher />
           </div>
@@ -71,7 +74,8 @@ const FixedNavigationNamES = ({ isBlog }: IFixedNavigation) => {
             <Nav.Link href="HomeNamES#body" className="navText" onClick={() => { handleLinkClick("HomeNamES#body") }}>Disponibilidad</Nav.Link>
             <Nav.Link href="HomeNamES#portfolioES" className="navText" onClick={() => { handleLinkClick("HomeNamES#portfolioES") }}>Fotos</Nav.Link>
             <Nav.Link href="HomeNamES#contact-usES" className="navText" onClick={() => { handleLinkClick("HomeNamES#contact-usES") }}>Contactanos</Nav.Link>
-            <Nav.Link href="/twodaysinpuertoviejoES" className={`navText${(isActive && isBlog) ? ' active' : ''}`} onClick={closeMenu}>Blog</Nav.Link>
+            <Nav.Link href="/blogES" className={`navText${(isActive && isBlog) ? ' active' : ''}`} onClick={closeMenu}>Blog</Nav.Link>
+            <Nav.Link href="https://wa.me/50684632276" className="navText" target="_blank" rel="noopener noreferrer">WhatsApp</Nav.Link>
           </Nav>
         <div className="navbar-flag">
             <LanguageSwitcher />

--- a/src/components/FixedNavigation/FixedNavigation.componentRIB.tsx
+++ b/src/components/FixedNavigation/FixedNavigation.componentRIB.tsx
@@ -52,6 +52,9 @@ const FixedNavigationRib = ({ isBlog }: IFixedNavigation) => {
           />
         </Navbar.Brand>
         <div className="mobile-controls">
+          <a href="HomeVillas#callToAction" className="nav-cta-btn" onClick={() => { handleLinkClick("HomeVillas#callToAction") }}>
+            Book now
+          </a>
           <div className="mobile-flag">
             <LanguageSwitcher />
           </div>
@@ -65,7 +68,8 @@ const FixedNavigationRib = ({ isBlog }: IFixedNavigation) => {
             <Nav.Link href="HomeVillas#body" className="navText" onClick={() => { handleLinkClick("HomeVillas#callToAction") }}>Availability</Nav.Link>
             <Nav.Link href="HomeVillas#portfolio" className="navText" onClick={() => { handleLinkClick("HomeVillas#portfolio") }}>Photos</Nav.Link>
             <Nav.Link href="HomeVillas#contact-us" className="navText" onClick={() => { handleLinkClick("HomeVillas#contact-us") }}>Contact</Nav.Link>
-            <Nav.Link href="/twodaysinpuertoviejo" className={`navText${(isActive && isBlog) ? ' active' : ''}`} onClick={closeMenu}>Blog</Nav.Link>
+            <Nav.Link href="/blog" className={`navText${(isActive && isBlog) ? ' active' : ''}`} onClick={closeMenu}>Blog</Nav.Link>
+            <Nav.Link href="https://wa.me/50684632276" className="navText" target="_blank" rel="noopener noreferrer">WhatsApp</Nav.Link>
           </Nav>
         <div className="navbar-flag">
             <LanguageSwitcher />

--- a/src/components/FixedNavigation/FixedNavigation.componentRIBES.tsx
+++ b/src/components/FixedNavigation/FixedNavigation.componentRIBES.tsx
@@ -52,6 +52,9 @@ const FixedNavigationRibES = ({ isBlog }: IFixedNavigationES) => {
           />
         </Navbar.Brand>
         <div className="mobile-controls">
+          <a href="HomeVillasES#callToActionES" className="nav-cta-btn" onClick={() => { handleLinkClick("HomeVillasES#callToActionES") }}>
+            Reservar
+          </a>
           <div className="mobile-flag">
             <LanguageSwitcher />
           </div>
@@ -65,7 +68,8 @@ const FixedNavigationRibES = ({ isBlog }: IFixedNavigationES) => {
             <Nav.Link href="HomeVillasES#body" className="navText" onClick={() => { handleLinkClick("HomeVillasES#callToActionES") }}>Disponibilidad</Nav.Link>
             <Nav.Link href="HomeVillasES#portfolioES" className="navText" onClick={() => { handleLinkClick("HomeVillasES#portfolioES") }}>Fotos</Nav.Link>
             <Nav.Link href="HomeVillasES#contact-usES" className="navText" onClick={() => { handleLinkClick("HomeVillasES#contact-usES") }}>Contactanos</Nav.Link>
-            <Nav.Link href="/twodaysinpuertoviejoES" className={`navText${(isActive && isBlog) ? ' active' : ''}`} onClick={closeMenu}>Blog</Nav.Link>
+            <Nav.Link href="/blogES" className={`navText${(isActive && isBlog) ? ' active' : ''}`} onClick={closeMenu}>Blog</Nav.Link>
+            <Nav.Link href="https://wa.me/50684632276" className="navText" target="_blank" rel="noopener noreferrer">WhatsApp</Nav.Link>
           </Nav>
         <div className="navbar-flag">
             <LanguageSwitcher/>

--- a/src/components/FixedNavigation/FixedNavigation.style.scss
+++ b/src/components/FixedNavigation/FixedNavigation.style.scss
@@ -76,6 +76,30 @@
   gap: 10px;
 }
 
+// Always visible, at every breakpoint — .mobile-controls itself isn't
+// hidden on desktop, only its language-flag and hamburger children are.
+// This is what "travels with the sticky nav" per the audit: the header
+// is the one element that follows the visitor down the whole page, and
+// before this it never asked for anything.
+.nav-cta-btn {
+  display: inline-block;
+  white-space: nowrap;
+  background: $kalawala-light-green;
+  color: $kalawala-darker-green;
+  font-weight: 700;
+  font-size: 14px;
+  padding: 8px 16px;
+  border-radius: 20px;
+  text-decoration: none;
+
+  &:hover,
+  &:focus-visible {
+    background: #fff;
+    color: $kalawala-darker-green;
+    text-decoration: none;
+  }
+}
+
 .mobile-flag {
   display: none;
 
@@ -148,8 +172,13 @@
     left: 10px !important;
     right: 10px !important;
     z-index: 1001 !important;
-    max-height: 400px !important;
-    /* Increased height for better usability */
+    /* 400px clipped the sixth link ("My Booking") on common phone
+       viewports — six nav items plus the language switcher need more room
+       than that. min() keeps a generous cap on tall screens while still
+       never exceeding the viewport (with a 100px margin for the sticky
+       header) on short ones; overflow-y stays as a safety net, not the
+       primary way anyone is expected to reach the last item. */
+    max-height: min(560px, calc(100vh - 100px)) !important;
     overflow-y: auto !important;
     /* Enable scrolling when content exceeds height */
   }

--- a/src/components/Footer/Footer.component.tsx
+++ b/src/components/Footer/Footer.component.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { PROPERTY_DISPLAY_NAMES, BLOG_ARTICLES } from '../../utils/constants';
+import './Footer.style.scss';
+
+interface IFooter {
+  isSpanish: boolean;
+}
+
+const Footer: React.FC<IFooter> = ({ isSpanish }) => {
+  const suffix = isSpanish ? 'ES' : '';
+  const bookPath = isSpanish ? '/bookES' : '/book';
+
+  return (
+    <footer className="site-footer">
+      <div className="container">
+        <div className="footer-grid">
+          <div className="footer-col">
+            <h4>{isSpanish ? 'Nuestras Casas' : 'Our Homes'}</h4>
+            <ul>
+              {Object.entries(PROPERTY_DISPLAY_NAMES).map(([code, name]) => (
+                <li key={code}>
+                  <Link to={`/${code}${suffix}`}>{name}</Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="footer-col">
+            <h4>{isSpanish ? 'Guías de Viaje' : 'Travel Guides'}</h4>
+            <ul>
+              {BLOG_ARTICLES.map((article) => (
+                <li key={article.key}>
+                  <Link to={isSpanish ? article.pathEs : article.pathEn}>
+                    {isSpanish ? article.titleEs : article.titleEn}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="footer-col">
+            <h4>{isSpanish ? 'Contacto' : 'Contact'}</h4>
+            <ul className="footer-contact">
+              <li>
+                <a href="tel:+50684632276">+506 8463-2276</a>
+              </li>
+              <li>
+                <a href="https://wa.me/50684632276" target="_blank" rel="noopener noreferrer">
+                  {isSpanish ? 'Chatear por WhatsApp' : 'Chat on WhatsApp'}
+                </a>
+              </li>
+              <li>
+                <a href="mailto:reservas.kalawala@gmail.com">reservas.kalawala@gmail.com</a>
+              </li>
+              <li className="footer-address">Puerto Viejo de Talamanca, Costa Rica</li>
+            </ul>
+          </div>
+
+          <div className="footer-col footer-cta-col">
+            <h4>{isSpanish ? '¿Listo para reservar?' : 'Ready to book?'}</h4>
+            <Link to={bookPath} className="footer-cta-btn">
+              {isSpanish ? 'Ver disponibilidad' : 'Check availability'}
+            </Link>
+          </div>
+        </div>
+
+        <div className="footer-bottom">
+          <span>Reservas Kalawala &middot; Puerto Viejo de Talamanca, Costa Rica</span>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/src/components/Footer/Footer.style.scss
+++ b/src/components/Footer/Footer.style.scss
@@ -1,0 +1,92 @@
+@import '../../styles/_variables.scss';
+
+.site-footer {
+  background: $kalawala-darker-green;
+  color: rgba(255, 255, 255, 0.85);
+  padding: 56px 0 28px;
+  margin-top: 40px;
+  font-family: $primary-font;
+
+  a {
+    color: rgba(255, 255, 255, 0.85);
+    text-decoration: none;
+
+    &:hover,
+    &:focus-visible {
+      color: $kalawala-light-green;
+      text-decoration: underline;
+    }
+  }
+
+  .footer-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 32px;
+
+    @media (max-width: 991px) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    @media (max-width: 575px) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .footer-col {
+    h4 {
+      color: #fff;
+      font-size: 15px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      margin-bottom: 18px;
+    }
+
+    ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+
+      li {
+        margin-bottom: 10px;
+        font-size: 14.5px;
+        line-height: 1.5;
+      }
+    }
+  }
+
+  .footer-address {
+    color: rgba(255, 255, 255, 0.85);
+  }
+
+  .footer-cta-col {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .footer-cta-btn {
+    display: inline-block;
+    background: $kalawala-light-green;
+    color: $kalawala-darker-green;
+    font-weight: 700;
+    padding: 12px 22px;
+    border-radius: 6px;
+    margin-top: 4px;
+
+    &:hover,
+    &:focus-visible {
+      background: #fff;
+      color: $kalawala-darker-green;
+      text-decoration: none;
+    }
+  }
+
+  .footer-bottom {
+    margin-top: 44px;
+    padding-top: 20px;
+    border-top: 1px solid rgba(255, 255, 255, 0.15);
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.6);
+  }
+}

--- a/src/components/GuestReviews/GuestReviews.component.tsx
+++ b/src/components/GuestReviews/GuestReviews.component.tsx
@@ -12,9 +12,30 @@ const STARS = '★★★★★';
 const GuestReviews: React.FC<GuestReviewsProps> = ({ propertyKey, isSpanish }) => {
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
+  const cardsRef = useRef<HTMLDivElement>(null);
 
   const openPanel = () => setIsPanelOpen(true);
   const closePanel = () => setIsPanelOpen(false);
+
+  // Only horizontally-scrollable below 768px (see GuestReviews.style.scss).
+  // Chromium redirects a vertical wheel gesture into horizontal scroll on any
+  // element that can only scroll on the X axis, so without this a visitor
+  // scrolling down the page gets stuck the moment the cursor crosses this
+  // row. React attaches wheel listeners as passive by default, so
+  // preventDefault() from an onWheel prop is silently ignored — this has to
+  // be a real DOM listener registered with { passive: false }.
+  useEffect(() => {
+    const cards = cardsRef.current;
+    if (!cards) return;
+    const onWheel = (e: WheelEvent) => {
+      if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+        e.preventDefault();
+        window.scrollBy(0, e.deltaY);
+      }
+    };
+    cards.addEventListener('wheel', onWheel, { passive: false });
+    return () => cards.removeEventListener('wheel', onWheel);
+  }, []);
 
   useEffect(() => {
     if (!isPanelOpen) return;
@@ -60,7 +81,7 @@ const GuestReviews: React.FC<GuestReviewsProps> = ({ propertyKey, isSpanish }) =
     <div className="guest-reviews">
       <h2 className="guest-reviews__title">{heading}</h2>
 
-      <div className="guest-reviews__cards">
+      <div className="guest-reviews__cards" ref={cardsRef}>
         {reviews.map((review, index) => {
           const { text, stayLabel } = renderReviewMeta(review);
           return (

--- a/src/components/HomeReviews/HomeReviews.component.tsx
+++ b/src/components/HomeReviews/HomeReviews.component.tsx
@@ -23,7 +23,7 @@ const PROPERTY_LABELS: Record<string, { en: string; es: string }> = {
   PLUMERIA: { en: 'House Plumeria', es: 'Casa Plumeria' },
   GIULIA: { en: 'Casa Giulia', es: 'Casa Giulia' },
   'VILLA MAR': { en: 'Villa Mar', es: 'Villa Mar' },
-  DELFINES: { en: 'House Delfines', es: 'Casa Delfines' },
+  DELFINES: { en: 'Casa Delfines', es: 'Casa Delfines' },
 };
 
 // Round-robin interleave so consecutive cards are always from different properties
@@ -101,6 +101,26 @@ const HomeReviews: React.FC<HomeReviewsProps> = ({ isSpanish }) => {
     return () => { if (rafRef.current) cancelAnimationFrame(rafRef.current); };
   }, [activeReview]);
 
+  // Let a vertical wheel gesture scroll the page instead of this track.
+  // Chromium redirects vertical wheel input into horizontal scroll on any
+  // element that can only scroll on the X axis — no custom handling needed
+  // to cause it, which is why a visitor scrolling straight down the page
+  // gets stuck the moment the cursor crosses this track. React attaches
+  // wheel listeners as passive by default, so calling preventDefault() from
+  // an onWheel prop is silently ignored; this has to be a real DOM listener
+  // registered with { passive: false }.
+  useEffect(() => {
+    const track = trackRef.current;
+    if (!track) return;
+    const onWheel = (e: WheelEvent) => {
+      if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+        e.preventDefault();
+        window.scrollBy(0, e.deltaY);
+      }
+    };
+    track.addEventListener('wheel', onWheel, { passive: false });
+    return () => track.removeEventListener('wheel', onWheel);
+  }, []);
 
   // Panel: lock body scroll + ESC to close
   useEffect(() => {

--- a/src/components/OurHomes/Components/HomeCard.component.tsx
+++ b/src/components/OurHomes/Components/HomeCard.component.tsx
@@ -17,14 +17,21 @@ interface IHomeCard {
 const HomeCard: FC<IHomeCard> = ({ guestNumber, parking, name, image, houseLangCode }) => {
 
     const navigate = useNavigate();
-    const handleClick = () => {
+    const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+        // A real href already handles ctrl/cmd-click, middle-click and "open in
+        // new tab" correctly — only take over plain left-clicks so those keep
+        // working, and use the SPA transition (no full reload) for everything else.
+        if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+            return;
+        }
+        event.preventDefault();
         navigate(`/${houseLangCode}`);
         setTimeout(() => {
             window.scrollTo(0, 0);
         }, 0);
     };
     return (
-        <div className="home-card-item" data-wow-duration="500ms" onClick={handleClick}>
+        <a className="home-card-item" data-wow-duration="500ms" href={`/${houseLangCode}`} onClick={handleClick}>
             <div className="block">
                 <div className="icon-box d-block mx-auto">
                     <img src={image} alt={name} className="img-fluid rounded our-homes-img-m" width={1000} height={667} loading="lazy" decoding="async" srcSet={cdnSrcSet(image)} sizes="160px" />
@@ -44,7 +51,7 @@ const HomeCard: FC<IHomeCard> = ({ guestNumber, parking, name, image, houseLangC
                 </div>
             </div>
 
-        </div>
+        </a>
     )
 }
 export default HomeCard;

--- a/src/components/OurHomes/Components/HomeCard.style.scss
+++ b/src/components/OurHomes/Components/HomeCard.style.scss
@@ -91,8 +91,27 @@
 }
 
 .home-card-item {
+  display: block;
   width: 100%;
   max-width: 350px;
+  text-decoration: none;
+
+  &:focus-visible {
+    outline: 2px solid $primary-color;
+    outline-offset: 2px;
+  }
+}
+
+/* VillaCard / NamCard: same anchor-default reset as .home-card-item, but they
+   carry Bootstrap's col-lg-3 etc. classes, which .home-card-item's own width
+   rules would fight. */
+.grid-card-link {
+  text-decoration: none;
+
+  &:focus-visible {
+    outline: 2px solid $primary-color;
+    outline-offset: 2px;
+  }
 }
 
 .about .row {

--- a/src/components/OurHomes/Components/NamCard.component.tsx
+++ b/src/components/OurHomes/Components/NamCard.component.tsx
@@ -17,14 +17,21 @@ interface IHomeCard {
 const NamCard: FC<IHomeCard> = ({ guestNumber, name, image, houseLangCode }) => {
 
     const navigate = useNavigate();
-    const handleClick = () => {
+    const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+        // A real href already handles ctrl/cmd-click, middle-click and "open in
+        // new tab" correctly — only take over plain left-clicks so those keep
+        // working, and use the SPA transition (no full reload) for everything else.
+        if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+            return;
+        }
+        event.preventDefault();
         navigate(`/${houseLangCode}`);
         setTimeout(() => {
             window.scrollTo(0, 0);
         }, 0);
     };
     return (
-        <div className="col-lg-3 col-md-6 col-sm-6 col-12" data-wow-duration="500ms" onClick={handleClick}>
+        <a className="col-lg-3 col-md-6 col-sm-6 col-12 grid-card-link" data-wow-duration="500ms" href={`/${houseLangCode}`} onClick={handleClick}>
             <div className="block">
                 <div className="icon-box d-block mx-auto">
                     <img src={image} alt={name} className="img-fluid rounded our-homes-img-m" width={1000} height={667} loading="lazy" decoding="async" srcSet={cdnSrcSet(image)} sizes="160px" />
@@ -43,7 +50,7 @@ const NamCard: FC<IHomeCard> = ({ guestNumber, name, image, houseLangCode }) => 
                 </div>
             </div>
 
-        </div>
+        </a>
     )
 }
 export default NamCard;

--- a/src/components/OurHomes/Components/VillaCard.component.tsx
+++ b/src/components/OurHomes/Components/VillaCard.component.tsx
@@ -17,14 +17,21 @@ interface IHomeCard {
 const VillaCard: FC<IHomeCard> = ({ guestNumber, name, image, houseLangCode }) => {
 
     const navigate = useNavigate();
-    const handleClick = () => {
+    const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+        // A real href already handles ctrl/cmd-click, middle-click and "open in
+        // new tab" correctly — only take over plain left-clicks so those keep
+        // working, and use the SPA transition (no full reload) for everything else.
+        if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+            return;
+        }
+        event.preventDefault();
         navigate(`/${houseLangCode}`);
         setTimeout(() => {
             window.scrollTo(0, 0);
         }, 0);
     };
     return (
-        <div className="col-lg-3 col-md-6 col-sm-6 col-12" data-wow-duration="500ms" onClick={handleClick}>
+        <a className="col-lg-3 col-md-6 col-sm-6 col-12 grid-card-link" data-wow-duration="500ms" href={`/${houseLangCode}`} onClick={handleClick}>
             <div className="block">
                 <div className="icon-box d-block mx-auto">
                     {/* Laid out at 156px at every breakpoint (measured with
@@ -58,7 +65,7 @@ const VillaCard: FC<IHomeCard> = ({ guestNumber, name, image, houseLangCode }) =
                 </div>
             </div>
 
-        </div>
+        </a>
     )
 }
 export default VillaCard;

--- a/src/components/OurOtherHomes/Components/OtherHomesCard.component.tsx
+++ b/src/components/OurOtherHomes/Components/OtherHomesCard.component.tsx
@@ -16,17 +16,23 @@ interface IOtherHomesCard {
 const OtherHomesCard: FC<IOtherHomesCard> = ({ guestNumber, name, image, redirectPath }) => {
     const navigate = useNavigate();
 
-    const handleClick = () => {
-        if (redirectPath) {
-            navigate(redirectPath);
-            setTimeout(() => {
-                window.scrollTo(0, 0);
-            }, 0);
+    const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+        if (!redirectPath) return;
+        // A real href already handles ctrl/cmd-click, middle-click and "open in
+        // new tab" correctly — only take over plain left-clicks so those keep
+        // working, and use the SPA transition (no full reload) for everything else.
+        if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+            return;
         }
+        event.preventDefault();
+        navigate(redirectPath);
+        setTimeout(() => {
+            window.scrollTo(0, 0);
+        }, 0);
     };
 
     return (
-        <div className="other-homes-card" onClick={handleClick} style={{ cursor: redirectPath ? 'pointer' : 'default' }}>
+        <a className="other-homes-card" href={redirectPath || undefined} onClick={handleClick}>
             <div className="image-container">
                 <img src={image} alt={name} className="home-image" width={1000} height={667} loading="lazy" decoding="async" srcSet={cdnSrcSet(image)} sizes="(max-width: 575px) 46vw, 220px" />
             </div>
@@ -43,7 +49,7 @@ const OtherHomesCard: FC<IOtherHomesCard> = ({ guestNumber, name, image, redirec
                     <FontAwesomeIcon icon={faParking} />
                 </div>
             </div>
-        </div>
+        </a>
     );
 };
 

--- a/src/components/OurOtherHomes/Components/OtherHomesCard.componentRib.tsx
+++ b/src/components/OurOtherHomes/Components/OtherHomesCard.componentRib.tsx
@@ -16,17 +16,23 @@ interface IOtherHomesCard {
 const OtherHomesCardRib: FC<IOtherHomesCard> = ({ guestNumber, name, image, redirectPath }) => {
     const navigate = useNavigate();
 
-    const handleClick = () => {
-        if (redirectPath) {
-            navigate(redirectPath);
-            setTimeout(() => {
-                window.scrollTo(0, 0);
-            }, 0);
+    const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+        if (!redirectPath) return;
+        // A real href already handles ctrl/cmd-click, middle-click and "open in
+        // new tab" correctly — only take over plain left-clicks so those keep
+        // working, and use the SPA transition (no full reload) for everything else.
+        if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+            return;
         }
+        event.preventDefault();
+        navigate(redirectPath);
+        setTimeout(() => {
+            window.scrollTo(0, 0);
+        }, 0);
     };
 
     return (
-        <div className="other-homes-card" onClick={handleClick} style={{ cursor: redirectPath ? 'pointer' : 'default' }}>
+        <a className="other-homes-card" href={redirectPath || undefined} onClick={handleClick}>
             <div className="image-container">
                 <img src={image} alt={name} className="home-image" width={1000} height={667} loading="lazy" decoding="async" srcSet={cdnSrcSet(image)} sizes="(max-width: 575px) 46vw, 220px" />
             </div>
@@ -44,7 +50,7 @@ const OtherHomesCardRib: FC<IOtherHomesCard> = ({ guestNumber, name, image, redi
                     <FontAwesomeIcon icon={faParking} />
                 </div>
             </div>
-        </div>
+        </a>
     );
 };
 

--- a/src/components/OurOtherHomes/Components/OtherHomesCard.style.scss
+++ b/src/components/OurOtherHomes/Components/OtherHomesCard.style.scss
@@ -13,7 +13,14 @@
     border-radius: 8px;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     transition: transform 0.2s ease-in-out;
-  
+    text-decoration: none;
+    cursor: pointer;
+
+    &:focus-visible {
+      outline: 2px solid $primary-color;
+      outline-offset: 2px;
+    }
+
     .image-container {
       width: 100%;
       border-radius: 8px;

--- a/src/components/OurOtherHomes/OurOtherHomes.ComponentES.tsx
+++ b/src/components/OurOtherHomes/OurOtherHomes.ComponentES.tsx
@@ -26,8 +26,8 @@ const OurOtherHomesES = () => {
         <div className="section">
           <h2>Casitas Privadas A Solo Unos Pasos Playa Chiquita, Puerto Viejo</h2>
           <div className="cards-container">
-          <OtherHomesCard guestNumber={2} name="Plumeria" image="https://lh3.googleusercontent.com/d/1JGQiusfHscT4pSE-1KpejP0uNLUBOTa-=w1000" redirectPath="/PlumeriaES" />
-          <OtherHomesCard guestNumber={4} name="Giulia" image="https://lh3.googleusercontent.com/d/1v3hAHbAjvFf9CYaJx7IV8JqTbDKK__8S=w1000" redirectPath="/GiuliaES" />
+          <OtherHomesCard guestNumber={2} name="Casa Plumeria" image="https://lh3.googleusercontent.com/d/1JGQiusfHscT4pSE-1KpejP0uNLUBOTa-=w1000" redirectPath="/PlumeriaES" />
+          <OtherHomesCard guestNumber={4} name="Casa Giulia" image="https://lh3.googleusercontent.com/d/1v3hAHbAjvFf9CYaJx7IV8JqTbDKK__8S=w1000" redirectPath="/GiuliaES" />
           </div>
        </div>
       </div>

--- a/src/components/OurOtherHomes/OurOtherHomes.ComponentRIBES.tsx
+++ b/src/components/OurOtherHomes/OurOtherHomes.ComponentRIBES.tsx
@@ -25,8 +25,8 @@ const OurOtherHomesRIBES = () => {
         <div className="section">
           <h2>Casitas privadas A Solo Unos Pasos Playa Chiquita, Puerto Viejo</h2>
           <div className="cards-container">
-            <OtherHomesCard guestNumber={2} name="Plumeria" image="https://lh3.googleusercontent.com/d/1JGQiusfHscT4pSE-1KpejP0uNLUBOTa-=w1000" redirectPath="/PlumeriaES" />
-            <OtherHomesCard guestNumber={4} name="Giulia" image="https://lh3.googleusercontent.com/d/1v3hAHbAjvFf9CYaJx7IV8JqTbDKK__8S=w1000" redirectPath="/GiuliaES" />
+            <OtherHomesCard guestNumber={2} name="Casa Plumeria" image="https://lh3.googleusercontent.com/d/1JGQiusfHscT4pSE-1KpejP0uNLUBOTa-=w1000" redirectPath="/PlumeriaES" />
+            <OtherHomesCard guestNumber={4} name="Casa Giulia" image="https://lh3.googleusercontent.com/d/1v3hAHbAjvFf9CYaJx7IV8JqTbDKK__8S=w1000" redirectPath="/GiuliaES" />
           </div>
         </div>
       </div>

--- a/src/components/OurOtherHomes/OurOtherHomes.component.tsx
+++ b/src/components/OurOtherHomes/OurOtherHomes.component.tsx
@@ -26,8 +26,8 @@ const OurOtherHomes = () => {
         <div className="section">
           <h2>Private Retreat in Playa Chiquita, Puerto Viejo</h2>
           <div className="cards-container">
-          <OtherHomesCard guestNumber={2} name="Plumeria" image="https://lh3.googleusercontent.com/d/1JGQiusfHscT4pSE-1KpejP0uNLUBOTa-=w1000" redirectPath="/Plumeria" />
-          <OtherHomesCard guestNumber={4} name="Giulia" image="https://lh3.googleusercontent.com/d/1v3hAHbAjvFf9CYaJx7IV8JqTbDKK__8S=w1000" redirectPath="/Giulia" />
+          <OtherHomesCard guestNumber={2} name="Casa Plumeria" image="https://lh3.googleusercontent.com/d/1JGQiusfHscT4pSE-1KpejP0uNLUBOTa-=w1000" redirectPath="/Plumeria" />
+          <OtherHomesCard guestNumber={4} name="Casa Giulia" image="https://lh3.googleusercontent.com/d/1v3hAHbAjvFf9CYaJx7IV8JqTbDKK__8S=w1000" redirectPath="/Giulia" />
           </div>
        </div>
       </div>

--- a/src/components/OurOtherHomes/OurOtherHomes.componentRIB.tsx
+++ b/src/components/OurOtherHomes/OurOtherHomes.componentRIB.tsx
@@ -25,8 +25,8 @@ const OurOtherHomesRIB = () => {
         <div className="section">
           <h2>Private Retreat in Playa Chiquita, Puerto Viejo</h2>
           <div className="cards-container">
-            <OtherHomesCard guestNumber={2} name="Plumeria" image="https://lh3.googleusercontent.com/d/1JGQiusfHscT4pSE-1KpejP0uNLUBOTa-=w1000" redirectPath="/Plumeria" />
-            <OtherHomesCard guestNumber={4} name="Giulia" image="https://lh3.googleusercontent.com/d/1v3hAHbAjvFf9CYaJx7IV8JqTbDKK__8S=w1000" redirectPath="/Giulia" />
+            <OtherHomesCard guestNumber={2} name="Casa Plumeria" image="https://lh3.googleusercontent.com/d/1JGQiusfHscT4pSE-1KpejP0uNLUBOTa-=w1000" redirectPath="/Plumeria" />
+            <OtherHomesCard guestNumber={4} name="Casa Giulia" image="https://lh3.googleusercontent.com/d/1v3hAHbAjvFf9CYaJx7IV8JqTbDKK__8S=w1000" redirectPath="/Giulia" />
           </div>
         </div>
       </div>

--- a/src/pages/Blog/BlogIndex.page.tsx
+++ b/src/pages/Blog/BlogIndex.page.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect } from 'react';
+import { Helmet } from 'react-helmet';
+import { Link } from 'react-router-dom';
+import { Col, Row } from 'react-bootstrap';
+import '../Listing/Listing.style.scss';
+import FixedNavigation from '../../components/FixedNavigation/FixedNavigation.component';
+import Footer from '../../components/Footer/Footer.component';
+import { BLOG_ARTICLES } from '../../utils/constants';
+
+/**
+ * The nav's "Blog" link used to go straight to a single article — the other
+ * nine were only reachable if a visitor already happened to be on one of
+ * them (via the OtherBlogs carousel). This is the index everything else
+ * should have pointed at from the start.
+ */
+const BlogIndex = () => {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
+  return (
+    <div className="listingContainer">
+      <Helmet>
+        <meta charSet="utf-8" />
+        <title>Puerto Viejo Travel Guides | Reservas Kalawala</title>
+        <meta
+          name="description"
+          content="Ten local guides to Puerto Viejo de Talamanca: getting there, getting around, and what to do once you're here."
+        />
+        <link rel="canonical" href="https://www.reservaskalawala.com/blog" />
+        <link rel="alternate" hrefLang="en" href="https://www.reservaskalawala.com/blog" />
+        <link rel="alternate" hrefLang="es" href="https://www.reservaskalawala.com/blogES" />
+        <link rel="alternate" hrefLang="x-default" href="https://www.reservaskalawala.com/blog" />
+      </Helmet>
+      <FixedNavigation isBlog={true} />
+      <Row className="subContainer" style={{ justifyContent: 'center' }}>
+        <Col className="info col" lg={{ order: 'first', span: 8 }} md={{ order: 'first', span: 10 }} sm={12} xs={12}>
+          <div className="heading title-container">
+            <h1 className="title blog-title">Puerto Viejo Travel Guides</h1>
+            <div className="border"></div>
+          </div>
+          <ul style={{ listStyle: 'none', padding: 0, marginTop: '2rem' }}>
+            {BLOG_ARTICLES.map((article) => (
+              <li key={article.key} style={{ marginBottom: '1.25rem', paddingBottom: '1.25rem', borderBottom: '1px solid rgba(0,0,0,0.1)' }}>
+                <Link to={article.pathEn} style={{ fontSize: '1.2rem', fontWeight: 600 }}>
+                  {article.titleEn}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </Col>
+      </Row>
+      <Footer isSpanish={false} />
+    </div>
+  );
+};
+
+export default BlogIndex;

--- a/src/pages/Blog/BlogIndex.page_ES.tsx
+++ b/src/pages/Blog/BlogIndex.page_ES.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect } from 'react';
+import { Helmet } from 'react-helmet';
+import { Link } from 'react-router-dom';
+import { Col, Row } from 'react-bootstrap';
+import '../Listing/Listing.style.scss';
+import FixedNavigationES from '../../components/FixedNavigation/FixedNavigation.componentES';
+import Footer from '../../components/Footer/Footer.component';
+import { BLOG_ARTICLES } from '../../utils/constants';
+
+const BlogIndexES = () => {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
+  return (
+    <div className="listingContainer">
+      <Helmet>
+        <html lang="es" />
+        <meta charSet="utf-8" />
+        <title>Guías de Viaje de Puerto Viejo | Reservas Kalawala</title>
+        <meta
+          name="description"
+          content="Diez guías locales de Puerto Viejo de Talamanca: cómo llegar, cómo moverte y qué hacer una vez que estés aquí."
+        />
+        <link rel="canonical" href="https://www.reservaskalawala.com/blogES" />
+        <link rel="alternate" hrefLang="en" href="https://www.reservaskalawala.com/blog" />
+        <link rel="alternate" hrefLang="es" href="https://www.reservaskalawala.com/blogES" />
+        <link rel="alternate" hrefLang="x-default" href="https://www.reservaskalawala.com/blog" />
+      </Helmet>
+      <FixedNavigationES isBlog={true} />
+      <Row className="subContainer" style={{ justifyContent: 'center' }}>
+        <Col className="info col" lg={{ order: 'first', span: 8 }} md={{ order: 'first', span: 10 }} sm={12} xs={12}>
+          <div className="heading title-container">
+            <h1 className="title blog-title">Guías de Viaje de Puerto Viejo</h1>
+            <div className="border"></div>
+          </div>
+          <ul style={{ listStyle: 'none', padding: 0, marginTop: '2rem' }}>
+            {BLOG_ARTICLES.map((article) => (
+              <li key={article.key} style={{ marginBottom: '1.25rem', paddingBottom: '1.25rem', borderBottom: '1px solid rgba(0,0,0,0.1)' }}>
+                <Link to={article.pathEs} style={{ fontSize: '1.2rem', fontWeight: 600 }}>
+                  {article.titleEs}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </Col>
+      </Row>
+      <Footer isSpanish={true} />
+    </div>
+  );
+};
+
+export default BlogIndexES;

--- a/src/pages/Home/Home.page.nam.tsx
+++ b/src/pages/Home/Home.page.nam.tsx
@@ -10,6 +10,7 @@ import FixedNavigation from "../../components/FixedNavigation/FixedNavigation.co
 import HelpMeChoose from "../../components/HelpMeChoose/HelpMeChoose.component";
 import BookingSearchWidget from "../../components/BookingSearchWidget/BookingSearchWidget.component";
 import HomeReviews from "../../components/HomeReviews/HomeReviews.component";
+import Footer from "../../components/Footer/Footer.component";
 
 const helpMeChooseOptions = [
     {
@@ -22,21 +23,21 @@ const helpMeChooseOptions = [
     {
         emoji: "👨‍👩‍👧",
         label: "Perfect for families",
-        houseName: "Delfines",
+        houseName: "Casa Delfines",
         houseLangCode: "Delfin",
         image: "https://lh3.googleusercontent.com/d/1ui0cNzHTb2WM-k59OkwnJXw77m0P7PPW=w1000"
     },
     {
         emoji: "🐾",
         label: "Pet-friendly",
-        houseName: "Rana",
+        houseName: "Casa Rana",
         houseLangCode: "Rana",
         image: "https://lh3.googleusercontent.com/d/1UiGI8gFf6UR5kn8Eo30u457NX8NkP95X=w1000"
     },
     {
         emoji: "⭐",
         label: "Best value",
-        houseName: "House Plumeria",
+        houseName: "Casa Plumeria",
         houseLangCode: "Plumeria",
         image: "https://lh3.googleusercontent.com/d/1b2x2aVIjqlSws4KePOS_NVb4NItGsra1=w1000"
     }
@@ -67,7 +68,8 @@ const HomeNam = () => {
       <PortfolioNam />
       {/* <Testimonial /> */}
       <ContactUs />
-      
+      <Footer isSpanish={false} />
+
     </div>
   )
 }

--- a/src/pages/Home/Home.page.rib.tsx
+++ b/src/pages/Home/Home.page.rib.tsx
@@ -10,6 +10,7 @@ import DiscoverRIB from "../../components/Discover/Discover.componentRIB";
 import PortfolioRIB from "../../components/Portfolio/Portfolio.componentRIB";
 import OurOtherHomesRIB from "../../components/OurOtherHomes/OurOtherHomes.componentRIB";
 import BookingSearchWidget from "../../components/BookingSearchWidget/BookingSearchWidget.component";
+import Footer from "../../components/Footer/Footer.component";
 
 const HomeRib = () => {
  
@@ -35,6 +36,7 @@ const HomeRib = () => {
       <PortfolioRIB />
       {/* <Testimonial /> */}
       <ContactUs />
+      <Footer isSpanish={false} />
     </div>
   )
 }

--- a/src/pages/Home/Home.page.tsx
+++ b/src/pages/Home/Home.page.tsx
@@ -7,6 +7,8 @@ import WelcomeSlider from "../../components/WelcomeSlider/WelcomeSlider.componen
 import Portfolio from "../../components/Portfolio/Portfolio.component";
 import HelpMeChoose from "../../components/HelpMeChoose/HelpMeChoose.component";
 import HomeReviews from "../../components/HomeReviews/HomeReviews.component";
+import Footer from "../../components/Footer/Footer.component";
+import BookingCtaBanner from "../../components/BookingCtaBanner/BookingCtaBanner.component";
 
 import { houseDataEngList } from '../../utils/constants';
 import OurOtherHomes from "../../components/OurOtherHomes/OurOtherHomes.component";
@@ -22,21 +24,21 @@ const helpMeChooseOptions = [
     {
         emoji: "👨‍👩‍👧",
         label: "Perfect for families",
-        houseName: "Delfines",
+        houseName: "Casa Delfines",
         houseLangCode: "Delfin",
         image: "https://lh3.googleusercontent.com/d/1ui0cNzHTb2WM-k59OkwnJXw77m0P7PPW=w1000"
     },
     {
         emoji: "🐾",
         label: "Pet-friendly",
-        houseName: "Rana",
+        houseName: "Casa Rana",
         houseLangCode: "Rana",
         image: "https://lh3.googleusercontent.com/d/1UiGI8gFf6UR5kn8Eo30u457NX8NkP95X=w1000"
     },
     {
         emoji: "⭐",
         label: "Best value",
-        houseName: "House Plumeria",
+        houseName: "Casa Plumeria",
         houseLangCode: "Plumeria",
         image: "https://lh3.googleusercontent.com/d/1b2x2aVIjqlSws4KePOS_NVb4NItGsra1=w1000"
     }
@@ -62,11 +64,13 @@ const Home = () => {
       <HomeReviews isSpanish={false} />
       <OurHomes houseDataList={houseDataEngList} />
       <OurOtherHomes />
+      <BookingCtaBanner isSpanish={false} />
       <Discover />
       {/* <CallToAction /> */}
       <Portfolio />
       {/* <Testimonial /> */}
       <ContactUs />
+      <Footer isSpanish={false} />
 
     </div>
   )

--- a/src/pages/Home/Home.pageES.nam.tsx
+++ b/src/pages/Home/Home.pageES.nam.tsx
@@ -11,6 +11,7 @@ import OurOtherHomesNamES from "../../components/OurOtherHomes/OurOtherHomes.com
 import HelpMeChoose from "../../components/HelpMeChoose/HelpMeChoose.component";
 import BookingSearchWidget from "../../components/BookingSearchWidget/BookingSearchWidget.component";
 import HomeReviews from "../../components/HomeReviews/HomeReviews.component";
+import Footer from "../../components/Footer/Footer.component";
 
 const helpMeChooseOptionsES = [
     {
@@ -23,21 +24,21 @@ const helpMeChooseOptionsES = [
     {
         emoji: "👨‍👩‍👧",
         label: "Perfecto para familias",
-        houseName: "Delfines",
+        houseName: "Casa Delfines",
         houseLangCode: "DelfinES",
         image: "https://lh3.googleusercontent.com/d/1ui0cNzHTb2WM-k59OkwnJXw77m0P7PPW=w1000"
     },
     {
         emoji: "🐾",
         label: "Pet-friendly",
-        houseName: "Rana",
+        houseName: "Casa Rana",
         houseLangCode: "RanaES",
         image: "https://lh3.googleusercontent.com/d/1UiGI8gFf6UR5kn8Eo30u457NX8NkP95X=w1000"
     },
     {
         emoji: "⭐",
         label: "Opción Recomendada",
-        houseName: "House Plumeria",
+        houseName: "Casa Plumeria",
         houseLangCode: "Plumeria",
         image: "https://lh3.googleusercontent.com/d/1b2x2aVIjqlSws4KePOS_NVb4NItGsra1=w1000"
     }
@@ -68,7 +69,8 @@ const HomeNamES = () => {
       <PortfolioNam />
       {/* <Testimonial /> */}
       <ContactUs />
-      
+      <Footer isSpanish={true} />
+
     </div>
   )
 }

--- a/src/pages/Home/Home.pageES.rib.tsx
+++ b/src/pages/Home/Home.pageES.rib.tsx
@@ -9,6 +9,7 @@ import WelcomeSliderRibES from "../../components/WelcomeSlider/WelcomeSlider.com
 import PortfolioRIBES from "../../components/Portfolio/Portfolio.componentRIBES";
 import OurOtherHomesRIBES from "../../components/OurOtherHomes/OurOtherHomes.ComponentRIBES";
 import BookingSearchWidget from "../../components/BookingSearchWidget/BookingSearchWidget.component";
+import Footer from "../../components/Footer/Footer.component";
 
 const HomeRibES = () => {
   return (
@@ -31,6 +32,7 @@ const HomeRibES = () => {
       <CallToActionES />
       <PortfolioRIBES />
       <ContactUs />
+      <Footer isSpanish={true} />
     </div>
   )
 }

--- a/src/pages/Home/Home.pageES.tsx
+++ b/src/pages/Home/Home.pageES.tsx
@@ -9,6 +9,8 @@ import ContactUsES from "../../components/ContactUs/ContactUs.componentES";
 import OurOtherHomesES from "../../components/OurOtherHomes/OurOtherHomes.ComponentES";
 import HelpMeChoose from "../../components/HelpMeChoose/HelpMeChoose.component";
 import HomeReviews from "../../components/HomeReviews/HomeReviews.component";
+import Footer from "../../components/Footer/Footer.component";
+import BookingCtaBanner from "../../components/BookingCtaBanner/BookingCtaBanner.component";
 
 const helpMeChooseOptionsES = [
     {
@@ -21,21 +23,21 @@ const helpMeChooseOptionsES = [
     {
         emoji: "👨‍👩‍👧",
         label: "Perfecto para familias",
-        houseName: "Delfines",
+        houseName: "Casa Delfines",
         houseLangCode: "DelfinES",
         image: "https://lh3.googleusercontent.com/d/1ui0cNzHTb2WM-k59OkwnJXw77m0P7PPW=w1000"
     },
     {
         emoji: "🐾",
         label: "Pet-friendly",
-        houseName: "Rana",
+        houseName: "Casa Rana",
         houseLangCode: "RanaES",
         image: "https://lh3.googleusercontent.com/d/1UiGI8gFf6UR5kn8Eo30u457NX8NkP95X=w1000"
     },
     {
         emoji: "⭐",
         label: "Opción Recomendada",
-        houseName: "House Plumeria",
+        houseName: "Casa Plumeria",
         houseLangCode: "PlumeriaES",
         image: "https://lh3.googleusercontent.com/d/1b2x2aVIjqlSws4KePOS_NVb4NItGsra1=w1000"
     }
@@ -60,11 +62,13 @@ const HomeES = () => {
       <HomeReviews isSpanish={true} />
       <OurHomesES houseDataList={houseDataList}/>
       <OurOtherHomesES/>
+      <BookingCtaBanner isSpanish={true} />
       <DiscoverES />
       <PortfolioES />
       {/* <Testimonial /> */}
       <ContactUsES />
-      
+      <Footer isSpanish={true} />
+
     </div>
   )
 }

--- a/src/pages/Listing/components/OtherListings/OtherListings.component.tsx
+++ b/src/pages/Listing/components/OtherListings/OtherListings.component.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from "react";
+import React, { FC, useEffect, useRef, useState } from "react";
 import './OtherListings.style.scss'
 import { ListingType } from "../../../../utils/types";
 import { useNavigate } from "react-router-dom";
@@ -11,12 +11,33 @@ interface IOtherListing {
 const OtherListings: FC<IOtherListing> = ({ currentListing, listings }) => {
     const [windowWidth, setWindowWidth] = useState(window.innerWidth)
     const navigate = useNavigate()
+    const gridRef = useRef<HTMLDivElement>(null)
     const otherListings = listings.filter(listing => listing.name !== currentListing)
 
     useEffect(() => {
         const handleResize = () => setWindowWidth(window.innerWidth)
         window.addEventListener("resize", handleResize)
         return () => window.removeEventListener("resize", handleResize)
+    }, [])
+
+    // Only horizontally-scrollable in the 'mobile-scroll' layout. Chromium
+    // redirects a vertical wheel gesture into horizontal scroll on any
+    // element that can only scroll on the X axis, so without this a visitor
+    // scrolling down the page gets stuck the moment the cursor crosses this
+    // row. React attaches wheel listeners as passive by default, so
+    // preventDefault() from an onWheel prop is silently ignored — this has
+    // to be a real DOM listener registered with { passive: false }.
+    useEffect(() => {
+        const grid = gridRef.current
+        if (!grid) return
+        const onWheel = (e: WheelEvent) => {
+            if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+                e.preventDefault()
+                window.scrollBy(0, e.deltaY)
+            }
+        }
+        grid.addEventListener('wheel', onWheel, { passive: false })
+        return () => grid.removeEventListener('wheel', onWheel)
     }, [])
 
     const isMobile = windowWidth <= 1199
@@ -40,7 +61,10 @@ const OtherListings: FC<IOtherListing> = ({ currentListing, listings }) => {
     return (
         <div className="other-listings-container">
             <h2 className="other-listings-header">Check out our other options!</h2>
-            <div className={`other-listings-grid ${getLayoutClass()}`}>
+            <div
+                className={`other-listings-grid ${getLayoutClass()}`}
+                ref={gridRef}
+            >
                 {otherListings.map(({ name, mainImage }) => (
                     <div
                         key={name}

--- a/src/pages/Listing/components/OtherListings/OtherListings.componentES.tsx
+++ b/src/pages/Listing/components/OtherListings/OtherListings.componentES.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState, useCallback, useMemo } from "react";
+import React, { FC, useEffect, useRef, useState, useCallback, useMemo } from "react";
 import './OtherListings.style.scss'
 import { ListingType } from "../../../../utils/types";
 import { useNavigate } from "react-router-dom";
@@ -11,6 +11,7 @@ interface IOtherListings {
 const OtherListingsES: FC<IOtherListings> = ({ currentListing, listings }) => {
     const [windowWidth, setWindowWidth] = useState(window.innerWidth)
     const navigate = useNavigate()
+    const gridRef = useRef<HTMLDivElement>(null)
 
     const handleResize = useCallback(() => {
         setWindowWidth(window.innerWidth)
@@ -20,6 +21,26 @@ const OtherListingsES: FC<IOtherListings> = ({ currentListing, listings }) => {
         window.addEventListener("resize", handleResize)
         return () => window.removeEventListener("resize", handleResize)
     }, [handleResize])
+
+    // Only horizontally-scrollable in the 'mobile-scroll' layout. Chromium
+    // redirects a vertical wheel gesture into horizontal scroll on any
+    // element that can only scroll on the X axis, so without this a visitor
+    // scrolling down the page gets stuck the moment the cursor crosses this
+    // row. React attaches wheel listeners as passive by default, so
+    // preventDefault() from an onWheel prop is silently ignored — this has
+    // to be a real DOM listener registered with { passive: false }.
+    useEffect(() => {
+        const grid = gridRef.current
+        if (!grid) return
+        const onWheel = (e: WheelEvent) => {
+            if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+                e.preventDefault()
+                window.scrollBy(0, e.deltaY)
+            }
+        }
+        grid.addEventListener('wheel', onWheel, { passive: false })
+        return () => grid.removeEventListener('wheel', onWheel)
+    }, [])
 
     const normalizeName = useCallback((name: string) => name.replace(/ES$/, ''), [])
 
@@ -55,7 +76,10 @@ const OtherListingsES: FC<IOtherListings> = ({ currentListing, listings }) => {
     return (
         <div className="other-listings-container">
             <h2 className="other-listings-header">¡Revisa nuestras otras opciones!</h2>
-            <div className={`other-listings-grid ${getLayoutClass}`}>
+            <div
+                className={`other-listings-grid ${getLayoutClass}`}
+                ref={gridRef}
+            >
                 {otherListings.map(({ name, mainImage }) => (
                     <div 
                         key={name} 

--- a/src/pages/Listing/staticPages/ListingAreka.page.tsx
+++ b/src/pages/Listing/staticPages/ListingAreka.page.tsx
@@ -5,6 +5,7 @@ import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { NamSnippet } from "../../../utils/constants";
 import { HouseDataType } from "../../../utils/types";
 import Amenities from "../components/Amenities/Amenities.component";
@@ -29,7 +30,7 @@ const ListingAreka = () => {
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
-    const houseData: HouseDataType | undefined = NamDataList.find((house) => house.name === listing);
+    const houseData: HouseDataType | undefined = NamDataList.find((house) => house.houseLangCode === listing);
     const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
 
@@ -44,7 +45,7 @@ const ListingAreka = () => {
         <div className={`listingContainer${show ? ' modal-open' : ''}`}>
             <Helmet>
                 <meta charSet="utf-8" />
-                <title>House Areka - Couples Retreat with A/C</title>
+                <title>Casa Areka - Couples Retreat with A/C</title>
                 <meta name="description" content="New fully equipped Bungalows with A/C located 200mts from the beautiful Playa Chiquita beach, in one of the safest and calm neighborhoods in the Caribbean. A few minutes from Puerto Viejo and Manzanillo, we are perfectly located to visit Punta Uva beach and Arrecife." />
                 <link rel="canonical" href="https://www.reservaskalawala.com/Areka" />
                 <link rel="alternate" hrefLang="en" href="https://www.reservaskalawala.com/Areka" />
@@ -59,7 +60,7 @@ const ListingAreka = () => {
             <Row className="subContainer">
                 <Col className="info col" lg={{ order: 'first', span: 10 }} md={{ order: 'first', span: 12 }} sm={12} xs={12}>
                     <div className="heading">
-                        <h1 className="title">House Areka</h1>
+                        <h1 className="title">Casa Areka</h1>
                         <p className="location">
                             <a href="https://maps.app.goo.gl/cT74qg6iqX35aa5t9" target="_blank" rel="noopener noreferrer">
                                 Playa Chiquita, Puerto Viejo de Talamanca, Limón, Costa Rica
@@ -123,6 +124,7 @@ const ListingAreka = () => {
                 <OtherListings listings={NamSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            <Footer isSpanish={false} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages/ListingDelfin.page.tsx
+++ b/src/pages/Listing/staticPages/ListingDelfin.page.tsx
@@ -5,6 +5,7 @@ import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { HouseDataType } from "../../../utils/types";
 import { homesSnippet } from "../../../utils/constants";
 import Amenities from "../components/Amenities/Amenities.component";
@@ -30,7 +31,7 @@ const ListingDelfin = () => {
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
-    const houseData: HouseDataType | undefined = houseDataList.find((house) => house.name === listing);
+    const houseData: HouseDataType | undefined = houseDataList.find((house) => house.houseLangCode === listing);
     const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
 
@@ -44,7 +45,7 @@ const ListingDelfin = () => {
         <div className={`listingContainer${show ? ' modal-open' : ''}`}>
             <Helmet>
                 <meta charSet="utf-8" />
-                <title>House Delfin - Puerto Viejo Vacation Home Rental</title>
+                <title>Casa Delfines - Puerto Viejo Vacation Home Rental</title>
                 <meta name="description" content="Welcome to Reservas Kalawala. Located in the heart of town, this house accommodates up to 6 guests with fully equipped kitchen, 2 bathrooms, 2 A/C units, and private parking for 2 cars." />
                 <link rel="canonical" href="https://www.reservaskalawala.com/Delfin" />
                 <link rel="alternate" hrefLang="en" href="https://www.reservaskalawala.com/Delfin" />
@@ -58,7 +59,7 @@ const ListingDelfin = () => {
             <Row className="subContainer">
                 <Col className="info col" lg={{ order: 'first', span: 10 }} md={{ order: 'first', span: 12 }} sm={12} xs={12}>
                     <div className="heading">
-                        <h1 className="title">House Delfines</h1>
+                        <h1 className="title">Casa Delfines</h1>
                         <p className="location">
                             <a href="https://maps.app.goo.gl/ixZHjG7yYsMF9U2e9" target="_blank" rel="noopener noreferrer">
                                 Puerto Viejo de Talamanca, Limón, Costa Rica
@@ -126,6 +127,7 @@ const ListingDelfin = () => {
                 <OtherListings listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            <Footer isSpanish={false} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages/ListingGeco.page.tsx
+++ b/src/pages/Listing/staticPages/ListingGeco.page.tsx
@@ -5,6 +5,7 @@ import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { homesSnippet } from "../../../utils/constants";
 import { HouseDataType } from "../../../utils/types";
 import Amenities from "../components/Amenities/Amenities.component";
@@ -31,7 +32,7 @@ const ListingGeco = () => {
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
-    const houseData: HouseDataType | undefined = houseDataList.find((house) => house.name === listing);
+    const houseData: HouseDataType | undefined = houseDataList.find((house) => house.houseLangCode === listing);
     const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
 
@@ -45,7 +46,7 @@ const ListingGeco = () => {
         <div className={`listingContainer${show ? ' modal-open' : ''}`}>
             <Helmet>
                 <meta charSet="utf-8" />
-                <title>House Geco - Pet Friendly Home in Puerto Viejo</title>
+                <title>Casa Geco - Pet Friendly Home in Puerto Viejo</title>
                 <meta name="description" content="Located in the heart of town, this house has space for up to 5 people and features a fully equipped kitchen, a bathroom, 2 A/C units, and a private parking lot." />
                 <link rel="canonical" href="https://www.reservaskalawala.com/Geco" />
                 <link rel="alternate" hrefLang="en" href="https://www.reservaskalawala.com/Geco" />
@@ -59,7 +60,7 @@ const ListingGeco = () => {
             <Row className="subContainer">
                 <Col className="info col" lg={{ order: 'first', span: 10 }} md={{ order: 'first', span: 12 }} sm={12} xs={12}>
                     <div className="heading">
-                        <h1 className="title">House Geco</h1>
+                        <h1 className="title">Casa Geco</h1>
                         <p className="location">
                             <a href="https://maps.app.goo.gl/ixZHjG7yYsMF9U2e9" target="_blank" rel="noopener noreferrer">
                                 Puerto Viejo de Talamanca, Limón, Costa Rica
@@ -135,6 +136,7 @@ const ListingGeco = () => {
                 <OtherListings listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            <Footer isSpanish={false} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages/ListingGiulia.page.tsx
+++ b/src/pages/Listing/staticPages/ListingGiulia.page.tsx
@@ -5,6 +5,7 @@ import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { NamSnippet } from "../../../utils/constants";
 import { HouseDataType } from "../../../utils/types";
 import Amenities from "../components/Amenities/Amenities.component";
@@ -28,7 +29,7 @@ const ListingGiulia = () => {
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
-    const houseData: HouseDataType | undefined = NamDataList.find((house) => house.name === listing);
+    const houseData: HouseDataType | undefined = NamDataList.find((house) => house.houseLangCode === listing);
     const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
 
@@ -42,7 +43,7 @@ const ListingGiulia = () => {
         <div className={`listingContainer${show ? ' modal-open' : ''}`}>
             <Helmet>
                 <meta charSet="utf-8" />
-                <title>House Giulia - Family Retreat</title>
+                <title>Casa Giulia - Family Retreat</title>
                 <meta name="description" content="New fully equipped Bungalows with A/C located 200mts from the beautiful Playa Chiquita beach, in one of the safest and calm neighborhoods in the Caribbean. Perfect for families up to 4 people." />
                 <link rel="canonical" href="https://www.reservaskalawala.com/Giulia" />
                 <link rel="alternate" hrefLang="en" href="https://www.reservaskalawala.com/Giulia" />
@@ -56,7 +57,7 @@ const ListingGiulia = () => {
             <Row className="subContainer">
                 <Col className="info col" lg={{ order: 'first', span: 10 }} md={{ order: 'first', span: 12 }} sm={12} xs={12}>
                     <div className="heading">
-                        <h1 className="title">House Giulia</h1>
+                        <h1 className="title">Casa Giulia</h1>
                         <p className="location">
                             <a href="https://maps.app.goo.gl/cT74qg6iqX35aa5t9" target="_blank" rel="noopener noreferrer">
                                 Playa Chiquita, Puerto Viejo de Talamanca, Limón, Costa Rica
@@ -120,6 +121,7 @@ const ListingGiulia = () => {
                 <OtherListings listings={NamSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            <Footer isSpanish={false} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages/ListingPappagallo.page.tsx
+++ b/src/pages/Listing/staticPages/ListingPappagallo.page.tsx
@@ -5,6 +5,7 @@ import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { HouseDataType } from "../../../utils/types";
 import { homesSnippet } from "../../../utils/constants";
 import Amenities from "../components/Amenities/Amenities.component";
@@ -29,7 +30,7 @@ const ListingPappagallo = () => {
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
-    const houseData: HouseDataType | undefined = houseDataList.find((house) => house.name === listing);
+    const houseData: HouseDataType | undefined = houseDataList.find((house) => house.houseLangCode === listing);
     const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
 
@@ -43,7 +44,7 @@ const ListingPappagallo = () => {
         <div className={`listingContainer${show ? ' modal-open' : ''}`}>
             <Helmet>
                 <meta charSet="utf-8" />
-                <title>House Pappagallo - Fully equipped Home in Puerto Viejo</title>
+                <title>Casa Pappagallo - Fully equipped Home in Puerto Viejo</title>
                 <meta name="description" content="Welcome to Kalawala, a charming complex of two apartments located in the heart of Puerto Viejo. Each apartment is built entirely of wood and is situated above a delightful Italian bakery and are equipped with everything you need for a comfortable stay." />
                 <link rel="canonical" href="https://www.reservaskalawala.com/Pappagallo" />
                 <link rel="alternate" hrefLang="en" href="https://www.reservaskalawala.com/Pappagallo" />
@@ -57,7 +58,7 @@ const ListingPappagallo = () => {
             <Row className="subContainer">
                 <Col className="info col" lg={{ order: 'first', span: 10 }} md={{ order: 'first', span: 12 }} sm={12} xs={12}>
                     <div className="heading">
-                        <h1 className="title">House Pappagallo</h1>
+                        <h1 className="title">Casa Pappagallo</h1>
                         <p className="location">
                             <a href="https://maps.app.goo.gl/ixZHjG7yYsMF9U2e9" target="_blank" rel="noopener noreferrer">
                                 Puerto Viejo de Talamanca, Limón, Costa Rica
@@ -127,6 +128,7 @@ const ListingPappagallo = () => {
                 <OtherListings listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            <Footer isSpanish={false} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages/ListingPlumeria.page.tsx
+++ b/src/pages/Listing/staticPages/ListingPlumeria.page.tsx
@@ -5,6 +5,7 @@ import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { NamSnippet } from "../../../utils/constants";
 import { HouseDataType } from "../../../utils/types";
 import Amenities from "../components/Amenities/Amenities.component";
@@ -28,7 +29,7 @@ const ListingPlumeria = () => {
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
-    const houseData: HouseDataType | undefined = NamDataList.find((house) => house.name === listing);
+    const houseData: HouseDataType | undefined = NamDataList.find((house) => house.houseLangCode === listing);
     const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
 
@@ -42,7 +43,7 @@ const ListingPlumeria = () => {
         <div className={`listingContainer${show ? ' modal-open' : ''}`}>
             <Helmet>
                 <meta charSet="utf-8" />
-                <title>House Plumeria - Couples Retreat</title>
+                <title>Casa Plumeria - Couples Retreat</title>
                 <meta name="description" content="New fully equipped Bungalows with A/C located 200mts from the beautiful Playa Chiquita beach, in one of the safest and calm neighborhoods in the Caribbean. A few minutes from Puerto Viejo and Manzanillo, we are perfectly located to visit Punta Uva beach and Arrecife." />
                 <link rel="canonical" href="https://www.reservaskalawala.com/Plumeria" />
                 <link rel="alternate" hrefLang="en" href="https://www.reservaskalawala.com/Plumeria" />
@@ -56,7 +57,7 @@ const ListingPlumeria = () => {
             <Row className="subContainer">
                 <Col className="info col" lg={{ order: 'first', span: 10 }} md={{ order: 'first', span: 12 }} sm={12} xs={12}>
                     <div className="heading">
-                        <h1 className="title">House Plumeria</h1>
+                        <h1 className="title">Casa Plumeria</h1>
                         <p className="location">
                             <a href="https://maps.app.goo.gl/cT74qg6iqX35aa5t9" target="_blank" rel="noopener noreferrer">
                                 Playa Chiquita, Puerto Viejo de Talamanca, Limón, Costa Rica
@@ -115,6 +116,7 @@ const ListingPlumeria = () => {
                 <OtherListings listings={NamSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            <Footer isSpanish={false} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages/ListingRana.page.tsx
+++ b/src/pages/Listing/staticPages/ListingRana.page.tsx
@@ -5,6 +5,7 @@ import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { HouseDataType } from "../../../utils/types";
 import { homesSnippet } from "../../../utils/constants";
 import Amenities from "../components/Amenities/Amenities.component";
@@ -30,7 +31,7 @@ const ListingRana = () => {
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
-    const houseData: HouseDataType | undefined = houseDataList.find((house) => house.name === listing);
+    const houseData: HouseDataType | undefined = houseDataList.find((house) => house.houseLangCode === listing);
     const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
 
@@ -44,7 +45,7 @@ const ListingRana = () => {
         <div className={`listingContainer${show ? ' modal-open' : ''}`}>
             <Helmet>
                 <meta charSet="utf-8" />
-                <title>House Rana - Puerto Viejo Vacation Home Rental</title>
+                <title>Casa Rana - Puerto Viejo Vacation Home Rental</title>
                 <meta name="description" content="Nestled in the heart of town, this charming house comfortably accommodates up to 5 guests. It boasts a fully equipped kitchen, a bathroom, two A/C units, and a private parking space." />
                 <link rel="canonical" href="https://www.reservaskalawala.com/Rana" />
                 <link rel="alternate" hrefLang="en" href="https://www.reservaskalawala.com/Rana" />
@@ -58,7 +59,7 @@ const ListingRana = () => {
             <Row className="subContainer">
                 <Col className="info col" lg={{ order: 'first', span: 10 }} md={{ order: 'first', span: 12 }} sm={12} xs={12}>
                     <div className="heading">
-                        <h1 className="title">House Rana</h1>
+                        <h1 className="title">Casa Rana</h1>
                         <p className="location">
                             <a href="https://maps.app.goo.gl/ixZHjG7yYsMF9U2e9" target="_blank" rel="noopener noreferrer">
                                 Puerto Viejo de Talamanca, Limón, Costa Rica
@@ -133,6 +134,7 @@ const ListingRana = () => {
                 <OtherListings listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            <Footer isSpanish={false} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages/ListingTucano.page.tsx
+++ b/src/pages/Listing/staticPages/ListingTucano.page.tsx
@@ -5,6 +5,7 @@ import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { HouseDataType } from "../../../utils/types";
 import { homesSnippet} from "../../../utils/constants";
 import Amenities from "../components/Amenities/Amenities.component";
@@ -29,7 +30,7 @@ const ListingTucano = () => {
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
-    const houseData: HouseDataType | undefined = houseDataList.find((house) => house.name === listing);
+    const houseData: HouseDataType | undefined = houseDataList.find((house) => house.houseLangCode === listing);
     const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
 
@@ -43,7 +44,7 @@ const ListingTucano = () => {
         <div className={`listingContainer${show ? ' modal-open' : ''}`}>
             <Helmet>
                 <meta charSet="utf-8" />
-                <title>House Tucano - Like Nothing Else in Puerto Viejo</title>
+                <title>Casa Tucano - Like Nothing Else in Puerto Viejo</title>
                 <meta name="description" content="This house offers a delightful experience in the heart of Puerto Viejo with a charming wooden apartment located above an Italian bakery. The apartment features two comfortable bedrooms, a well-equipped bathroom, a fully equipped kitchen, a lovely terrace, and two A/C units." />
                 <link rel="canonical" href="https://www.reservaskalawala.com/Tucano" />
                 <link rel="alternate" hrefLang="en" href="https://www.reservaskalawala.com/Tucano" />
@@ -54,7 +55,7 @@ const ListingTucano = () => {
             <Row className="subContainer">
                 <Col className="info col" lg={{ order: 'first', span: 10 }} md={{ order: 'first', span: 12 }} sm={12} xs={12}>
                     <div className="heading">
-                        <h1 className="title">House Tucano</h1>
+                        <h1 className="title">Casa Tucano</h1>
                         <p className="location">
                             <a href="https://maps.app.goo.gl/ixZHjG7yYsMF9U2e9" target="_blank" rel="noopener noreferrer">
                                 Puerto Viejo de Talamanca, Limón, Costa Rica
@@ -118,6 +119,7 @@ const ListingTucano = () => {
                 <OtherListings listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            <Footer isSpanish={false} />
             
         </div>
     )

--- a/src/pages/Listing/staticPages/ListingVillaCoral.page.tsx
+++ b/src/pages/Listing/staticPages/ListingVillaCoral.page.tsx
@@ -5,6 +5,7 @@ import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { VillaSnippet } from "../../../utils/constants";
 import { HouseDataType } from "../../../utils/types";
 import Amenities from "../components/Amenities/Amenities.component";
@@ -28,7 +29,11 @@ const ListingVillaCoral = () => {
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
-    const houseData: HouseDataType | undefined = VillasDataList.find((house) => house.name === listing);
+    // `listing` ('Villa Coral', with a space) is the display/snippet-lookup
+    // value used below for ImagesContainer/OtherListings/ImagesModal — it is
+    // NOT the houseLangCode, which has no space (matches the /VillaCoral
+    // route, same as the propertyKey="VillaCoral" literals elsewhere here).
+    const houseData: HouseDataType | undefined = VillasDataList.find((house) => house.houseLangCode === 'VillaCoral');
     const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
 
@@ -126,6 +131,7 @@ const ListingVillaCoral = () => {
                 <OtherListings listings={VillaSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            <Footer isSpanish={false} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages/ListingVillaMar.page.tsx
+++ b/src/pages/Listing/staticPages/ListingVillaMar.page.tsx
@@ -5,6 +5,7 @@ import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { VillaSnippet } from "../../../utils/constants";
 import { HouseDataType } from "../../../utils/types";
 import Amenities from "../components/Amenities/Amenities.component";
@@ -28,7 +29,11 @@ const ListingVillaMar = () => {
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
-    const houseData: HouseDataType | undefined = VillasDataList.find((house) => house.name === listing);
+    // `listing` ('Villa Mar', with a space) is the display/snippet-lookup
+    // value used below for ImagesContainer/OtherListings/ImagesModal — it is
+    // NOT the houseLangCode, which has no space (matches the /VillaMar route,
+    // same as the propertyKey="VillaMar" literals elsewhere in this file).
+    const houseData: HouseDataType | undefined = VillasDataList.find((house) => house.houseLangCode === 'VillaMar');
     const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
 
@@ -125,6 +130,7 @@ const ListingVillaMar = () => {
                 <OtherListings listings={VillaSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            <Footer isSpanish={false} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages/__tests__/ListingDelfin.test.tsx
+++ b/src/pages/Listing/staticPages/__tests__/ListingDelfin.test.tsx
@@ -107,7 +107,7 @@ describe('ListingDelfin Component', () => {
     );
     
     expect(screen.getByTestId('fixed-navigation')).toBeInTheDocument();
-    expect(screen.getByText('House Delfines')).toBeInTheDocument();
+    expect(screen.getByText('Casa Delfines')).toBeInTheDocument();
     expect(screen.getByTestId('images-container')).toBeInTheDocument();
     expect(screen.getByTestId('booking-search-widget')).toBeInTheDocument();
   });
@@ -120,7 +120,7 @@ describe('ListingDelfin Component', () => {
     );
     
     // Verify that the component finds the correct house data
-    const delfinData = houseDataList.find((house) => house.name === 'Delfin');
+    const delfinData = houseDataList.find((house) => house.name === 'Casa Delfines');
     expect(delfinData).toBeDefined();
     expect(delfinData?.houseLangCode).toBe('Delfin');
     expect(delfinData?.guestNumber).toBe(6);
@@ -147,7 +147,7 @@ describe('ListingDelfin Component', () => {
       </BrowserRouter>
     );
     
-    const delfinData = houseDataList.find((house) => house.name === 'Delfin');
+    const delfinData = houseDataList.find((house) => house.name === 'Casa Delfines');
     const amenityNames = delfinData?.amenities.map(a => a.name) || [];
     
     // Check that expected amenities are present

--- a/src/pages/Listing/staticPages_ES/ListingAreka.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingAreka.page_ES.tsx
@@ -4,6 +4,7 @@ import '../Listing.style.scss'
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { NamSnippetES } from "../../../utils/constants";
 import { HouseDataType } from "../../../utils/types";
 import Amenities from "../components/Amenities/Amenities.component";
@@ -121,6 +122,7 @@ const ListingArekaES = () => {
                 <OtherListingsES listings={NamSnippetES} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName="Areka" />}
+            <Footer isSpanish={true} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/ListingDelfin.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingDelfin.page_ES.tsx
@@ -4,6 +4,7 @@ import '../Listing.style.scss'
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { homesSnippet } from "../../../utils/constants";
 import Amenities from "../components/Amenities/Amenities.component";
 import { AmenityType, HouseDataType } from "../../../utils/types";
@@ -134,6 +135,7 @@ const ListingDelfin = () => {
                 <OtherListingsES listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            <Footer isSpanish={true} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/ListingGeco.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingGeco.page_ES.tsx
@@ -4,6 +4,7 @@ import '../Listing.style.scss'
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { homesSnippet } from "../../../utils/constants";
 import { HouseDataType } from "../../../utils/types";
 import Amenities from "../components/Amenities/Amenities.component";
@@ -132,6 +133,7 @@ const ListingGecoES = () => {
                 <OtherListingsES listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            <Footer isSpanish={true} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/ListingGiulia.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingGiulia.page_ES.tsx
@@ -4,6 +4,7 @@ import '../Listing.style.scss'
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { NamSnippetES } from "../../../utils/constants";
 import { HouseDataType } from "../../../utils/types";
 import Amenities from "../components/Amenities/Amenities.component";
@@ -116,6 +117,7 @@ const ListingGiuliaES = () => {
                 <OtherListingsES listings={NamSnippetES} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName="Giulia" />}
+            <Footer isSpanish={true} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/ListingPappagallo.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingPappagallo.page_ES.tsx
@@ -4,6 +4,7 @@ import '../Listing.style.scss'
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { HouseDataType } from "../../../utils/types";
 import { homesSnippet } from "../../../utils/constants";
 import Amenities from "../components/Amenities/Amenities.component";
@@ -129,6 +130,7 @@ const ListingPappagalloES = () => {
                 <OtherListingsES listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            <Footer isSpanish={true} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/ListingPlumeria.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingPlumeria.page_ES.tsx
@@ -4,6 +4,7 @@ import '../Listing.style.scss'
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { NamSnippetES } from "../../../utils/constants";
 import { HouseDataType } from "../../../utils/types";
 import Amenities from "../components/Amenities/Amenities.component";
@@ -120,6 +121,7 @@ const ListingPlumeriaES = () => {
                 <OtherListingsES listings={NamSnippetES} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName="Plumeria" />}
+            <Footer isSpanish={true} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/ListingRana.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingRana.page_ES.tsx
@@ -4,6 +4,7 @@ import '../Listing.style.scss'
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { homesSnippet } from "../../../utils/constants";
 import Amenities from "../components/Amenities/Amenities.component";
 import { AmenityType, HouseDataType } from "../../../utils/types";
@@ -134,6 +135,7 @@ const ListingRana = () => {
                 <OtherListingsES listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            <Footer isSpanish={true} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/ListingTucano.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingTucano.page_ES.tsx
@@ -4,6 +4,7 @@ import '../Listing.style.scss'
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { HouseDataType } from "../../../utils/types";
 import { homesSnippet } from "../../../utils/constants";
 import Amenities from "../components/Amenities/Amenities.component";
@@ -121,6 +122,7 @@ const ListingTucanoES = () => {
                 <OtherListingsES listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            <Footer isSpanish={true} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/ListingVillaCoral.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingVillaCoral.page_ES.tsx
@@ -4,6 +4,7 @@ import '../Listing.style.scss'
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { VillaCoralSnippet } from "../../../utils/constants";
 import { HouseDataType } from "../../../utils/types";
 import Amenities from "../components/Amenities/Amenities.component";
@@ -128,6 +129,7 @@ const ListingVillaCoralES = () => {
                 <OtherListingsES listings={VillaCoralSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            <Footer isSpanish={true} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/ListingVillaMar.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingVillaMar.page_ES.tsx
@@ -4,6 +4,7 @@ import '../Listing.style.scss'
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
 import ImagesContainer from "../components/ImagesContainer/ImagesContainer.component";
 import ImagesModal from "../components/ImagesModal/ImagesModal.component";
+import Footer from "../../../components/Footer/Footer.component";
 import { VillaMarSnippet } from "../../../utils/constants";
 import { HouseDataType } from "../../../utils/types";
 import Amenities from "../components/Amenities/Amenities.component";
@@ -128,6 +129,7 @@ const ListingVillaMarES = () => {
                 <OtherListingsES listings={VillaMarSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            <Footer isSpanish={true} />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/__tests__/ListingDelfinES.test.tsx
+++ b/src/pages/Listing/staticPages_ES/__tests__/ListingDelfinES.test.tsx
@@ -122,7 +122,7 @@ describe('ListingDelfinES Component', () => {
     // Verify that the component finds the correct Spanish house data
     const delfinESData = houseDataList.find((house) => house.houseLangCode === 'DelfinES');
     expect(delfinESData).toBeDefined();
-    expect(delfinESData?.name).toBe('Delfín');
+    expect(delfinESData?.name).toBe('Casa Delfines');
     expect(delfinESData?.guestNumber).toBe(6);
     expect(delfinESData?.houseCode).toBe(10);
   });
@@ -302,7 +302,7 @@ describe('ListingDelfinES Component', () => {
     const delfinESData = houseDataList.find((house) => house.houseLangCode === 'DelfinES');
     
     expect(delfinESData).toBeDefined();
-    expect(delfinESData?.name).toBe('Delfín');
+    expect(delfinESData?.name).toBe('Casa Delfines');
     expect(delfinESData?.houseLangCode).toBe('DelfinES');
     expect(delfinESData?.guestNumber).toBe(6);
     expect(delfinESData?.houseCode).toBe(10);

--- a/src/utils/__tests__/delfinIntegration.test.ts
+++ b/src/utils/__tests__/delfinIntegration.test.ts
@@ -26,14 +26,14 @@ describe('Delfin Integration Tests', () => {
     
     // English version
     expect(delfinEnglish).toBeDefined();
-    expect(delfinEnglish?.name).toBe('Delfin');
+    expect(delfinEnglish?.name).toBe('Casa Delfines');
     expect(delfinEnglish?.guestNumber).toBe(6);
     expect(delfinEnglish?.houseCode).toBe(10);
     expect(delfinEnglish?.parking).toBe(true);
-    
+
     // Spanish version
     expect(delfinSpanish).toBeDefined();
-    expect(delfinSpanish?.name).toBe('Delfín');
+    expect(delfinSpanish?.name).toBe('Casa Delfines');
     expect(delfinSpanish?.guestNumber).toBe(6);
     expect(delfinSpanish?.houseCode).toBe(10);
     expect(delfinSpanish?.parking).toBe(true);
@@ -110,9 +110,12 @@ describe('Delfin Integration Tests', () => {
     
     expect(delfinHouses.length).toBe(2); // English and Spanish versions
     
-    // Verify it can be filtered out when viewing Delfin page itself
-    const otherHousesWhenViewingDelfin = allHouses.filter(house => house.name !== 'Delfin');
-    expect(otherHousesWhenViewingDelfin.length).toBe(allHouses.length - 1);
+    // Verify it can be filtered out when viewing Delfin page itself. Both the
+    // English and Spanish entries now share the display name "Casa Delfines"
+    // (previously "Delfin" / "Delfín" — inconsistent even within this file),
+    // so a name-based filter drops both language variants at once.
+    const otherHousesWhenViewingDelfin = allHouses.filter(house => house.name !== 'Casa Delfines');
+    expect(otherHousesWhenViewingDelfin.length).toBe(allHouses.length - 2);
   });
 
   test('should have proper description content', () => {
@@ -135,7 +138,7 @@ describe('Delfin Integration Tests', () => {
 
   test('should be included in houseDataEngList for home page display', () => {
     // Requirement 3.1, 3.2, 3.3: Home page integration
-    const delfinInEngList = houseDataEngList.find(house => house.name === 'Delfin');
+    const delfinInEngList = houseDataEngList.find(house => house.name === 'Casa Delfines');
     
     expect(delfinInEngList).toBeDefined();
     expect(delfinInEngList?.guestNumber).toBe(6);

--- a/src/utils/__tests__/delfinIntegrationManual.test.ts
+++ b/src/utils/__tests__/delfinIntegrationManual.test.ts
@@ -14,7 +14,7 @@ describe('Delfin Manual Integration Verification', () => {
     const delfinEnglish = houseDataList.find(house => house.houseLangCode === 'Delfin');
     const delfinSpanish = houseDataList.find(house => house.houseLangCode === 'DelfinES');
     const delfinInSnippet = homesSnippet.find(home => home.name === 'Delfin');
-    const delfinInEngList = houseDataEngList.find(house => house.name === 'Delfin');
+    const delfinInEngList = houseDataEngList.find(house => house.name === 'Casa Delfines');
     
     // All data structures should contain Delfin
     expect(delfinEnglish).toBeDefined();

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1092,7 +1092,7 @@ export const ribHouseDataEngList: HouseDataType[] = [
     }]
 export const houseDataEngList: HouseDataType[] = [
     {
-        name: "Geco",
+        name: "Casa Geco",
         guestNumber: 5,
         location: "Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "Located in the heart of town, this house has space for up to 5 people and features a fully equipped kitchen, a bathroom, 2 A/C units, and a private parking lot. Our prime location offers easy access to both the town center and the most beautiful beaches that Puerto Viejo has to offer.<br/>   Most shops and restaurants are just a short walk away, and there is a nearby jungle path that runs along the ocean and leads to natural pools in the coral and to Cocles.<br/>    All of the spaces described here are private, including the fully equipped kitchen and bathroom. You'll have everything you need to make yourself at home.<br/>    We offer cleaning services for reservations of 5 nights or longer. Our team will contact you during your stay to coordinate a convenient time for the cleaning.<br/>   Do you have a special request? We would be more than happy to accommodate you if we can. Please don't hesitate to let us know.<br/>    If you require a pack- and - play crib during your stay, please inform us ahead of time. We'll make sure to set it up in your room during our cleaning process.",
@@ -1131,7 +1131,7 @@ export const houseDataEngList: HouseDataType[] = [
         ],
     },
     {
-        name: "Rana",
+        name: "Casa Rana",
         guestNumber: 5,
         location: "Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "Nestled in the heart of town, this charming house comfortably accommodates up to 5 guests. It boasts a fully equipped kitchen, a bathroom, two A/C units, and a private parking space. Our prime location ensures easy access to both the town center and the beaches of Puerto Viejo.<br/>     The house offers complete privacy, with all described spaces, including the kitchen and bathroom, exclusively for your use. You'll have all the amenities needed to feel at home.<br/>     You'll find most shops and restaurants within a short walking distance. Additionally, a nearby jungle path along the ocean leads to natural coral pools and Cocles.<br/>     Have a special request? We are happy to accommodate if possible. Please don't hesitate to let us know.<br/>     We strongly recommend this option if you are planning to travel with your pet, as it offers a small, fenced garden.",
@@ -1168,7 +1168,7 @@ export const houseDataEngList: HouseDataType[] = [
         ],
     },
     {
-        name: "Tucano",
+        name: "Casa Tucano",
         guestNumber: 5,
         location: "Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "This house offers a delightful experience in the heart of Puerto Viejo with a charming wooden apartment located above an Italian bakery. The apartment features two comfortable bedrooms, a well-equipped bathroom, a fully equipped kitchen, a lovely terrace, and two A/C units, ensuring a cozy stay.<br/>    These apartments provide private spaces, including the kitchen and bathroom, offering everything you need to feel at home. For stays of 5 nights or more, we provide complimentary cleaning services, and our team will coordinate a suitable time with you during your visit.<br/>    If you have any special requests, we're happy to accommodate them whenever possible, so don't hesitate to let us know. Should you need a pack-and-play crib for your stay, please inform us in advance, and we'll ensure it's set up in your room during the cleaning process.",
@@ -1207,7 +1207,7 @@ export const houseDataEngList: HouseDataType[] = [
     },
 
     {
-        name: "Pappagallo",
+        name: "Casa Pappagallo",
         guestNumber: 5,
         location: "Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "Welcome to Kalawala, a charming complex of two apartments located in the heart of Puerto Viejo. Each apartment is built entirely of wood and is situated above a delightful Italian bakery. The apartments are equipped with everything you need for a comfortable stay, including a fully equipped kitchen, two cozy bedrooms, a lovely terrace, two A/C units, and one well equipped bathroom.<br/>    All of the spaces described here are private, including the fully equipped kitchen and bathroom. You'll have everything you need to make yourself at home.<br/>    We offer cleaning services for reservations of 5 nights or longer. Our team will contact you during your stay to coordinate a convenient time for the cleaning.<br/>    Do you have a special request? We would be more than happy to accommodate you if we can. Please don't hesitate to let us know.<br/>    If you require a pack - and - play crib during your stay, please inform us ahead of time. We'll make sure to set it up in your room during our cleaning process.",
@@ -1244,7 +1244,7 @@ export const houseDataEngList: HouseDataType[] = [
         ],
     },
     {
-        name: "Delfin",
+        name: "Casa Delfines",
         guestNumber: 6,
         location: "Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "Welcome to Reservas Kalawala. Located in the heart of town, this house accommodates up to 6 guests with fully equipped kitchen, bathroom, 2 A/C units (not in kitchen or living room), and private parking. Our prime location offers easy access to both the town center and the most beautiful beaches that Puerto Viejo has to offer.<br/>    All of the spaces described here are private, including the fully equipped kitchen and bathroom. You'll have everything you need to make yourself at home.<br/>    We offer Automated check-in and check-out with lockbox key drop-off for your convenience.<br/>    Do you have a special request? We would be more than happy to accommodate you if we can. Please don't hesitate to let us know.",
@@ -1279,7 +1279,7 @@ export const houseDataEngList: HouseDataType[] = [
 
 export const houseDataList: HouseDataType[] = [
     {
-        name: "Geco",
+        name: "Casa Geco",
         guestNumber: 5,
         location: "Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "Located in the heart of town, this house has space for up to 5 people and features a fully equipped kitchen, a bathroom, 2 A/C units, and a private parking lot. Our prime location offers easy access to both the town center and the most beautiful beaches that Puerto Viejo has to offer.<br/>   Most shops and restaurants are just a short walk away, and there is a nearby jungle path that runs along the ocean and leads to natural pools in the coral and to Cocles.<br/>    All of the spaces described here are private, including the fully equipped kitchen and bathroom. You'll have everything you need to make yourself at home.<br/>    We offer cleaning services for reservations of 5 nights or longer. Our team will contact you during your stay to coordinate a convenient time for the cleaning.<br/>   Do you have a special request? We would be more than happy to accommodate you if we can. Please don't hesitate to let us know.<br/>    If you require a pack- and - play crib during your stay, please inform us ahead of time. We'll make sure to set it up in your room during our cleaning process.",
@@ -1318,7 +1318,7 @@ export const houseDataList: HouseDataType[] = [
         ],
     },
     {
-        name: "Rana",
+        name: "Casa Rana",
         guestNumber: 5,
         location: "Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "Nestled in the heart of town, this charming house comfortably accommodates up to 5 guests. It boasts a fully equipped kitchen, a bathroom, two A/C units, and a private parking space. Our prime location ensures easy access to both the town center and the beaches of Puerto Viejo.<br/>     The house offers complete privacy, with all described spaces, including the kitchen and bathroom, exclusively for your use. You'll have all the amenities needed to feel at home.<br/>     You'll find most shops and restaurants within a short walking distance. Additionally, a nearby jungle path along the ocean leads to natural coral pools and Cocles.<br/>     Have a special request? We are happy to accommodate if possible. Please don't hesitate to let us know.<br/>     We strongly recommend this option if you are planning to travel with your pet, as it offers a small, fenced garden.",
@@ -1356,7 +1356,7 @@ export const houseDataList: HouseDataType[] = [
         ],
     },
     {
-        name: "Tucano",
+        name: "Casa Tucano",
         guestNumber: 5,
         location: "Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "This house offers a delightful experience in the heart of Puerto Viejo with a charming wooden apartment located above an Italian bakery. The apartment features two comfortable bedrooms, a well-equipped bathroom, a fully equipped kitchen, a lovely terrace, and two A/C units, ensuring a cozy stay.<br/>    These apartments provide private spaces, including the kitchen and bathroom, offering everything you need to feel at home. For stays of 5 nights or more, we provide complimentary cleaning services, and our team will coordinate a suitable time with you during your visit.<br/>    If you have any special requests, we're happy to accommodate them whenever possible, so don't hesitate to let us know. Should you need a pack-and-play crib for your stay, please inform us in advance, and we'll ensure it's set up in your room during the cleaning process.",
@@ -1395,7 +1395,7 @@ export const houseDataList: HouseDataType[] = [
     },
 
     {
-        name: "Pappagallo",
+        name: "Casa Pappagallo",
         guestNumber: 5,
         location: "Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "Welcome to Kalawala, a charming complex of two apartments located in the heart of Puerto Viejo. Each apartment is built entirely of wood and is situated above a delightful Italian bakery. The apartments are equipped with everything you need for a comfortable stay, including a fully equipped kitchen, two cozy bedrooms, a lovely terrace, two A/C units, and one well equipped bathroom.<br/>    All of the spaces described here are private, including the fully equipped kitchen and bathroom. You'll have everything you need to make yourself at home.<br/>    We offer cleaning services for reservations of 5 nights or longer. Our team will contact you during your stay to coordinate a convenient time for the cleaning.<br/>    Do you have a special request? We would be more than happy to accommodate you if we can. Please don't hesitate to let us know.<br/>    If you require a pack - and - play crib during your stay, please inform us ahead of time. We'll make sure to set it up in your room during our cleaning process.",
@@ -1432,7 +1432,7 @@ export const houseDataList: HouseDataType[] = [
         ],
     },
     {
-        name: "Geco",
+        name: "Casa Geco",
         guestNumber: 5,
         location: "AAA Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "Located in the heart of town, this house has space for up to 5 people and features a fully equipped kitchen, a bathroom, 2 A/C units, and a private parking lot. Our prime location offers easy access to both the town center and the most beautiful beaches that Puerto Viejo has to offer.<br/>   Most shops and restaurants are just a short walk away, and there is a nearby jungle path that runs along the ocean and leads to natural pools in the coral and to Cocles.<br/>    All of the spaces described here are private, including the fully equipped kitchen and bathroom. You'll have everything you need to make yourself at home.<br/>    We offer cleaning services for reservations of 5 nights or longer. Our team will contact you during your stay to coordinate a convenient time for the cleaning.<br/>   Do you have a special request? We would be more than happy to accommodate you if we can. Please don't hesitate to let us know.<br/>    If you require a pack- and - play crib during your stay, please inform us ahead of time. We'll make sure to set it up in your room during our cleaning process.",
@@ -1470,7 +1470,7 @@ export const houseDataList: HouseDataType[] = [
         ],
     },
     {
-        name: "Rana",
+        name: "Casa Rana",
         guestNumber: 5,
         location: "AAA Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "Nestled in the heart of town, this charming house comfortably accommodates up to 5 guests. It boasts a fully equipped kitchen, a bathroom, two A/C units, and a private parking space. Our prime location ensures easy access to both the town center and the beaches of Puerto Viejo.<br/>     The house offers complete privacy, with all described spaces, including the kitchen and bathroom, exclusively for your use. You'll have all the amenities needed to feel at home.<br/>     You'll find most shops and restaurants within a short walking distance. Additionally, a nearby jungle path along the ocean leads to natural coral pools and Cocles.<br/>     Have a special request? We are happy to accommodate if possible. Please don't hesitate to let us know.<br/>     We strongly recommend this option if you are planning to travel with your pet, as it offers a small, fenced garden.",
@@ -1507,7 +1507,7 @@ export const houseDataList: HouseDataType[] = [
         ],
     },
     {
-        name: "Tucano",
+        name: "Casa Tucano",
         guestNumber: 5,
         location: "AAA Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "This house offers a delightful experience in the heart of Puerto Viejo with a charming wooden apartment located above an Italian bakery. The apartment features two comfortable bedrooms, a well-equipped bathroom, a fully equipped kitchen, a lovely terrace, and two A/C units, ensuring a cozy stay.<br/>    These apartments provide private spaces, including the kitchen and bathroom, offering everything you need to feel at home. For stays of 5 nights or more, we provide complimentary cleaning services, and our team will coordinate a suitable time with you during your visit.<br/>    If you have any special requests, we're happy to accommodate them whenever possible, so don't hesitate to let us know. Should you need a pack-and-play crib for your stay, please inform us in advance, and we'll ensure it's set up in your room during the cleaning process.",
@@ -1546,7 +1546,7 @@ export const houseDataList: HouseDataType[] = [
     },
 
     {
-        name: "Pappagallo",
+        name: "Casa Pappagallo",
         guestNumber: 5,
         location: "AAA Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "Welcome to Kalawala, a charming complex of two apartments located in the heart of Puerto Viejo. Each apartment is built entirely of wood and is situated above a delightful Italian bakery. The apartments are equipped with everything you need for a comfortable stay, including a fully equipped kitchen, two cozy bedrooms, a lovely terrace, two A/C units, and one well equipped bathroom.<br/>    All of the spaces described here are private, including the fully equipped kitchen and bathroom. You'll have everything you need to make yourself at home.<br/>    We offer cleaning services for reservations of 5 nights or longer. Our team will contact you during your stay to coordinate a convenient time for the cleaning.<br/>    Do you have a special request? We would be more than happy to accommodate you if we can. Please don't hesitate to let us know.<br/>    If you require a pack - and - play crib during your stay, please inform us ahead of time. We'll make sure to set it up in your room during our cleaning process.",
@@ -1583,7 +1583,7 @@ export const houseDataList: HouseDataType[] = [
         ],
     },
     {
-        name: "Delfin",
+        name: "Casa Delfines",
         guestNumber: 6,
         location: "Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "Welcome to Reservas Kalawala. Located in the heart of town, this house accommodates up to 6 guests with fully equipped kitchen, bathroom, 2 A/C units (not in kitchen or living room), and private parking. Our prime location offers easy access to both the town center and the most beautiful beaches that Puerto Viejo has to offer.<br/>    All of the spaces described here are private, including the fully equipped kitchen and bathroom. You'll have everything you need to make yourself at home.<br/>    We offer flexible check-out with lockbox key drop-off for your convenience.<br/>    Do you have a special request? We would be more than happy to accommodate you if we can. Please don't hesitate to let us know.",
@@ -1616,7 +1616,7 @@ export const houseDataList: HouseDataType[] = [
         ],
     },
     {
-        name: "Delfín",
+        name: "Casa Delfines",
         guestNumber: 6,
         location: "AAA Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "Bienvenido a Reservas Kalawala. Ubicada en el corazón del pueblo, esta casa acomoda hasta 6 huéspedes con cocina totalmente equipada, baño, 2 unidades de aire acondicionado (no en cocina o sala de estar), y estacionamiento privado. Nuestra ubicación privilegiada ofrece fácil acceso tanto al centro del pueblo como a las playas más hermosas que Puerto Viejo tiene para ofrecer.<br/>    Todos los espacios descritos aquí son privados, incluyendo la cocina totalmente equipada y el baño. Tendrás todo lo que necesitas para sentirte como en casa.<br/>    Ofrecemos check-out flexible con entrega de llaves en caja de seguridad para tu conveniencia.<br/>    ¿Tienes alguna solicitud especial? Estaremos más que felices de complacerte si podemos. Por favor no dudes en hacérnoslo saber.",
@@ -1805,7 +1805,7 @@ export const VillasDataListES: HouseDataType[] = [
 
 export const NamDataList: HouseDataType[] = [
     {
-        name: "Areka",
+        name: "Casa Areka",
         guestNumber: 2,
         location: "Playa Chiquita, Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "",
@@ -1838,7 +1838,7 @@ export const NamDataList: HouseDataType[] = [
         ],
     },
     {
-        name: "Plumeria",
+        name: "Casa Plumeria",
         guestNumber: 2,
         location: "Playa Chiquita, Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "",
@@ -1871,7 +1871,7 @@ export const NamDataList: HouseDataType[] = [
         ],
     },
     {
-        name: "Giulia",
+        name: "Casa Giulia",
         guestNumber: 4,
         location: "Playa Chiquita, Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "",
@@ -1908,7 +1908,7 @@ export const NamDataList: HouseDataType[] = [
 
 export const NamDataListES: HouseDataType[] = [
     {
-        name: "Areka",
+        name: "Casa Areka",
         guestNumber: 2,
         location: "Playa Chiquita, Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "",
@@ -1941,7 +1941,7 @@ export const NamDataListES: HouseDataType[] = [
         ],
     },
     {
-        name: "Plumeria",
+        name: "Casa Plumeria",
         guestNumber: 2,
         location: "Playa Chiquita, Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "",
@@ -1974,7 +1974,7 @@ export const NamDataListES: HouseDataType[] = [
         ],
     },
     {
-        name: "Giulia",
+        name: "Casa Giulia",
         guestNumber: 4,
         location: "Playa Chiquita, Puerto Viejo de Talamanca, Limón, Costa Rica",
         description: "",
@@ -2026,7 +2026,7 @@ export const PROPERTY_DISPLAY_NAMES: Record<string, string> = {
     Areka: 'Casa Areka',
     Plumeria: 'Casa Plumeria',
     Giulia: 'Casa Giulia',
-    Delfin: 'Casa Delfin',
+    Delfin: 'Casa Delfines',
 };
 
 // Bedroom / bathroom counts and sleeping capacity, shown as a fact row at the
@@ -2354,7 +2354,7 @@ export const PUERTO_VIEJO_BLOG_RECOMMENDATIONS: PropertyRecommendation[] = [
     houseCode: 1
   },
   {
-    name: 'Plumeria',
+    name: 'Casa Plumeria',
     reason: 'Perfecta para descansar cerca de la playa',
     link: '/Plumeria',
     houseCode: 8
@@ -2376,7 +2376,7 @@ export const GENERAL_PUERTO_VIEJO_RECOMMENDATIONS: PropertyRecommendation[] = [
     houseCode: 1
   },
   {
-    name: 'Plumeria',
+    name: 'Casa Plumeria',
     reason: 'Ideal for beach relaxation',
     link: '/Plumeria',
     houseCode: 8
@@ -2392,7 +2392,7 @@ export const GENERAL_PUERTO_VIEJO_RECOMMENDATIONS: PropertyRecommendation[] = [
 // Cahuita-focused recommendations
 export const CAHUITA_AREA_RECOMMENDATIONS: PropertyRecommendation[] = [
   {
-    name: 'Plumeria',
+    name: 'Casa Plumeria',
     reason: 'Perfect Retreat for Couples',
     link: '/Plumeria',
     houseCode: 8
@@ -2420,7 +2420,7 @@ export const PUERTO_VIEJO_BLOG_RECOMMENDATIONS_ES: PropertyRecommendation[] = [
     houseCode: 1
   },
   {
-    name: 'Plumeria',
+    name: 'Casa Plumeria',
     reason: 'Perfecta para descansar cerca de la playa',
     link: '/PlumeriaES',
     houseCode: 8
@@ -2442,3 +2442,47 @@ export const MAX_PORTFOLIO_GUESTS: number = houseDataEngList.reduce(
   (max, house) => Math.max(max, house.guestNumber),
   1
 );
+
+/**
+ * Portfolio-wide bedroom/bathroom/guest ranges, derived from PROPERTY_CAPACITY
+ * so homepage copy can't drift from the per-listing facts the way the old
+ * hardcoded "4 remodeled homes... each house has 2 bedrooms" line did — that
+ * claim contradicted both the 9-10 differently-sized cards shown on the same
+ * page and PROPERTY_CAPACITY itself (bedrooms range from 1 to 2).
+ */
+const CAPACITY_VALUES = Object.values(PROPERTY_CAPACITY);
+export const PORTFOLIO_PROPERTY_COUNT: number = CAPACITY_VALUES.length;
+export const PORTFOLIO_BEDROOM_RANGE: { min: number; max: number } = CAPACITY_VALUES.reduce(
+  (range, { bedrooms }) => ({ min: Math.min(range.min, bedrooms), max: Math.max(range.max, bedrooms) }),
+  { min: Infinity, max: 0 }
+);
+export const PORTFOLIO_GUEST_RANGE: { min: number; max: number } = CAPACITY_VALUES.reduce(
+  (range, { maxGuests }) => ({ min: Math.min(range.min, maxGuests), max: Math.max(range.max, maxGuests) }),
+  { min: Infinity, max: 0 }
+);
+
+export interface BlogArticle {
+  key: string;
+  titleEn: string;
+  titleEs: string;
+  pathEn: string;
+  pathEs: string;
+}
+
+/**
+ * The ten travel guides, in one place, so the footer and the blog index don't
+ * drift apart. Titles here are short link labels, not the full SEO <title> —
+ * see src/pages/Blog/staticPages(_ES) for the per-article long-form title.
+ */
+export const BLOG_ARTICLES: BlogArticle[] = [
+  { key: 'twodays', titleEn: '2 Days in Puerto Viejo', titleEs: '2 días en Puerto Viejo', pathEn: '/twodaysinpuertoviejo', pathEs: '/twodaysinpuertoviejoES' },
+  { key: 'gandoca', titleEn: 'Getting to Gandoca-Manzanillo', titleEs: 'Cómo llegar a Gandoca-Manzanillo', pathEn: '/gettingtogandoca', pathEs: '/gettingtogandocaES' },
+  { key: 'sanjose', titleEn: 'From San José to Puerto Viejo', titleEs: 'De San José a Puerto Viejo', pathEn: '/travellingtopuertoviejo', pathEs: '/travellingtopuertoviejoES' },
+  { key: 'byplane', titleEn: 'Getting to Puerto Viejo by Plane', titleEs: 'Llegar a Puerto Viejo en avión', pathEn: '/puertoviejobyplane', pathEs: '/puertoviejobyplaneES' },
+  { key: 'tenhours', titleEn: 'Ten Hours to Explore Cahuita', titleEs: 'Diez horas para explorar Cahuita', pathEn: '/TenHoursInPuerto', pathEs: '/TenHoursInPuertoES' },
+  { key: 'bushours', titleEn: 'Bus Schedule & Routes', titleEs: 'Horarios de autobuses', pathEn: '/bushours', pathEs: '/bushoursES' },
+  { key: 'cahuitapark', titleEn: 'Visiting Cahuita National Park', titleEs: 'Visitar el Parque Nacional Cahuita', pathEn: '/cahuitaparkwhattodo', pathEs: '/cahuitaparkwhattodoES' },
+  { key: 'indigenous', titleEn: 'Indigenous Culture Nearby', titleEs: 'Cultura indígena cercana', pathEn: '/indigenousTravelPV', pathEs: '/indigenousTravelPVES' },
+  { key: 'besttime', titleEn: 'Best Time to Visit', titleEs: 'Mejor época para visitar', pathEn: '/bestTimeToVisitPuerto', pathEs: '/bestTimeToVisitPuertoES' },
+  { key: 'hiddengems', titleEn: 'Hidden Gems in Puerto Viejo', titleEs: 'Joyas escondidas', pathEn: '/puertoHiddenGems', pathEs: '/puertoHiddenGemsES' },
+];


### PR DESCRIPTION
## Summary

Fixes verified against an external UX/SEO/AI-search audit of reservaskalawala.com. Each item below was independently confirmed against the live site or a production build before being fixed — see individual commit messages for the specific evidence.

- **Property cards are real links** — homepage cards, "other homes" cards, and villa/nam variants now use `<a href>` instead of `<div onClick>`: keyboard-accessible, middle-click/new-tab work, crawlable.
- **Contact is tappable** — `tel:`, `wa.me`, `mailto:` links on the homepage contact block; persistent "Book now" header CTA + WhatsApp link in the mobile menu on all 6 header variants.
- **Fixed a real, contradictory homepage claim** — "4 remodeled homes, 2 bedrooms each" next to 9 differently-sized property cards; now derived from actual portfolio data.
- **Structured data fixes** — wrong "Playa Negra" copy on 3 properties actually in Playa Chiquita, a bedroom-count mismatch, plus `AggregateRating` and per-property `offers` that didn't exist before.
- **Standardized property naming** — "Casa X" everywhere instead of 4 different names per property depending on where you looked. Caught and fixed a regression this exposed: 10 listing pages were looking up house data by the display-name field being changed instead of `houseLangCode`.
- **Real `<footer>`** — every property, all 10 blog articles, contact links, booking CTA — on every homepage variant and all 20 listing pages.
- **Real HTTP 404s** — unknown URLs previously returned 200 with a soft-404; now return an actual 404 status with a branded page.
- **Mobile menu fix** — raised a height cap that was clipping the 6th nav item.
- **New `/blog` + `/blogES` index** — nav's Blog link no longer dead-ends on a single article.
- **Fixed a second, undeployed duplicate-tag bug** — `index.html` still had a hardcoded `<meta name="description">` that Helmet couldn't clean up (same root cause as an already-fixed canonical-tag bug), so every page was still shipping two competing descriptions.
- **Fixed the testimonial-carousel wheel bug** — confirmed live with a real scroll gesture (not synthetic dispatch): hovering the carousel and scrolling trapped the page, a native Chromium behavior for single-axis-scrollable elements. Fixed with a proper non-passive `wheel` listener (React's `onWheel` prop is passive by default and silently ignores `preventDefault()` — verified that a first attempt using it had no effect).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` (react-snap + full postbuild chain: 404 generation, route preloads, sitemap, llms.txt) — clean, run repeatedly through the branch and again after merging `main`
- [x] Verified in a real browser against a local production build: single meta description per page, real 404 status, footer/CTA present, cards are real anchors
- [ ] Manual check with a real mouse/trackpad once deployed: testimonial carousel no longer traps vertical scroll (could not get automated confirmation — the remote-browser tool's synthetic scroll doesn't fully respect `preventDefault()`, even with an unconditional test listener)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173QptMmu8qMrrL17sSA7dP