### PR TITLE
fix(booking-api): promote deposit-confirmed reservations off Smoobu's Blocked channel

### DIFF
--- a/booking-api/src/depositConfirm.test.ts
+++ b/booking-api/src/depositConfirm.test.ts
@@ -54,9 +54,58 @@ function createTestConfig(): BookingApiConfig {
     bookingSessions,
     holds: new InMemoryHoldRepository(),
     hold: { defaultTtlMinutes: 60, idempotencyTtlMinutes: 1440, staleIdempotencyLockSeconds: 120 },
+    deposit: { holdTtlHours: 48, confirmTokenTtlHours: 168, staffConfirmBaseUrl: "https://kalawala.test-api/prod" },
     abuseProtection: { enabled: false, captchaChallengesEnabled: false, maxTrackedBuckets: 100 },
     email: { fromAddress: "test@kalawala.com", region: "us-east-1", disabled: true },
     observability: { serviceName: "booking-api", environment: "test", logLevel: "silent", metricsEnabled: false },
+  };
+}
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+function jsonResp(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    ...init,
+    headers: { "content-type": "application/json", ...(init.headers as Record<string, string> | undefined) },
+  });
+}
+
+function makeSearchEvent(): LambdaHttpRequest {
+  return {
+    version: "2.0",
+    rawPath: "/api/search",
+    headers: { "content-type": "application/json", origin: "https://kalawala.test" },
+    body: JSON.stringify({ arrivalDate: "2099-06-10", departureDate: "2099-06-14", guests: 2, language: "en" }),
+    requestContext: { http: { method: "POST", path: "/api/search", sourceIp: "203.0.113.40" } },
+  };
+}
+
+function makeDepositHoldEvent(body: unknown): LambdaHttpRequest {
+  return {
+    version: "2.0",
+    rawPath: "/api/deposit-holds",
+    headers: {
+      "content-type": "application/json",
+      "idempotency-key": "idem-deposit-hold-promotion-001",
+      origin: "https://kalawala.test",
+    },
+    body: JSON.stringify(body),
+    requestContext: { http: { method: "POST", path: "/api/deposit-holds", sourceIp: "203.0.113.40" } },
+  };
+}
+
+function postDepositReviewSubmit(token: string): LambdaHttpRequest {
+  return {
+    version: "2.0",
+    rawPath: "/api/staff/deposit-review",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: `token=${encodeURIComponent(token)}`,
+    requestContext: { http: { method: "POST", path: "/api/staff/deposit-review", sourceIp: "203.0.113.40" } },
   };
 }
 
@@ -126,4 +175,80 @@ it("also resolves correctly with no stage/base-path prefix (e.g. a future custom
   const addressBarUrl = `https://api.kalawala.com/api/staff/deposit-review/${token}`;
   const resolved = new URL(action, addressBarUrl);
   expect(resolved.pathname).toBe("/api/staff/deposit-review");
+});
+
+// ─── Smoobu promotion on confirm ────────────────────────────────────────────
+//
+// A manual-deposit hold is created on Smoobu's "Blocked channel" (channelId 11)
+// so the dates come off sale on every OTA while the bank transfer clears. Once
+// staff confirm, it must be promoted to the "Homepage" channel (70) — the same
+// mechanism PayPal captures already use (smoobuPromotion.ts) — or the guest's
+// real reservation sits in Smoobu forever labeled as an anonymous block.
+
+it("promotes the Smoobu reservation to the Homepage channel on confirm, instead of leaving it Blocked", async () => {
+  let reservationCreateCount = 0;
+  const fetchFn = jest.fn(async (url: string | URL, init?: RequestInit) => {
+    const { hostname, pathname } = new URL(url.toString());
+    const method = init?.method ?? "GET";
+
+    if (hostname === "login.smoobu.com") {
+      if (pathname === "/booking/checkApartmentAvailability") {
+        return jsonResp({
+          availableApartments: [301061],
+          prices: { "301061": { price: 510, currency: "USD" } },
+          errorMessages: {},
+        });
+      }
+      if (pathname === "/api/reservations" && method === "POST") {
+        reservationCreateCount += 1;
+        // First call is the initial Blocked-channel hold; second is the promotion.
+        return jsonResp({ id: reservationCreateCount === 1 ? 555111 : 777222 });
+      }
+      if (pathname === "/api/reservations/555111" && method === "DELETE") {
+        return jsonResp({ success: true });
+      }
+    }
+
+    return jsonResp({ detail: "unexpected" }, { status: 500 });
+  });
+  global.fetch = fetchFn as typeof fetch;
+
+  const searchResp = await handler(makeSearchEvent());
+  expect(searchResp.statusCode).toBe(200);
+  const searchBody = JSON.parse(searchResp.body);
+
+  const holdResp = await handler(
+    makeDepositHoldEvent({
+      quoteId: searchBody.quoteId,
+      bookingSessionId: searchBody.bookingSessionId,
+      propertyId: searchBody.properties[0].propertyId,
+      guest: { firstName: "Ana", lastName: "Mora", email: "ana@example.com" },
+      portalPassword: "correct horse battery staple",
+      termsAccepted: true,
+    })
+  );
+  expect(holdResp.statusCode).toBe(200);
+  const { bookingSessionId, reservationPublicId } = JSON.parse(holdResp.body).booking;
+
+  const token = confirmToken(bookingSessionId, reservationPublicId);
+  const confirmResp = await handler(postDepositReviewSubmit(token));
+  expect(confirmResp.statusCode).toBe(200);
+  expect(confirmResp.body).toContain("is confirmed");
+
+  const deletedOldBlock = fetchFn.mock.calls.some(
+    ([u, i]) => new URL(u.toString()).pathname === "/api/reservations/555111" && (i as RequestInit | undefined)?.method === "DELETE"
+  );
+  expect(deletedOldBlock).toBe(true);
+
+  const promotedToHomepage = fetchFn.mock.calls.some(([u, i]) => {
+    if (new URL(u.toString()).pathname !== "/api/reservations" || (i as RequestInit | undefined)?.method !== "POST") {
+      return false;
+    }
+    const body = JSON.parse((i as RequestInit).body as string);
+    return body.channelId === 70;
+  });
+  expect(promotedToHomepage).toBe(true);
+
+  const hold = await bookingSessions.getById(bookingSessionId);
+  expect(hold?.status).toBe("booking_confirmed");
 });

