### PR TITLE
fix(hydration): stop MessageTipContainer causing React #418/#423 on every page

### DIFF
--- a/src/components/MessageTip/MessageTipContainer.component.tsx
+++ b/src/components/MessageTip/MessageTipContainer.component.tsx
@@ -18,7 +18,18 @@ const MessageTipContainer: React.FC<MessageTipContainerProps> = ({ className }) 
   const [messageTips, setMessageTips] = useState<MessageTipData[]>([]);
   const [isCookieBannerVisible, setIsCookieBannerVisible] = useState(false);
   const [stickyCTAHeight, setStickyCTAHeight] = useState(0);
-  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
+  // Seeded from window.innerWidth, this read react-snap's puppeteer viewport
+  // at prerender time and a real visitor's actual viewport at hydration time
+  // — two different numbers baked into the same first render, so the mobile
+  // bottom-offset style below came out different on the client than what was
+  // pre-rendered. React error #418 (hydration mismatch), the same failure
+  // mode WelcomeSlider.component.tsx already documents and fixes for the
+  // hero. null here means "not yet measured": isMobile stays false (matching
+  // whatever react-snap's own settled-DOM snapshot shows for a typical
+  // desktop-width prerender) until the resize-listener effect below runs and
+  // sets the visitor's real width post-hydration, when React is free to
+  // update without a mismatch.
+  const [windowWidth, setWindowWidth] = useState<number | null>(null);
   const location = useLocation();
 
   // Clear all message tips when route changes (language switching)
@@ -60,6 +71,8 @@ const MessageTipContainer: React.FC<MessageTipContainerProps> = ({ className }) 
 
     // Initial check
     checkElements();
+    // Real width, read only after mount — see the windowWidth state comment.
+    setWindowWidth(window.innerWidth);
 
     // Set up observer to watch for changes
     const observer = new MutationObserver(checkElements);
@@ -100,7 +113,7 @@ const MessageTipContainer: React.FC<MessageTipContainerProps> = ({ className }) 
 
   // Calculate dynamic bottom position
   const containerStyle: React.CSSProperties = {};
-  const isMobile = windowWidth <= 768;
+  const isMobile = windowWidth !== null && windowWidth <= 768;
   
   if (isMobile) {
     let bottomOffset = 20; // Base margin


### PR DESCRIPTION
## Summary

Found while verifying the previous PR's deploy: React errors #418/#423 fire on every page load in production, discarding the pre-rendered HTML and forcing a full client re-render (visible as a brief blank flash before repaint).

Root cause: `MessageTipContainer` seeded `windowWidth` from `window.innerWidth` read synchronously during render — react-snap's puppeteer viewport at prerender time and a real visitor's viewport at hydration time are different numbers, and this drives a mobile-only inline style, so the markup React hydrates against doesn't match what was baked into the static HTML. This is the exact pattern `WelcomeSlider.component.tsx` already documents and fixes for the hero.

Fixed the same way: seed `null` (matching the other two pieces of state in this component, which already default safely and update only after mount) and read the real width in the existing resize effect instead.

**This is a pre-existing bug**, not caused by the previous PR — `git blame` traces this file back to the project's earliest commits, and the previous PR only touched CSS + two 1-line `.tsx` attribute tweaks in unrelated files.

**Not a complete fix**: a local build with sourcemaps still showed the same #418/#423 with just this change applied, so at least one more contributing source remains. Production builds strip the component-level diff info (React only includes it in dev builds), so pinpointing the rest needs a proper local dev/DevTools session rather than more guessing against a minified stack trace.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [ ] Deploy and re-check console for reduced (not necessarily zero) hydration errors
- [ ] Follow-up: bisect the remaining source with React DevTools locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173QptMmu8qMrrL17sSA7dP