### PR TITLE
fix(nav): stop mobile header wrap, simplify menu, fix dropdown contrast

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,8 @@
       "Bash(aws lambda update-function-configuration *)",
       "Bash(aws lambda get-function-configuration *)",
       "Bash(cd C:\\\\Users\\\\User\\\\Documents\\\\ReactNativeApps\\\\Medical\\\\kalawala-web *)",
-      "WebFetch(domain:aws.amazon.com)"
+      "WebFetch(domain:aws.amazon.com)",
+      "Bash(netstat -ano)"
     ]
   }
 }

--- a/src/components/FixedNavigation/FixedNavigation.component.tsx
+++ b/src/components/FixedNavigation/FixedNavigation.component.tsx
@@ -92,14 +92,14 @@ const FixedNavigation = ({ isBlog }: IFixedNavigation) => {
         <Navbar.Collapse id="basic-navbar-nav">
           <Nav className="navMenu me-auto">
             <Nav.Link href="/#body" className={`navText${(isActive && !isBlog) ? ' active' : ''}`} onClick={closeMenu}>Home</Nav.Link>
-            <Nav.Link href="/book" className="navText" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("book") }}>Availability</Nav.Link>
-            <Nav.Link href="/#portfolio" className="navText" onClick={() => { handleLinkClick("#portfolio") }}>Photos</Nav.Link>
-            <Nav.Link href="/#contact-us" className="navText" onClick={() => { handleLinkClick("#contact-us") }}>Contact</Nav.Link>
             <Nav.Link href="/blog" className={`navText${(isActive && isBlog) ? ' active' : ''}`} onClick={closeMenu}>Blog</Nav.Link>
             <Nav.Link href="/portal" className="navText" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("portal") }}>My Booking</Nav.Link>
             <Nav.Link href="https://wa.me/50684632276" className="navText" target="_blank" rel="noopener noreferrer">WhatsApp</Nav.Link>
           </Nav>
         <div className="navbar-flag">
+            <a href="/book" className="nav-cta-btn" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("book") }}>
+              Book now
+            </a>
             <LanguageSwitcher />
         </div>
         </Navbar.Collapse>

--- a/src/components/FixedNavigation/FixedNavigation.componentES.tsx
+++ b/src/components/FixedNavigation/FixedNavigation.componentES.tsx
@@ -86,14 +86,14 @@ const FixedNavigationES = ({ isBlog }: IFixedNavigationES) => {
         <Navbar.Collapse id="basic-navbar-nav">
           <Nav className="navMenu me-auto">
             <Nav.Link href="HomeES#body" className={`navText${(isActive && !isBlog) ? ' active' : ''}`} onClick={closeMenu}>Inicio</Nav.Link>
-            <Nav.Link href="/bookES" className="navText" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("bookES") }}>Disponibilidad</Nav.Link>
-            <Nav.Link href="HomeES#portfolioES" className="navText" onClick={() => { handleLinkClick("HomeES#portfolio") }}>Fotos</Nav.Link>
-            <Nav.Link href="HomeES#contact-usES" className="navText" onClick={() => { handleLinkClick("HomeES#contact-us") }}>Contactanos</Nav.Link>
             <Nav.Link href="/blogES" className={`navText${(isActive && isBlog) ? ' active' : ''}`} onClick={closeMenu}>Blog</Nav.Link>
             <Nav.Link href="/portalES" className="navText" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("portalES") }}>Mi Reserva</Nav.Link>
             <Nav.Link href="https://wa.me/50684632276" className="navText" target="_blank" rel="noopener noreferrer">WhatsApp</Nav.Link>
           </Nav>
         <div className="navbar-flag">
+            <a href="/bookES" className="nav-cta-btn" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("bookES") }}>
+              Reservar
+            </a>
             <LanguageSwitcher/>
         </div>
         </Navbar.Collapse>

