### PR TITLE
fix(nav): make mobile menu glass match navbar so text stays legible

### DIFF
--- a/src/components/FixedNavigation/FixedNavigation.style.scss
+++ b/src/components/FixedNavigation/FixedNavigation.style.scss
@@ -160,18 +160,21 @@
     /* SVG will use its natural color */
   }
 
-  /* Fix mobile menu background and positioning */
+  /* Fix mobile menu background and positioning — same dark glass as the
+     navbar itself, so the panel reads as a continuation of it rather than
+     a mismatched light popover. */
   .navigation .navbar-collapse,
   .navigation .navbar-collapse.show,
   .navbar-collapse,
   .navbar-collapse.show {
-    background-color: rgba(255, 255, 255, 0.65) !important;
-    backdrop-filter: blur(20px) saturate(180%) !important;
-    -webkit-backdrop-filter: blur(20px) saturate(180%) !important;
+    background-color: rgba(0, 0, 0, 0.55) !important;
+    -webkit-backdrop-filter: blur(20px) saturate(200%) brightness(1.2) !important;
+    backdrop-filter: blur(20px) saturate(200%) brightness(1.2) !important;
+    border: 1px solid rgba(255, 255, 255, 0.15) !important;
     border-radius: 8px !important;
     padding: 20px 15px !important;
     /* Increased padding for better spacing */
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15) !important;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 8px 30px rgba(0, 0, 0, 0.3) !important;
     position: absolute !important;
     top: 100% !important;
     left: 10px !important;
@@ -190,22 +193,23 @@
 
   .navMenu {
     .navText {
-      color: var(--kalawala-text-gray);
-      font-weight: 500;
+      color: var(--kalawala-light-cream) !important;
+      text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+      font-weight: 600;
       padding: 8px 0;
-      border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.15);
 
       &:last-child {
         border-bottom: none;
       }
 
       &.active {
-        color: $primary-color;
-        font-weight: 600;
+        color: $kalawala-vivid-beige !important;
+        font-weight: 700;
       }
 
       &:hover {
-        color: $primary-color;
+        color: $kalawala-vivid-beige !important;
       }
     }
   }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -16,7 +16,7 @@ $icon-font: 'themefisher-font';
 $kalawala-darker-green:#0B3028;
 $kalawala-dark-green:#294F44;
 $kalawala-light-green:#8AA288;
-$kalawala-vivid-beige: #294F44;
+$kalawala-vivid-beige: #B5965F;
 $kalawala-opaque-beige: #FFFFFF;
 $kalawala-light-cream: #FFFFFF;
 $kalawala-text-gray: #171717;


### PR DESCRIPTION
## Summary
- Mobile hamburger dropdown was a near-opaque white panel with dark text that read poorly. Switched it to the same dark, blurred, brightened glass as the navbar itself, with white text — same visual language as the desktop nav.
- Fixed `$kalawala-vivid-beige`, which was mistakenly set to the dark-green hex (copy-paste of `$kalawala-dark-green`) instead of the intended beige (`#B5965F`). This made the active nav link (e.g. "Home") render nearly invisible against the dark glass bar, on desktop too.

## Test plan
- [x] Compiled the SCSS standalone to confirm no syntax errors
- [x] Verified visually with a headless Playwright screenshot of the open mobile menu (Pixel 5 viewport) — white nav text and gold active-link text are clearly legible against the glass panel
- [ ] Manual check on a real device recommended before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)