### PR TITLE
fix(hydration): stop reading window synchronously during render, site-wide

### DIFF
--- a/src/Router/__tests__/DelfinRouting.test.tsx
+++ b/src/Router/__tests__/DelfinRouting.test.tsx
@@ -16,11 +16,6 @@ jest.mock('../../utils/runPixelValidation', () => ({
   }),
 }));
 
-// Mock useMediaQuery hook
-jest.mock('@react-hook/media-query', () => ({
-  useMediaQuery: jest.fn(() => false),
-}));
-
 // Mock Meta Pixel to prevent actual tracking during tests
 beforeEach(() => {
   const mockFbq = jest.fn();

--- a/src/pages/Blog/Components/ListingAd/ListingAd.component.tsx
+++ b/src/pages/Blog/Components/ListingAd/ListingAd.component.tsx
@@ -11,21 +11,32 @@ interface IOtherListing {
 
 const ListingAd: FC<IOtherListing> = ({ listings }) => {
 
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth)
+    // Seeded null, not window.innerWidth — react-snap's puppeteer viewport at
+    // prerender time and a real visitor's viewport at hydration time are
+    // different numbers, and windowWidth below decides whether a <Slider>
+    // or a plain <div> renders, a structural (not just style) difference.
+    // Same fix as MessageTipContainer.component.tsx: null defaults every
+    // check below to the "desktop" branch, matching react-snap's
+    // desktop-sized prerender, until the resize effect sets the real width
+    // post-mount.
+    const [windowWidth, setWindowWidth] = useState<number | null>(null)
 
     const navigate = useNavigate()
 
     useEffect(() => {
         const handleResize = () => setWindowWidth(window.innerWidth);
+        handleResize(); // real width, read only after mount
         window.addEventListener("resize", handleResize);
         return () => window.removeEventListener("resize", handleResize);
     }, []);
+
+    const isMobile = windowWidth !== null && windowWidth <= 1199
 
     const sliderSettings = {
         dots: true,
         infinite: true,
         speed: 500,
-        slidesToShow:  windowWidth<881?1 : 4, // Adjust based on screen size
+        slidesToShow: windowWidth !== null && windowWidth < 881 ? 1 : 4, // Adjust based on screen size
         slidesToScroll: 1,
         adaptiveHeight: true, // Ensure the height of the slider adapts to its content
         nextArrow: <SampleNextArrow />,
@@ -37,7 +48,7 @@ const ListingAd: FC<IOtherListing> = ({ listings }) => {
                 <div className="header">We offer fully equipped homes:
                     <br />
                 </div>
-                {windowWidth <= 1199 ?
+                {isMobile ?
                     <Slider {...sliderSettings} className="subCont">
                         {listings.map(({ name, mainImage }) => (
                             <div key={name} className="houseContainer" ><div
@@ -55,7 +66,7 @@ const ListingAd: FC<IOtherListing> = ({ listings }) => {
                             </div></div>
                         ))}
                     </Slider> :
-                    <div className={`${windowWidth <= 1199 ? 'hstack' : 'vstack'} gap-5 subCont`}>
+                    <div className={`${isMobile ? 'hstack' : 'vstack'} gap-5 subCont`}>
                         {listings.map(({ name, mainImage }) => {
                             return (
                                 <div style={{ backgroundImage: `url(${mainImage})`, }} className="listing d-flex align-items-end" onClick={() => { navigate(`/${name}`) }}>

--- a/src/pages/Blog/Components/ListingAd/ListingAd.componentES.tsx
+++ b/src/pages/Blog/Components/ListingAd/ListingAd.componentES.tsx
@@ -11,22 +11,32 @@ interface IOtherListing {
 
 const ListingAdES: FC<IOtherListing> = ({ listings }) => {
 
-
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth)
+    // Seeded null, not window.innerWidth — react-snap's puppeteer viewport at
+    // prerender time and a real visitor's viewport at hydration time are
+    // different numbers, and windowWidth below decides whether a <Slider>
+    // or a plain <div> renders, a structural (not just style) difference.
+    // Same fix as MessageTipContainer.component.tsx: null defaults every
+    // check below to the "desktop" branch, matching react-snap's
+    // desktop-sized prerender, until the resize effect sets the real width
+    // post-mount.
+    const [windowWidth, setWindowWidth] = useState<number | null>(null)
 
     const navigate = useNavigate()
 
     useEffect(() => {
         const handleResize = () => setWindowWidth(window.innerWidth);
+        handleResize(); // real width, read only after mount
         window.addEventListener("resize", handleResize);
         return () => window.removeEventListener("resize", handleResize);
     }, []);
+
+    const isMobile = windowWidth !== null && windowWidth <= 1199
 
     const sliderSettings = {
         dots: true,
         infinite: true,
         speed: 500,
-        slidesToShow:  windowWidth<881?1 : 4, // Adjust based on screen size
+        slidesToShow: windowWidth !== null && windowWidth < 881 ? 1 : 4, // Adjust based on screen size
         slidesToScroll: 1,
         adaptiveHeight: true, // Ensure the height of the slider adapts to its content
         nextArrow: <SampleNextArrow />,
@@ -38,7 +48,7 @@ const ListingAdES: FC<IOtherListing> = ({ listings }) => {
                 <div className="header">Ofrecemos casas completamente equipadas:
                     <br />
                 </div>
-                {windowWidth <= 1199 ?
+                {isMobile ?
                     <Slider {...sliderSettings} className="subCont">
                         {listings.map(({ name, mainImage }) => {
                             const displayName = name.replace('ES', '');
@@ -59,7 +69,7 @@ const ListingAdES: FC<IOtherListing> = ({ listings }) => {
                             );
                         })}
                     </Slider> :
-                    <div className={`${windowWidth <= 1199 ? 'hstack' : 'vstack'} gap-5 subCont`}>
+                    <div className={`${isMobile ? 'hstack' : 'vstack'} gap-5 subCont`}>
                         {listings.map(({ name, mainImage }) => {
                             const displayName = name.replace('ES', '');
                             return (

--- a/src/pages/Blog/Components/OtherBlogs.Component.tsx
+++ b/src/pages/Blog/Components/OtherBlogs.Component.tsx
@@ -12,7 +12,15 @@ interface IOtherBlogs {
 }
 
 const OtherBlogs: FC<IOtherBlogs> = ({ currentBlog, blogs }) => {
-  const [windowWidth, setWindowWidth] = useState(window.innerWidth)
+  // Seeded null, not window.innerWidth — react-snap's puppeteer viewport at
+  // prerender time and a real visitor's viewport at hydration time are
+  // different numbers, and windowWidth below drives slidesToShow (which
+  // changes how many slide clones react-slick renders for its infinite
+  // loop). Same fix as MessageTipContainer.component.tsx: null falls back
+  // to the same value the "desktop" branch would produce, matching
+  // react-snap's desktop-sized prerender, until the resize effect sets the
+  // real width post-mount.
+  const [windowWidth, setWindowWidth] = useState<number | null>(null)
   const navigate = useNavigate()
 
   const handleResize = useCallback(() => {
@@ -20,6 +28,7 @@ const OtherBlogs: FC<IOtherBlogs> = ({ currentBlog, blogs }) => {
   }, [])
 
   useEffect(() => {
+    handleResize() // real width, read only after mount
     window.addEventListener("resize", handleResize)
     return () => window.removeEventListener("resize", handleResize)
   }, [handleResize])
@@ -33,7 +42,7 @@ const OtherBlogs: FC<IOtherBlogs> = ({ currentBlog, blogs }) => {
     dots: true,
     infinite: filteredBlogs.length > 4,
     speed: 500,
-    slidesToShow: windowWidth < 768 ? 1 : windowWidth < 1024 ? 2 : Math.min(4, filteredBlogs.length),
+    slidesToShow: windowWidth === null ? Math.min(4, filteredBlogs.length) : windowWidth < 768 ? 1 : windowWidth < 1024 ? 2 : Math.min(4, filteredBlogs.length),
     slidesToScroll: 1,
     adaptiveHeight: true,
     nextArrow: <SampleNextArrow />,

--- a/src/pages/Blog/Components/OtherBlogs.ComponentES.tsx
+++ b/src/pages/Blog/Components/OtherBlogs.ComponentES.tsx
@@ -12,7 +12,15 @@ interface IOtherBlogs {
 }
 
 const OtherBlogsES: FC<IOtherBlogs> = ({ currentBlog, blogs }) => {
-  const [windowWidth, setWindowWidth] = useState(window.innerWidth)
+  // Seeded null, not window.innerWidth — react-snap's puppeteer viewport at
+  // prerender time and a real visitor's viewport at hydration time are
+  // different numbers, and windowWidth below drives slidesToShow (which
+  // changes how many slide clones react-slick renders for its infinite
+  // loop). Same fix as MessageTipContainer.component.tsx: null falls back
+  // to the same value the "desktop" branch would produce, matching
+  // react-snap's desktop-sized prerender, until the resize effect sets the
+  // real width post-mount.
+  const [windowWidth, setWindowWidth] = useState<number | null>(null)
   const navigate = useNavigate()
 
   const handleResize = useCallback(() => {
@@ -20,6 +28,7 @@ const OtherBlogsES: FC<IOtherBlogs> = ({ currentBlog, blogs }) => {
   }, [])
 
   useEffect(() => {
+    handleResize() // real width, read only after mount
     window.addEventListener("resize", handleResize)
     return () => window.removeEventListener("resize", handleResize)
   }, [handleResize])
@@ -33,7 +42,7 @@ const OtherBlogsES: FC<IOtherBlogs> = ({ currentBlog, blogs }) => {
     dots: true,
     infinite: filteredBlogs.length > 4,
     speed: 500,
-    slidesToShow: windowWidth < 768 ? 1 : windowWidth < 1024 ? 2 : Math.min(4, filteredBlogs.length),
+    slidesToShow: windowWidth === null ? Math.min(4, filteredBlogs.length) : windowWidth < 768 ? 1 : windowWidth < 1024 ? 2 : Math.min(4, filteredBlogs.length),
     slidesToScroll: 1,
     adaptiveHeight: true,
     nextArrow: <SampleNextArrow />,

--- a/src/pages/Blog/staticPages/BestTimeToVisitPuerto.tsx
+++ b/src/pages/Blog/staticPages/BestTimeToVisitPuerto.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
@@ -16,12 +16,9 @@ const BestTimeToVisitPuerto = () => {
 
     const blogId = 'bestTimeToVisitPuerto'
     const blogData = blogs.find((blog) => blog.id === blogId);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
     return (
 

--- a/src/pages/Blog/staticPages/BusHours.tsx
+++ b/src/pages/Blog/staticPages/BusHours.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
@@ -13,11 +13,9 @@ import { GENERAL_PUERTO_VIEJO_RECOMMENDATIONS, PUERTO_VIEJO_BLOG_RECOMMENDATIONS
 
 
 const BusHours = () => {
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
     return (
 

--- a/src/pages/Blog/staticPages/CahuitaPark.tsx
+++ b/src/pages/Blog/staticPages/CahuitaPark.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
@@ -17,12 +17,9 @@ const CahuitaPark = () => {
 
     const blogId = 'cahuitaParkwhattodo'
     const blogData = blogs.find((blog) => blog.id === blogId);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
     return (
 

--- a/src/pages/Blog/staticPages/GettingToGandoca.tsx
+++ b/src/pages/Blog/staticPages/GettingToGandoca.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { cdnImage, cdnSrcSet } from '../../../utils/imageCdn';
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
@@ -18,11 +18,9 @@ const HERO_IMAGE =
   'https://lh3.googleusercontent.com/d/1example-gandoca-image=w1000';
 
 const GettingToGandoca = () => {
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
     return (
 

--- a/src/pages/Blog/staticPages/IndigenousTravel.tsx
+++ b/src/pages/Blog/staticPages/IndigenousTravel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
@@ -16,12 +16,9 @@ const IndigenousTravel = () => {
 
     const blogId = 'indigenousTravelPV'
     const blogData = blogs.find((blog) => blog.id === blogId);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
     return (
 

--- a/src/pages/Blog/staticPages/PuertoHiddenGems.tsx
+++ b/src/pages/Blog/staticPages/PuertoHiddenGems.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
 
@@ -14,12 +14,9 @@ import WhyStayWithUs from "../../../components/WhyStayWithUs/WhyStayWithUs.compo
 
 
 const PuertoHiddenGems = () => {
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
     return (
 

--- a/src/pages/Blog/staticPages/PuertoViejoByPlane.tsx
+++ b/src/pages/Blog/staticPages/PuertoViejoByPlane.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { cdnImage, cdnSrcSet } from '../../../utils/imageCdn';
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
@@ -18,11 +18,9 @@ const HERO_IMAGE =
   'https://lh3.googleusercontent.com/d/1example-plane-image=w1000';
 
 const PuertoViejoByPlane = () => {
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
 
     return (

--- a/src/pages/Blog/staticPages/TenHoursInPuerto.tsx
+++ b/src/pages/Blog/staticPages/TenHoursInPuerto.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { cdnImage, cdnSrcSet } from '../../../utils/imageCdn';
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
@@ -18,11 +18,9 @@ const HERO_IMAGE =
   'https://lh3.googleusercontent.com/d/1H81sxVh2z1VmcbZvVTlhdEINmQ0tQ5Es=w1000';
 
 const TenHoursInPuerto = () => {
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
     return (
 

--- a/src/pages/Blog/staticPages/TravellingToPuerto.tsx
+++ b/src/pages/Blog/staticPages/TravellingToPuerto.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { cdnImage, cdnSrcSet } from '../../../utils/imageCdn';
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
@@ -18,11 +18,9 @@ const HERO_IMAGE =
   'https://lh3.googleusercontent.com/d/1JxE6lYoK9C2maxtGP9rlUp2a47Ce5C9W=w1000';
 
 const TravellingToPuerto = () => {
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
     return (
 

--- a/src/pages/Blog/staticPages/TwoDaysInPV.tsx
+++ b/src/pages/Blog/staticPages/TwoDaysInPV.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { cdnImage, cdnSrcSet } from '../../../utils/imageCdn';
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
@@ -18,12 +18,9 @@ const HERO_IMAGE =
   'https://lh3.googleusercontent.com/d/13j6FfwVMxVg9lU4SuGST8ljrVkyW7rla=w1000';
 
 const TwoDaysInPV = () => {
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
     return (
 

--- a/src/pages/Blog/staticPages_ES/BestTimeToVisitPuertoES.tsx
+++ b/src/pages/Blog/staticPages_ES/BestTimeToVisitPuertoES.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
 
@@ -24,12 +24,9 @@ const BestTimeToVisitPuertoES = () => {
 
     const blogId = 'bestTimeToVisitPuertoES'
     const blogData = blogsES.find((blog) => blog.id === blogId);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
     return (
 

--- a/src/pages/Blog/staticPages_ES/BusHoursES.tsx
+++ b/src/pages/Blog/staticPages_ES/BusHoursES.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
 
@@ -22,12 +22,9 @@ const CahuitaParkES = () => {
 
     const blogId = 'cahuitaParkwhattodoES'
     const blogData = blogsES.find((blog) => blog.id === blogId);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
     return (
 

--- a/src/pages/Blog/staticPages_ES/CahuitaParkES.tsx
+++ b/src/pages/Blog/staticPages_ES/CahuitaParkES.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
 
@@ -22,12 +22,9 @@ const CahuitaParkwhattodoES = () => {
 
     const blogId = 'cahuitaParkwhattodoES'
     const blogData = blogsES.find((blog) => blog.id === blogId);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
     return (
 

--- a/src/pages/Blog/staticPages_ES/GettingToGandoca_ES.tsx
+++ b/src/pages/Blog/staticPages_ES/GettingToGandoca_ES.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
 
@@ -22,12 +22,9 @@ const TwoDaysInPV = () => {
     
     const blogId = 'gettingtogandocaES'
     const blogData = blogs.find((blog) => blog.id === blogId);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
     return (
 

--- a/src/pages/Blog/staticPages_ES/IndigenousTravelES.tsx
+++ b/src/pages/Blog/staticPages_ES/IndigenousTravelES.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
 
@@ -21,12 +21,9 @@ const IndigenousTravelES = () => {
     // const { blogId } = useParams();
     const blogId = 'indigenousTravelPVES'
     const blogData = blogsES.find((blog) => blog.id === blogId);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
     return (
         <div className={`listingContainer`}>

--- a/src/pages/Blog/staticPages_ES/PuertoHiddenGemsES.tsx
+++ b/src/pages/Blog/staticPages_ES/PuertoHiddenGemsES.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
 
@@ -23,12 +23,9 @@ const BestTimeToVisitPuertoES = () => {
 
     const blogId = 'puertoHiddenGemsES'
     const blogData = blogsES.find((blog) => blog.id === blogId);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
     return (
 

--- a/src/pages/Blog/staticPages_ES/PuertoViejoByPlane_ES.tsx
+++ b/src/pages/Blog/staticPages_ES/PuertoViejoByPlane_ES.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { cdnImage, cdnSrcSet } from '../../../utils/imageCdn';
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
@@ -24,12 +24,9 @@ const PuertoViejoByPlaneES = () => {
     // const { blogId } = useParams();
     const blogId = 'puertoviejobyplaneES'
     const blogData = blogsES.find((blog) => blog.id === blogId);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
 
     return (

--- a/src/pages/Blog/staticPages_ES/TenHoursInPuerto_ES.tsx
+++ b/src/pages/Blog/staticPages_ES/TenHoursInPuerto_ES.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { cdnImage, cdnSrcSet } from '../../../utils/imageCdn';
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
@@ -24,12 +24,9 @@ const TenHoursInPuertoES = () => {
     // const { blogId } = useParams();
     const blogId = 'TenHoursInPuertoES'
     const blogData = blogsES.find((blog) => blog.id === blogId);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
     return (
 

--- a/src/pages/Blog/staticPages_ES/TravellingToPuerto_ES.tsx
+++ b/src/pages/Blog/staticPages_ES/TravellingToPuerto_ES.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { cdnImage, cdnSrcSet } from '../../../utils/imageCdn';
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
@@ -23,12 +23,9 @@ const TravellingToPuertoES = () => {
     // const { blogId } = useParams();
     const blogId = 'travellingtopuertoES'
     const blogData = blogsES.find((blog) => blog.id === blogId);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
     return (
 

--- a/src/pages/Blog/staticPages_ES/TwoDaysInPV_ES.tsx
+++ b/src/pages/Blog/staticPages_ES/TwoDaysInPV_ES.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { cdnImage, cdnSrcSet } from '../../../utils/imageCdn';
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
@@ -25,12 +25,9 @@ const TwoDaysInPV = () => {
     // const { blogId } = useParams();
     const blogId = 'twodaysinpuertoviejoES'
     const blogData = blogsES.find((blog) => blog.id === blogId);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
     return (
 

--- a/src/pages/Listing/components/OtherListings/OtherListings.component.tsx
+++ b/src/pages/Listing/components/OtherListings/OtherListings.component.tsx
@@ -9,13 +9,21 @@ interface IOtherListing {
 }
 
 const OtherListings: FC<IOtherListing> = ({ currentListing, listings }) => {
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth)
+    // Seeded null, not window.innerWidth — react-snap's puppeteer viewport at
+    // prerender time and a real visitor's viewport at hydration time are
+    // different numbers, and isMobile below drives the layout class, so
+    // reading it synchronously here bakes a mismatch into every hydration.
+    // Same fix as MessageTipContainer.component.tsx: null means "not yet
+    // measured" (isMobile stays false, matching react-snap's desktop-sized
+    // prerender) until the resize effect sets the real width post-mount.
+    const [windowWidth, setWindowWidth] = useState<number | null>(null)
     const navigate = useNavigate()
     const gridRef = useRef<HTMLDivElement>(null)
     const otherListings = listings.filter(listing => listing.name !== currentListing)
 
     useEffect(() => {
         const handleResize = () => setWindowWidth(window.innerWidth)
+        handleResize() // real width, read only after mount
         window.addEventListener("resize", handleResize)
         return () => window.removeEventListener("resize", handleResize)
     }, [])
@@ -40,7 +48,7 @@ const OtherListings: FC<IOtherListing> = ({ currentListing, listings }) => {
         return () => grid.removeEventListener('wheel', onWheel)
     }, [])
 
-    const isMobile = windowWidth <= 1199
+    const isMobile = windowWidth !== null && windowWidth <= 1199
 
     const getLayoutClass = () => {
         if (otherListings.length === 0) return 'no-listings'

--- a/src/pages/Listing/components/OtherListings/OtherListings.componentES.tsx
+++ b/src/pages/Listing/components/OtherListings/OtherListings.componentES.tsx
@@ -9,7 +9,14 @@ interface IOtherListings {
 }
 
 const OtherListingsES: FC<IOtherListings> = ({ currentListing, listings }) => {
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth)
+    // Seeded null, not window.innerWidth — react-snap's puppeteer viewport at
+    // prerender time and a real visitor's viewport at hydration time are
+    // different numbers, and isMobile below drives the layout class, so
+    // reading it synchronously here bakes a mismatch into every hydration.
+    // Same fix as MessageTipContainer.component.tsx: null means "not yet
+    // measured" (isMobile stays false, matching react-snap's desktop-sized
+    // prerender) until the resize effect sets the real width post-mount.
+    const [windowWidth, setWindowWidth] = useState<number | null>(null)
     const navigate = useNavigate()
     const gridRef = useRef<HTMLDivElement>(null)
 
@@ -18,6 +25,7 @@ const OtherListingsES: FC<IOtherListings> = ({ currentListing, listings }) => {
     }, [])
 
     useEffect(() => {
+        handleResize() // real width, read only after mount
         window.addEventListener("resize", handleResize)
         return () => window.removeEventListener("resize", handleResize)
     }, [handleResize])
@@ -59,7 +67,7 @@ const OtherListingsES: FC<IOtherListings> = ({ currentListing, listings }) => {
     }, [navigate])
 
     const getLayoutClass = useMemo(() => {
-        const isMobile = windowWidth <= 1199
+        const isMobile = windowWidth !== null && windowWidth <= 1199
         const listingCount = otherListings.length
 
         if (listingCount === 0) return 'no-listings'

--- a/src/pages/Listing/staticPages/ListingAreka.page.tsx
+++ b/src/pages/Listing/staticPages/ListingAreka.page.tsx
@@ -12,7 +12,6 @@ import Amenities from "../components/Amenities/Amenities.component";
 import { AmenityType } from "../../../utils/types";
 import { NamDataList } from "../../../utils/constants";
 import { Helmet } from "react-helmet";
-import { useMediaQuery } from '@react-hook/media-query';
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import ListingMarketingSection from "../../../components/ListingMarketingSection/ListingMarketingSection.component";
 import SocialStatement from "../../../components/SocialStatement/SocialStatement.component";
@@ -23,7 +22,15 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 
 const ListingAreka = () => {
     const listing = "Areka"
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
     const [show, setShow] = useState(false);
 
@@ -31,14 +38,18 @@ const ListingAreka = () => {
     const handleShow = () => setShow(true);
 
     const houseData: HouseDataType | undefined = NamDataList.find((house) => house.houseLangCode === listing);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
     }, [])
 
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
+    }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');
     return (

--- a/src/pages/Listing/staticPages/ListingDelfin.page.tsx
+++ b/src/pages/Listing/staticPages/ListingDelfin.page.tsx
@@ -13,7 +13,6 @@ import { AmenityType } from "../../../utils/types";
 import { houseDataList } from "../../../utils/constants";
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import { Helmet } from "react-helmet";
-import { useMediaQuery } from '@react-hook/media-query';
 import ListingMarketingSection from "../../../components/ListingMarketingSection/ListingMarketingSection.component";
 import SocialStatement from "../../../components/SocialStatement/SocialStatement.component";
 import FeatureHighlights from "../../../components/FeatureHighlights/FeatureHighlights.component";
@@ -24,7 +23,15 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 const ListingDelfin = () => {
     //const { listing } = useParams()
     const listing = 'Delfin'
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
     const [show, setShow] = useState(false);
 
@@ -32,12 +39,17 @@ const ListingDelfin = () => {
     const handleShow = () => setShow(true);
 
     const houseData: HouseDataType | undefined = houseDataList.find((house) => house.houseLangCode === listing);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages/ListingGeco.page.tsx
+++ b/src/pages/Listing/staticPages/ListingGeco.page.tsx
@@ -13,7 +13,6 @@ import { AmenityType } from "../../../utils/types";
 import { houseDataList } from "../../../utils/constants";
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import { Helmet } from "react-helmet";
-import { useMediaQuery } from '@react-hook/media-query';
 
 import ListingMarketingSection from "../../../components/ListingMarketingSection/ListingMarketingSection.component";
 import SocialStatement from "../../../components/SocialStatement/SocialStatement.component";
@@ -24,7 +23,15 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 
 const ListingGeco = () => {
     const listing = 'Geco'
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
     const [show, setShow] = useState(false);
 
 
@@ -33,12 +40,17 @@ const ListingGeco = () => {
     const handleShow = () => setShow(true);
 
     const houseData: HouseDataType | undefined = houseDataList.find((house) => house.houseLangCode === listing);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages/ListingGiulia.page.tsx
+++ b/src/pages/Listing/staticPages/ListingGiulia.page.tsx
@@ -12,7 +12,6 @@ import Amenities from "../components/Amenities/Amenities.component";
 import { AmenityType } from "../../../utils/types";
 import { NamDataList } from "../../../utils/constants";
 import { Helmet } from "react-helmet";
-import { useMediaQuery } from '@react-hook/media-query';
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import ListingMarketingSection from "../../../components/ListingMarketingSection/ListingMarketingSection.component";
 import SocialStatement from "../../../components/SocialStatement/SocialStatement.component";
@@ -23,19 +22,32 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 
 const ListingGiulia = () => {
     const listing = "Giulia"
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
     const [show, setShow] = useState(false);
 
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
     const houseData: HouseDataType | undefined = NamDataList.find((house) => house.houseLangCode === listing);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages/ListingPappagallo.page.tsx
+++ b/src/pages/Listing/staticPages/ListingPappagallo.page.tsx
@@ -13,7 +13,6 @@ import { AmenityType } from "../../../utils/types";
 import { houseDataList } from "../../../utils/constants";
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import { Helmet } from "react-helmet";
-import { useMediaQuery } from '@react-hook/media-query';
 import ListingMarketingSection from "../../../components/ListingMarketingSection/ListingMarketingSection.component";
 import SocialStatement from "../../../components/SocialStatement/SocialStatement.component";
 import FeatureHighlights from "../../../components/FeatureHighlights/FeatureHighlights.component";
@@ -23,7 +22,15 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 
 const ListingPappagallo = () => {
     const listing = 'Pappagallo'
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
     const [show, setShow] = useState(false);
 
@@ -31,12 +38,17 @@ const ListingPappagallo = () => {
     const handleShow = () => setShow(true);
 
     const houseData: HouseDataType | undefined = houseDataList.find((house) => house.houseLangCode === listing);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages/ListingPlumeria.page.tsx
+++ b/src/pages/Listing/staticPages/ListingPlumeria.page.tsx
@@ -12,7 +12,6 @@ import Amenities from "../components/Amenities/Amenities.component";
 import { AmenityType } from "../../../utils/types";
 import { NamDataList } from "../../../utils/constants";
 import { Helmet } from "react-helmet";
-import { useMediaQuery } from '@react-hook/media-query';
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import ListingMarketingSection from "../../../components/ListingMarketingSection/ListingMarketingSection.component";
 import SocialStatement from "../../../components/SocialStatement/SocialStatement.component";
@@ -23,19 +22,32 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 
 const ListingPlumeria = () => {
     const listing = "Plumeria"
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
     const [show, setShow] = useState(false);
 
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
     const houseData: HouseDataType | undefined = NamDataList.find((house) => house.houseLangCode === listing);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages/ListingRana.page.tsx
+++ b/src/pages/Listing/staticPages/ListingRana.page.tsx
@@ -13,7 +13,6 @@ import { AmenityType } from "../../../utils/types";
 import { houseDataList } from "../../../utils/constants";
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import { Helmet } from "react-helmet";
-import { useMediaQuery } from '@react-hook/media-query';
 import ListingMarketingSection from "../../../components/ListingMarketingSection/ListingMarketingSection.component";
 import SocialStatement from "../../../components/SocialStatement/SocialStatement.component";
 import FeatureHighlights from "../../../components/FeatureHighlights/FeatureHighlights.component";
@@ -24,7 +23,15 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 const ListingRana = () => {
     //const { listing } = useParams()
     const listing = 'Rana'
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
     const [show, setShow] = useState(false);
 
@@ -32,12 +39,17 @@ const ListingRana = () => {
     const handleShow = () => setShow(true);
 
     const houseData: HouseDataType | undefined = houseDataList.find((house) => house.houseLangCode === listing);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages/ListingTucano.page.tsx
+++ b/src/pages/Listing/staticPages/ListingTucano.page.tsx
@@ -13,7 +13,6 @@ import { AmenityType } from "../../../utils/types";
 import { houseDataList } from "../../../utils/constants";
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import { Helmet } from "react-helmet";
-import { useMediaQuery } from '@react-hook/media-query';
 import ListingMarketingSection from "../../../components/ListingMarketingSection/ListingMarketingSection.component";
 import SocialStatement from "../../../components/SocialStatement/SocialStatement.component";
 import FeatureHighlights from "../../../components/FeatureHighlights/FeatureHighlights.component";
@@ -23,7 +22,15 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 
 const ListingTucano = () => {
     const listing = 'Tucano'
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
     const [show, setShow] = useState(false);
 
@@ -31,12 +38,17 @@ const ListingTucano = () => {
     const handleShow = () => setShow(true);
 
     const houseData: HouseDataType | undefined = houseDataList.find((house) => house.houseLangCode === listing);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages/ListingVillaCoral.page.tsx
+++ b/src/pages/Listing/staticPages/ListingVillaCoral.page.tsx
@@ -12,7 +12,6 @@ import Amenities from "../components/Amenities/Amenities.component";
 import { AmenityType } from "../../../utils/types";
 import { VillasDataList } from "../../../utils/constants";
 import { Helmet } from "react-helmet";
-import { useMediaQuery } from '@react-hook/media-query';
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import ListingMarketingSection from "../../../components/ListingMarketingSection/ListingMarketingSection.component";
 import SocialStatement from "../../../components/SocialStatement/SocialStatement.component";
@@ -23,7 +22,15 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 
 const ListingVillaCoral = () => {
     const listing = 'Villa Coral'
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
     const [show, setShow] = useState(false);
 
     const handleClose = () => setShow(false);
@@ -34,12 +41,17 @@ const ListingVillaCoral = () => {
     // NOT the houseLangCode, which has no space (matches the /VillaCoral
     // route, same as the propertyKey="VillaCoral" literals elsewhere here).
     const houseData: HouseDataType | undefined = VillasDataList.find((house) => house.houseLangCode === 'VillaCoral');
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages/ListingVillaMar.page.tsx
+++ b/src/pages/Listing/staticPages/ListingVillaMar.page.tsx
@@ -12,7 +12,6 @@ import Amenities from "../components/Amenities/Amenities.component";
 import { AmenityType } from "../../../utils/types";
 import { VillasDataList } from "../../../utils/constants";
 import { Helmet } from "react-helmet";
-import { useMediaQuery } from '@react-hook/media-query';
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import ListingMarketingSection from "../../../components/ListingMarketingSection/ListingMarketingSection.component";
 import SocialStatement from "../../../components/SocialStatement/SocialStatement.component";
@@ -23,7 +22,15 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 
 const ListingVillaMar = () => {
     const listing = 'Villa Mar'
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
     const [show, setShow] = useState(false);
 
     const handleClose = () => setShow(false);
@@ -34,12 +41,17 @@ const ListingVillaMar = () => {
     // NOT the houseLangCode, which has no space (matches the /VillaMar route,
     // same as the propertyKey="VillaMar" literals elsewhere in this file).
     const houseData: HouseDataType | undefined = VillasDataList.find((house) => house.houseLangCode === 'VillaMar');
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages/__tests__/ListingDelfin.test.tsx
+++ b/src/pages/Listing/staticPages/__tests__/ListingDelfin.test.tsx
@@ -11,11 +11,6 @@ import { BrowserRouter } from 'react-router-dom';
 import ListingDelfin from '../ListingDelfin.page';
 import { houseDataList } from '../../../../utils/constants';
 
-// Mock the media query hook
-jest.mock('@react-hook/media-query', () => ({
-  useMediaQuery: jest.fn(() => false), // Default to desktop view
-}));
-
 // Mock the booking search widget that replaced the Smoobu iframe
 jest.mock('../../../../components/BookingSearchWidget/BookingSearchWidget.component', () => {
   return function MockBookingSearchWidget({ isSpanish, defaultGuests, variant }: { isSpanish: boolean; defaultGuests?: number; variant?: string }) {

--- a/src/pages/Listing/staticPages_ES/ListingAreka.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingAreka.page_ES.tsx
@@ -11,7 +11,6 @@ import Amenities from "../components/Amenities/Amenities.component";
 import { AmenityType } from "../../../utils/types";
 import { NamDataListES } from "../../../utils/constants";
 import { Helmet } from "react-helmet";
-import { useMediaQuery } from '@react-hook/media-query';
 
 import OtherListingsES from "../components/OtherListings/OtherListings.componentES";
 import FixedNavigationES from "../../../components/FixedNavigation/FixedNavigation.componentES";
@@ -25,19 +24,32 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 
 const ListingArekaES = () => {
     const listing = "ArekaES"
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
     const [show, setShow] = useState(false);
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
     const houseData: HouseDataType | undefined = NamDataListES.find((house) => house.houseLangCode === "ArekaES");
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages_ES/ListingDelfin.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingDelfin.page_ES.tsx
@@ -9,7 +9,6 @@ import { homesSnippet } from "../../../utils/constants";
 import Amenities from "../components/Amenities/Amenities.component";
 import { AmenityType, HouseDataType } from "../../../utils/types";
 import { houseDataList } from "../../../utils/constants";
-import { useMediaQuery } from '@react-hook/media-query';
 import OtherListingsES from "../components/OtherListings/OtherListings.componentES";
 import FixedNavigationES from "../../../components/FixedNavigation/FixedNavigation.componentES";
 import { Helmet } from "react-helmet";
@@ -25,19 +24,32 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 const ListingDelfin = () => {
     //const { listing } = useParams()
     const listing = 'DelfinES'
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
     const [show, setShow] = useState(false);
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
     const houseData: HouseDataType | undefined = houseDataList.find((house) => house.houseLangCode === listing);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages_ES/ListingGeco.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingGeco.page_ES.tsx
@@ -11,7 +11,6 @@ import Amenities from "../components/Amenities/Amenities.component";
 import { AmenityType } from "../../../utils/types";
 import { houseDataList } from "../../../utils/constants";
 import { Helmet } from "react-helmet";
-import { useMediaQuery } from '@react-hook/media-query';
 import OtherListingsES from "../components/OtherListings/OtherListings.componentES";
 import FixedNavigationES from "../../../components/FixedNavigation/FixedNavigation.componentES";
 
@@ -24,19 +23,32 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 
 const ListingGecoES = () => {
     const listing = 'GecoES'
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
     const [show, setShow] = useState(false);
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
     const houseData: HouseDataType | undefined = houseDataList.find((house) => house.houseLangCode === listing);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages_ES/ListingGiulia.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingGiulia.page_ES.tsx
@@ -11,7 +11,6 @@ import Amenities from "../components/Amenities/Amenities.component";
 import { AmenityType } from "../../../utils/types";
 import { NamDataListES } from "../../../utils/constants";
 import { Helmet } from "react-helmet";
-import { useMediaQuery } from '@react-hook/media-query';
 
 import OtherListingsES from "../components/OtherListings/OtherListings.componentES";
 import FixedNavigationES from "../../../components/FixedNavigation/FixedNavigation.componentES";
@@ -25,19 +24,32 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 
 const ListingGiuliaES = () => {
     const listing = "GiuliaES"
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
     const [show, setShow] = useState(false);
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
     const houseData: HouseDataType | undefined = NamDataListES.find((house) => house.houseLangCode === "GiuliaES");
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages_ES/ListingPappagallo.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingPappagallo.page_ES.tsx
@@ -11,7 +11,6 @@ import Amenities from "../components/Amenities/Amenities.component";
 import { AmenityType } from "../../../utils/types";
 import { houseDataList } from "../../../utils/constants";
 import { Helmet } from "react-helmet";
-import { useMediaQuery } from '@react-hook/media-query';
 
 import OtherListingsES from "../components/OtherListings/OtherListings.componentES";
 import FixedNavigationES from "../../../components/FixedNavigation/FixedNavigation.componentES";
@@ -25,7 +24,15 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 
 const ListingPappagalloES = () => {
     const listing = 'PappagalloES'
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
 
     const [show, setShow] = useState(false);
@@ -33,12 +40,17 @@ const ListingPappagalloES = () => {
     const handleShow = () => setShow(true);
 
     const houseData: HouseDataType | undefined = houseDataList.find((house) => house.houseLangCode === listing);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages_ES/ListingPlumeria.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingPlumeria.page_ES.tsx
@@ -11,7 +11,6 @@ import Amenities from "../components/Amenities/Amenities.component";
 import { AmenityType } from "../../../utils/types";
 import { NamDataListES } from "../../../utils/constants";
 import { Helmet } from "react-helmet";
-import { useMediaQuery } from '@react-hook/media-query';
 
 import OtherListingsES from "../components/OtherListings/OtherListings.componentES";
 import FixedNavigationES from "../../../components/FixedNavigation/FixedNavigation.componentES";
@@ -25,19 +24,32 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 
 const ListingPlumeriaES = () => {
     const listing = "PlumeriaES"
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
     const [show, setShow] = useState(false);
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
     const houseData: HouseDataType | undefined = NamDataListES.find((house) => house.houseLangCode === "PlumeriaES");
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages_ES/ListingRana.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingRana.page_ES.tsx
@@ -9,7 +9,6 @@ import { homesSnippet } from "../../../utils/constants";
 import Amenities from "../components/Amenities/Amenities.component";
 import { AmenityType, HouseDataType } from "../../../utils/types";
 import { houseDataList } from "../../../utils/constants";
-import { useMediaQuery } from '@react-hook/media-query';
 
 import OtherListingsES from "../components/OtherListings/OtherListings.componentES";
 import FixedNavigationES from "../../../components/FixedNavigation/FixedNavigation.componentES";
@@ -25,19 +24,32 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 const ListingRana = () => {
     //const { listing } = useParams()
     const listing = 'RanaES'
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
     const [show, setShow] = useState(false);
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
     const houseData: HouseDataType | undefined = houseDataList.find((house) => house.houseLangCode === listing);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages_ES/ListingTucano.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingTucano.page_ES.tsx
@@ -11,7 +11,6 @@ import Amenities from "../components/Amenities/Amenities.component";
 import { AmenityType } from "../../../utils/types";
 import { houseDataList } from "../../../utils/constants";
 import { Helmet } from "react-helmet";
-import { useMediaQuery } from '@react-hook/media-query';
 
 import OtherListingsES from "../components/OtherListings/OtherListings.componentES";
 import FixedNavigationES from "../../../components/FixedNavigation/FixedNavigation.componentES";
@@ -25,19 +24,32 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 
 const ListingTucanoES = () => {
     const listing = 'TucanoES'
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
     const [show, setShow] = useState(false);
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
     const houseData: HouseDataType | undefined = houseDataList.find((house) => house.houseLangCode === listing);
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages_ES/ListingVillaCoral.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingVillaCoral.page_ES.tsx
@@ -11,7 +11,6 @@ import Amenities from "../components/Amenities/Amenities.component";
 import { AmenityType } from "../../../utils/types";
 import { VillasDataListES } from "../../../utils/constants";
 import { Helmet } from "react-helmet";
-import { useMediaQuery } from '@react-hook/media-query';
 
 import OtherListingsES from "../components/OtherListings/OtherListings.componentES";
 import FixedNavigationES from "../../../components/FixedNavigation/FixedNavigation.componentES";
@@ -25,19 +24,32 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 
 const ListingVillaCoralES = () => {
     const listing = 'Villa CoralES'
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
     const [show, setShow] = useState(false);
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
     const houseData: HouseDataType | undefined = VillasDataListES.find((house) => house.houseLangCode === "VillaCoralES");
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages_ES/ListingVillaMar.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingVillaMar.page_ES.tsx
@@ -11,7 +11,6 @@ import Amenities from "../components/Amenities/Amenities.component";
 import { AmenityType } from "../../../utils/types";
 import { VillasDataListES } from "../../../utils/constants";
 import { Helmet } from "react-helmet";
-import { useMediaQuery } from '@react-hook/media-query';
 import OtherListingsES from "../components/OtherListings/OtherListings.componentES";
 import FixedNavigationES from "../../../components/FixedNavigation/FixedNavigation.componentES";
 
@@ -25,19 +24,32 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 
 const ListingVillaMarES = () => {
     const listing = 'Villa MarES'
-    const isScreenSmall = useMediaQuery('(max-width: 992px)');
+    // Seeded null, not read from useMediaQuery/matchMedia synchronously —
+    // react-snap's puppeteer viewport at prerender time and a real visitor's
+    // viewport at hydration time are different numbers, and isScreenSmall
+    // drives whether the sticky mobile CTA div renders at all (a structural
+    // difference, not just style). Same fix as
+    // MessageTipContainer.component.tsx: null means "not yet measured" (no
+    // CTA div, matching react-snap's desktop-sized prerender) until the
+    // effect below sets the real match post-mount.
+    const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
     const [show, setShow] = useState(false);
 
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
     const houseData: HouseDataType | undefined = VillasDataListES.find((house) => house.houseLangCode === "VillaMarES");
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        window.addEventListener("resize", () => setWindowWidth(window.innerWidth));
+    }, [])
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 992px)');
+        setIsScreenSmall(mq.matches); // real match, read only after mount
+        const handleChange = () => setIsScreenSmall(mq.matches);
+        mq.addEventListener('change', handleChange);
+        return () => mq.removeEventListener('change', handleChange);
     }, [])
     //const description = houseData?.description.split('<br/>');
     //const neighborhood = houseData?.neighborhood.split('<br/>');

--- a/src/pages/Listing/staticPages_ES/__tests__/ListingDelfinES.test.tsx
+++ b/src/pages/Listing/staticPages_ES/__tests__/ListingDelfinES.test.tsx
@@ -11,11 +11,6 @@ import { BrowserRouter } from 'react-router-dom';
 import ListingDelfin from '../ListingDelfin.page_ES';
 import { houseDataList } from '../../../../utils/constants';
 
-// Mock the media query hook
-jest.mock('@react-hook/media-query', () => ({
-  useMediaQuery: jest.fn(() => false), // Default to desktop view
-}));
-
 // Mock the booking search widget that replaced the Smoobu iframe
 jest.mock('../../../../components/BookingSearchWidget/BookingSearchWidget.component', () => {
   return function MockBookingSearchWidget({ isSpanish, defaultGuests, variant }: { isSpanish: boolean; defaultGuests?: number; variant?: string }) {
@@ -203,17 +198,29 @@ describe('ListingDelfinES Component', () => {
   });
 
   test('should display Spanish booking button text', () => {
-    // Mock useMediaQuery to return true for small screen
-    const mockUseMediaQuery = require('@react-hook/media-query').useMediaQuery;
-    mockUseMediaQuery.mockReturnValue(true);
-    
+    // The component now checks window.matchMedia directly (post-mount, see
+    // ListingDelfin.page_ES.tsx) instead of the useMediaQuery hook, so force
+    // the small-screen query to match here to simulate a mobile visitor.
+    const matchMediaSpy = jest.spyOn(window, 'matchMedia').mockReturnValue({
+      matches: true,
+      media: '(max-width: 992px)',
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    } as unknown as MediaQueryList);
+
     render(
       <BrowserRouter>
         <ListingDelfin />
       </BrowserRouter>
     );
-    
+
     expect(screen.getByText('VER DISPONIBILIDAD')).toBeInTheDocument();
+
+    matchMediaSpy.mockRestore();
   });
 
   test('should handle image modal functionality with Spanish content', () => {


### PR DESCRIPTION
## Summary
PR #22 fixed one instance of the React #418/#423 hydration-mismatch bug (`MessageTipContainer`) but explicitly flagged it as incomplete: "a local build with sourcemaps still showed the same #418/#423 ... so at least one more contributing source remains." This PR is that remaining source — the same anti-pattern (reading `window.innerWidth`/`matchMedia` synchronously during the initial render, instead of after mount) was duplicated across ~40 more files covering nearly every Listing and Blog page. react-snap prerenders at a fixed desktop-sized viewport, so any real mobile visitor's first hydration render disagreed with the prerendered HTML.

- `OtherListings`, `ListingAd`, `OtherBlogs` (EN/ES) — `windowWidth` now seeds `null`, real value set post-mount. `ListingAd` was the worst offender: it swapped between a `<Slider>` and a plain `<div>` based on the mismatched value, a structural DOM difference on every blog page.
- All 20 Listing pages — replaced synchronous `useMediaQuery('(max-width: 992px)')` (which mounted/unmounted a whole sticky-CTA div) with local `matchMedia` state read only after mount. Also removed a second, fully dead `windowWidth` state duplicated in every file.
- All 20 Blog pages — removed that same dead `windowWidth` state.
- Updated the 3 test files referencing the removed `useMediaQuery` hook (2 had inert mocks removed; 1 had an active test rewritten to mock `window.matchMedia` instead, matching the new implementation).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [ ] Jest suite couldn't be run locally in this worktree (pre-existing path-separator bug unrelated to this change breaks Jest's glob matching here) — verified the 3 touched test files by manual review. CI doesn't run Jest currently anyway (only tsc + Playwright), so this isn't a regression risk either way.
- [ ] Deploy and confirm #418/#423 are gone from the production console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173QptMmu8qMrrL17sSA7dP