--- a/src/components/FixedNavigation/FixedNavigation.componentNam.tsx
+++ b/src/components/FixedNavigation/FixedNavigation.componentNam.tsx
@@ -65,13 +65,14 @@ const FixedNavigationNam = ({ isBlog }: IFixedNavigation) => {
         <Navbar.Collapse id="basic-navbar-nav">
           <Nav className="navMenu me-auto">
             <Nav.Link href="HomeNam#body" className={`navText${(isActive && !isBlog) ? ' active' : ''}`} onClick={closeMenu}>Home</Nav.Link>
-            <Nav.Link href="HomeNam#body" className="navText" onClick={() => { handleLinkClick("HomeNam#body") }}>Availability</Nav.Link>
-            <Nav.Link href="HomeNam#portfolio" className="navText" onClick={() => { handleLinkClick("HomeNam#portfolio") }}>Photos</Nav.Link>
-            <Nav.Link href="HomeNam#contact-us" className="navText" onClick={() => { handleLinkClick("HomeNam#contact-us") }}>Contact</Nav.Link>
             <Nav.Link href="/blog" className={`navText${(isActive && isBlog) ? ' active' : ''}`} onClick={closeMenu}>Blog</Nav.Link>
+            <Nav.Link href="/portal" className="navText" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("portal") }}>My Booking</Nav.Link>
             <Nav.Link href="https://wa.me/50684632276" className="navText" target="_blank" rel="noopener noreferrer">WhatsApp</Nav.Link>
           </Nav>
         <div className="navbar-flag">
+            <a href="HomeNam#body" className="nav-cta-btn" onClick={() => { handleLinkClick("HomeNam#body") }}>
+              Book now
+            </a>
             <LanguageSwitcher />
         </div>
         </Navbar.Collapse>

--- a/src/components/FixedNavigation/FixedNavigation.componentNamES.tsx
+++ b/src/components/FixedNavigation/FixedNavigation.componentNamES.tsx
@@ -71,13 +71,14 @@ const FixedNavigationNamES = ({ isBlog }: IFixedNavigation) => {
         <Navbar.Collapse id="basic-navbar-nav">
           <Nav className="navMenu me-auto">
           <Nav.Link href="HomeNamES#body" className={`navText${(isActive && !isBlog) ? ' active' : ''}`} onClick={closeMenu}>Inicio</Nav.Link>
-            <Nav.Link href="HomeNamES#body" className="navText" onClick={() => { handleLinkClick("HomeNamES#body") }}>Disponibilidad</Nav.Link>
-            <Nav.Link href="HomeNamES#portfolioES" className="navText" onClick={() => { handleLinkClick("HomeNamES#portfolioES") }}>Fotos</Nav.Link>
-            <Nav.Link href="HomeNamES#contact-usES" className="navText" onClick={() => { handleLinkClick("HomeNamES#contact-usES") }}>Contactanos</Nav.Link>
             <Nav.Link href="/blogES" className={`navText${(isActive && isBlog) ? ' active' : ''}`} onClick={closeMenu}>Blog</Nav.Link>
+            <Nav.Link href="/portalES" className="navText" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("portalES") }}>Mi Reserva</Nav.Link>
             <Nav.Link href="https://wa.me/50684632276" className="navText" target="_blank" rel="noopener noreferrer">WhatsApp</Nav.Link>
           </Nav>
         <div className="navbar-flag">
+            <a href="HomeNamES#body" className="nav-cta-btn" onClick={() => { handleLinkClick("HomeNamES#body") }}>
+              Reservar
+            </a>
             <LanguageSwitcher />
         </div>
         </Navbar.Collapse>