--- a/booking-api/src/depositConfirm.ts
+++ b/booking-api/src/depositConfirm.ts
@@ -23,6 +23,7 @@ import { htmlResponse } from "./http/response";
 import { presignReceiptDownload } from "./depositReceipt";
 import { BOOKING_PROPERTIES_BY_ID } from "./propertyCatalog";
 import { createSmoobuClient, SmoobuProviderError } from "./smoobuClient";
+import { promoteSmoobuReservation } from "./smoobuPromotion";
 import { verifySignedToken, type SignedTokenPayload } from "./signedTokens";
 import { ApiResponse, BookingApiConfig, RouteRequest } from "./types";
 
@@ -191,43 +192,28 @@ export async function handleStaffDepositReviewSubmit(
     tokenJti: payload.jti,
   });
 
-  // The hold must leave the expiry worker's reach. listExpiredHolds sweeps
-  // creating|active holds past expires_at, so a confirmed booking left `active`
-  // would have its Smoobu reservation cancelled when the TTL elapsed.
+  // Promote the Smoobu reservation from Blocked channel to Homepage (website) —
+  // the same mechanism PayPal captures use, see smoobuPromotion.ts. This also
+  // moves the hold to `converted`, taking it out of the expiry worker's reach:
+  // listExpiredHolds sweeps creating|active holds past expires_at, so a confirmed
+  // booking left `active` would have its Smoobu reservation cancelled at the TTL.
   if (hold) {
-    try {
-      await holds.convertHold({
-        holdId: hold.id,
-        newSmoobuReservationId: hold.smoobuReservationId ?? 0,
-        newSmoobuChannelId: hold.smoobuChannelId,
-      });
-    } catch (error) {
-      request.observability.logger.error("deposit_confirm_hold_convert_failed", {
+    await promoteSmoobuReservation(
+      {
+        session: confirmedSession,
+        hold,
+        notice: `Kalawala manual deposit CONFIRMED by staff on ${confirmedAt}. Reservation ${session.reservationPublicId}.`,
+        amountCents: confirmedSession.totalAmountCents ?? 0,
+      },
+      holds,
+      config,
+      request.observability
+    ).catch((err) => {
+      request.observability.logger.warn("deposit_confirm_smoobu_promotion_unexpected_error", {
         bookingSessionId: session.id,
-        error: error instanceof Error ? error.message : String(error),
+        error: err instanceof Error ? err.message : String(err),
       });
-    }
-  }
-
-  // Mark the Smoobu reservation as paid so the dashboard reflects reality.
-  if (hold?.smoobuReservationId) {
-    try {
-      const smoobuClient = await createSmoobuClient(config);
-      await smoobuClient.updateReservation(
-        hold.smoobuReservationId,
-        {
-          notice: `Kalawala manual deposit CONFIRMED by staff on ${confirmedAt}. Reservation ${session.reservationPublicId}.`,
-          priceStatus: 1,
-          prepaymentStatus: 1,
-        },
-        request.observability
-      );
-    } catch (error) {
-      request.observability.logger.warn("deposit_confirm_smoobu_update_failed", {
-        bookingSessionId: session.id,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
+    });
   }
 
   request.observability.recordStateTransition({

--- a/booking-api/src/paypalOrders.ts
+++ b/booking-api/src/paypalOrders.ts
@@ -305,9 +305,8 @@ export async function handleCapturePayPalOrder(
       {
         session,
         hold,
-        captureId: captureResult.captureId,
+        notice: buildPaypalConfirmedNotice(session, captureResult.captureId, capturedAt),
         amountCents: captureResult.amountCents,
-        confirmedAt: capturedAt,
       },
       holds,
       config,
@@ -329,6 +328,15 @@ export async function handleCapturePayPalOrder(
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+export function buildPaypalConfirmedNotice(session: BookingSessionRecord, captureId: string, confirmedAt: string): string {
+  return [
+    `Confirmed — PayPal payment received.`,
+    `Reservation ID: ${session.reservationPublicId}`,
+    `PayPal capture: ${captureId}`,
+    `Confirmed at: ${confirmedAt}`,
+  ].join("\n");
+}
 
 function getRequiredBookingSessionRepository(config: BookingApiConfig): BookingSessionRepository {
   if (!config.bookingSessions) {

--- a/booking-api/src/paypalWebhooks.ts
+++ b/booking-api/src/paypalWebhooks.ts
@@ -9,6 +9,7 @@ import { jsonResponse } from "./http/response";
 import { PaymentRepository } from "./payments";
 import { BOOKING_PROPERTIES_BY_ID } from "./propertyCatalog";
 import { createPayPalClient, PayPalVerifySignatureInput } from "./paypalClient";
+import { buildPaypalConfirmedNotice } from "./paypalOrders";
 import { promoteSmoobuReservation } from "./smoobuPromotion";
 import { ApiResponse, BookingApiConfig, RouteRequest } from "./types";
 
@@ -595,9 +596,8 @@ async function handleCaptureCompleted(
           {
             session,
             hold,
-            captureId,
+            notice: buildPaypalConfirmedNotice(session, captureId, confirmedAt),
             amountCents: captureAmount,
-            confirmedAt,
           },
           holds,
           config,

--- a/booking-api/src/smoobuPromotion.ts
+++ b/booking-api/src/smoobuPromotion.ts
@@ -1,7 +1,9 @@
 /**
  * Smoobu reservation promotion — converts a "Blocked channel" (channelId 11)
- * hold into a "Homepage" / website reservation (channelId 70) after PayPal
- * payment is captured.
+ * hold into a "Homepage" / website reservation (channelId 70) once a booking
+ * is confirmed, whether by PayPal capture (paypalOrders.ts) or by staff
+ * confirming a manual deposit (depositConfirm.ts). Both callers build their
+ * own `notice` text, since the wording differs by payment method.
  *
  * The Smoobu PUT /api/reservations endpoint does NOT support changing channelId,
  * so promotion requires deleting the old blocked reservation and creating a new
@@ -28,9 +30,9 @@ interface SmoobuCreateReservationResponse {
 export interface PromoteSmoobuReservationInput {
   session: BookingSessionRecord;
   hold: HoldRecord;
-  captureId: string;
+  /** Caller-built, since the wording differs by payment method (PayPal capture vs. staff-confirmed deposit). */
+  notice: string;
   amountCents: number;
-  confirmedAt: string;
 }
 
 export interface PromoteSmoobuReservationResult {
@@ -57,7 +59,7 @@ export async function promoteSmoobuReservation(
   config: BookingApiConfig,
   observability: RouteObservability
 ): Promise<PromoteSmoobuReservationResult> {
-  const { session, hold, captureId, amountCents, confirmedAt } = input;
+  const { session, hold, notice, amountCents } = input;
   const logger = observability.logger;
 
   if (!hold.smoobuReservationId) {
@@ -90,9 +92,7 @@ export async function promoteSmoobuReservation(
 
   // If the hold is already on the website channel, just update payment fields.
   if (hold.smoobuChannelId === WEBSITE_CHANNEL_ID) {
-    return updateExistingWebsiteBooking(
-      smoobuClient, hold, session, captureId, amountCents, confirmedAt, observability, logger
-    );
+    return updateExistingWebsiteBooking(smoobuClient, hold, session, notice, amountCents, observability, logger);
   }
 
   // Step 1: Delete the old blocked reservation
@@ -109,15 +109,13 @@ export async function promoteSmoobuReservation(
       error: err instanceof Error ? err.message : String(err),
     });
     // Fall back to just updating the existing reservation's payment fields
-    return fallbackUpdateReservation(
-      smoobuClient, hold, session, captureId, amountCents, confirmedAt, observability, logger
-    );
+    return fallbackUpdateReservation(smoobuClient, hold, session, notice, amountCents, observability, logger);
   }
 
   // Step 2: Create a new reservation on the Homepage (website) channel
   let newReservationId: number;
   try {
-    const payload = buildConfirmedReservationPayload(session, property, captureId, amountCents, confirmedAt);
+    const payload = buildConfirmedReservationPayload(session, property, notice, amountCents);
     const response = await smoobuClient.createReservation<SmoobuCreateReservationResponse>(payload, observability);
     newReservationId = parseSmoobuReservationId(response.data);
 
@@ -186,9 +184,8 @@ async function updateExistingWebsiteBooking(
   smoobuClient: SmoobuClient,
   hold: HoldRecord,
   session: BookingSessionRecord,
-  captureId: string,
+  notice: string,
   amountCents: number,
-  confirmedAt: string,
   observability: RouteObservability,
   logger: ObservabilityLogger
 ): Promise<PromoteSmoobuReservationResult> {
@@ -196,7 +193,7 @@ async function updateExistingWebsiteBooking(
     await smoobuClient.updateReservation(
       hold.smoobuReservationId!,
       {
-        notice: buildConfirmedNotice(session, captureId, confirmedAt),
+        notice,
         prepayment: amountCents / 100,
         prepaymentStatus: 1,
         priceStatus: 1,
@@ -226,9 +223,8 @@ async function fallbackUpdateReservation(
   smoobuClient: SmoobuClient,
   hold: HoldRecord,
   session: BookingSessionRecord,
-  captureId: string,
+  notice: string,
   amountCents: number,
-  confirmedAt: string,
   observability: RouteObservability,
   logger: ObservabilityLogger
 ): Promise<PromoteSmoobuReservationResult> {
@@ -236,7 +232,7 @@ async function fallbackUpdateReservation(
     await smoobuClient.updateReservation(
       hold.smoobuReservationId!,
       {
-        notice: buildConfirmedNotice(session, captureId, confirmedAt),
+        notice,
         prepayment: amountCents / 100,
         prepaymentStatus: 1,
         priceStatus: 1,
@@ -262,9 +258,8 @@ async function fallbackUpdateReservation(
 function buildConfirmedReservationPayload(
   session: BookingSessionRecord,
   property: BookingProperty,
-  captureId: string,
-  amountCents: number,
-  confirmedAt: string
+  notice: string,
+  amountCents: number
 ) {
   const guest = session.guest;
   return {
@@ -277,7 +272,7 @@ function buildConfirmedReservationPayload(
     email: guest?.email ?? "",
     ...(guest?.phone ? { phone: guest.phone } : {}),
     ...(guest?.country ? { country: guest.country } : {}),
-    notice: buildConfirmedNotice(session, captureId, confirmedAt),
+    notice,
     adults: session.guests,
     children: 0,
     price: amountCents / 100,
@@ -288,19 +283,6 @@ function buildConfirmedReservationPayload(
     depositStatus: 0,
     language: session.language,
   };
-}
-
-function buildConfirmedNotice(
-  session: BookingSessionRecord,
-  captureId: string,
-  confirmedAt: string
-): string {
-  return [
-    `Confirmed — PayPal payment received.`,
-    `Reservation ID: ${session.reservationPublicId}`,
-    `PayPal capture: ${captureId}`,
-    `Confirmed at: ${confirmedAt}`,
-  ].join("\n");
 }
 
 function parseSmoobuReservationId(data: SmoobuCreateReservationResponse): number {


### PR DESCRIPTION
## Summary
- Staff confirming a manual-deposit booking only updated payment fields on the existing Smoobu reservation — it never left the **Blocked channel (11)**, since Smoobu's `PUT /api/reservations` can't change `channelId`. Result: confirmed bookings still showed as an anonymous block in Smoobu, not a real guest reservation.
- PayPal captures already solve this correctly via `smoobuPromotion.ts` (delete the blocked reservation, create a new one on the **Homepage channel (70)**). `depositConfirm.ts` never called it.
- Generalized `promoteSmoobuReservation` to accept a caller-built `notice` + `amountCents` (was PayPal-specific `captureId`/`confirmedAt` wording), so the PayPal capture flow, the PayPal webhook flow, and the staff deposit-confirm flow all share one promotion implementation instead of depositConfirm.ts reimplementing it ad hoc.

## Test plan
- [x] Added a regression test driving a real deposit-hold → staff-confirm flow against a mocked Smoobu API; asserts the old blocked reservation is deleted and a new one is created with `channelId: 70`. Confirmed it fails against the prior code (reservation stays Blocked) and passes with the fix.
- [x] `npx tsc --noEmit` clean
- [x] All existing tests across `depositConfirm`, `paypalOrders`, `paypalWebhooks`, `smoobuClient`, `smoobuWebhooks` still pass (79/79)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tH9v87W9CV6TwfnHMYzAe