--- a/src/components/FixedNavigation/FixedNavigation.componentRIB.tsx
+++ b/src/components/FixedNavigation/FixedNavigation.componentRIB.tsx
@@ -65,13 +65,14 @@ const FixedNavigationRib = ({ isBlog }: IFixedNavigation) => {
         <Navbar.Collapse id="basic-navbar-nav">
           <Nav className="navMenu me-auto">
             <Nav.Link href="HomeVillas#body" className={`navText${(isActive && !isBlog) ? ' active' : ''}`} onClick={closeMenu}>Home</Nav.Link>
-            <Nav.Link href="HomeVillas#body" className="navText" onClick={() => { handleLinkClick("HomeVillas#callToAction") }}>Availability</Nav.Link>
-            <Nav.Link href="HomeVillas#portfolio" className="navText" onClick={() => { handleLinkClick("HomeVillas#portfolio") }}>Photos</Nav.Link>
-            <Nav.Link href="HomeVillas#contact-us" className="navText" onClick={() => { handleLinkClick("HomeVillas#contact-us") }}>Contact</Nav.Link>
             <Nav.Link href="/blog" className={`navText${(isActive && isBlog) ? ' active' : ''}`} onClick={closeMenu}>Blog</Nav.Link>
+            <Nav.Link href="/portal" className="navText" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("portal") }}>My Booking</Nav.Link>
             <Nav.Link href="https://wa.me/50684632276" className="navText" target="_blank" rel="noopener noreferrer">WhatsApp</Nav.Link>
           </Nav>
         <div className="navbar-flag">
+            <a href="HomeVillas#callToAction" className="nav-cta-btn" onClick={() => { handleLinkClick("HomeVillas#callToAction") }}>
+              Book now
+            </a>
             <LanguageSwitcher />
         </div>
         </Navbar.Collapse>

--- a/src/components/FixedNavigation/FixedNavigation.componentRIBES.tsx
+++ b/src/components/FixedNavigation/FixedNavigation.componentRIBES.tsx
@@ -65,13 +65,14 @@ const FixedNavigationRibES = ({ isBlog }: IFixedNavigationES) => {
         <Navbar.Collapse id="basic-navbar-nav">
           <Nav className="navMenu me-auto">
             <Nav.Link href="HomeVillasES#body" className={`navText${(isActive && !isBlog) ? ' active' : ''}`} onClick={closeMenu}>Inicio</Nav.Link>
-            <Nav.Link href="HomeVillasES#body" className="navText" onClick={() => { handleLinkClick("HomeVillasES#callToActionES") }}>Disponibilidad</Nav.Link>
-            <Nav.Link href="HomeVillasES#portfolioES" className="navText" onClick={() => { handleLinkClick("HomeVillasES#portfolioES") }}>Fotos</Nav.Link>
-            <Nav.Link href="HomeVillasES#contact-usES" className="navText" onClick={() => { handleLinkClick("HomeVillasES#contact-usES") }}>Contactanos</Nav.Link>
             <Nav.Link href="/blogES" className={`navText${(isActive && isBlog) ? ' active' : ''}`} onClick={closeMenu}>Blog</Nav.Link>
+            <Nav.Link href="/portalES" className="navText" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("portalES") }}>Mi Reserva</Nav.Link>
             <Nav.Link href="https://wa.me/50684632276" className="navText" target="_blank" rel="noopener noreferrer">WhatsApp</Nav.Link>
           </Nav>
         <div className="navbar-flag">
+            <a href="HomeVillasES#callToActionES" className="nav-cta-btn" onClick={() => { handleLinkClick("HomeVillasES#callToActionES") }}>
+              Reservar
+            </a>
             <LanguageSwitcher/>
         </div>
         </Navbar.Collapse>

--- a/src/components/FixedNavigation/FixedNavigation.style.scss
+++ b/src/components/FixedNavigation/FixedNavigation.style.scss
@@ -8,9 +8,11 @@
   margin-bottom: 0;
   padding: 10px;
   min-height: 80px;
-  /* Fixed height to prevent CLS */
-  height: 80px;
-  /* Lock height for consistency */
+  /* Floor height to prevent CLS on the common single-line layout — no fixed
+     height, so if the brand row and mobile-controls row (CTA, flag,
+     hamburger) ever wrap to two lines on a narrow viewport, the sticky
+     header grows to contain both instead of the second line overlapping
+     the page content underneath it. */
   position: sticky;
   top: 0;
   background-color: rgba(0, 0, 0, 0.2);
@@ -58,6 +60,10 @@
   transform: translateY(-50%);
   display: flex;
   align-items: center;
+  gap: 12px;
+  /* Spaces the desktop "Book now" pill from the language switcher — they
+     share this box so the CTA sits right next to the flag, same as it
+     does in .mobile-controls on mobile. */
 
   button {
     background: none;
@@ -82,11 +88,12 @@
   gap: 10px;
 }
 
-// Always visible, at every breakpoint — .mobile-controls itself isn't
-// hidden on desktop, only its language-flag and hamburger children are.
-// This is what "travels with the sticky nav" per the audit: the header
-// is the one element that follows the visitor down the whole page, and
-// before this it never asked for anything.
+// There are two "Book now" pills in the markup, never both visible at once:
+// one in .mobile-controls (next to .mobile-flag) for mobile, one in
+// .navbar-flag (next to the desktop LanguageSwitcher) for desktop. The
+// media query below hides the mobile-controls copy once .navbar-flag's
+// own copy takes over; .navbar-flag is already display:none on mobile so
+// its copy needs no matching rule the other way.
 .nav-cta-btn {
   display: inline-block;
   white-space: nowrap;
@@ -124,6 +131,14 @@
   }
 }
 
+@media (min-width: 992px) {
+  // Desktop shows the .navbar-flag copy of the CTA instead — see the
+  // .nav-cta-btn comment above.
+  .mobile-controls .nav-cta-btn {
+    display: none;
+  }
+}
+
 @media (max-width: 991.98px) {
   .navbar-flag {
     display: none;
@@ -133,6 +148,23 @@
   .mobile-flag {
     display: flex;
     /* Show mobile flag */
+  }
+
+  /* The CTA pill added a fourth element (logo, CTA, flag, hamburger) to a
+     row that used to fit two — tighten it back down so it stays on one
+     line on common phone widths instead of wrapping under the logo. */
+  .mobile-controls {
+    gap: 6px;
+  }
+
+  .nav-cta-btn {
+    padding: 6px 12px;
+    font-size: 13px;
+  }
+
+  .navbar-brand img.logo {
+    width: 120px;
+    height: auto;
   }
 
   /* Fix navbar positioning - use sticky but ensure proper z-index */
@@ -188,9 +220,16 @@
     /* Enable scrolling when content exceeds height */
   }
 
-  .navMenu {
+  // Needs the .navigation prefix to match the desktop rule's specificity
+  // (.navigation .navMenu .navText, 3 classes) — a bare .navMenu .navText
+  // here is weaker and silently loses the cascade to the desktop color
+  // (--kalawala-light-cream, i.e. white) regardless of this media query,
+  // which is what made the dropdown unreadable: white text on the white
+  // frosted-glass panel below.
+  .navigation .navMenu {
     .navText {
       color: var(--kalawala-text-gray);
+      text-shadow: none;
       font-weight: 500;
       padding: 8px 0;
       border-bottom: 1px solid rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Summary
- Mobile header wrapped to two lines and overlapped page content on common Android widths (<=360px) after a "Book now" CTA pill was added to the row; tightened sizing to hold one line on real devices, and gave the sticky header a floor height (instead of a fixed one) so any residual wrap grows the header instead of overlapping content.
- Simplified the nav dropdown to Home, Blog, My Booking, WhatsApp — "Book now" now lives outside the dropdown, next to the language flag on both mobile and desktop. Also added the missing "My Booking" link to the RIB/Villas EN header.
- Fixed a CSS specificity bug that silently prevented the mobile dropdown's dark-text override from ever applying — it was rendering white text on a white frosted-glass panel.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] Verified in a local dev server: measured DOM layout at real phone widths (contrast: wraps at <=360px before the fix, holds to ~340px after) and confirmed the "Book now" pill renders next to the flag on both the desktop and simulated-mobile layouts
- [x] Confirmed via live CSSOM inspection that the mobile dropdown's text-color rule now matches the desktop rule's specificity and wins the cascade
- [ ] Visual check on an actual phone after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173QptMmu8qMrrL17sSA7dP