### PR TITLE
Refine homepage CTA, card icons, and rate copy

### DIFF
--- a/src/components/BookingCtaBanner/BookingCtaBanner.component.tsx
+++ b/src/components/BookingCtaBanner/BookingCtaBanner.component.tsx
@@ -29,11 +29,6 @@ const BookingCtaBanner: React.FC<IBookingCtaBanner> = ({ isSpanish }) => {
   return (
     <section className="booking-cta-banner">
       <div className="container">
-        <p className="booking-cta-banner__text">
-          {isSpanish
-            ? '4.9/5 · reserva directo, sin comisiones de plataforma'
-            : '4.9/5 · book direct, no platform fees'}
-        </p>
         <a href={bookPath} className="booking-cta-banner__btn" onClick={handleClick}>
           {isSpanish ? 'Ver disponibilidad' : 'Check availability'}
         </a>

--- a/src/components/BookingCtaBanner/BookingCtaBanner.style.scss
+++ b/src/components/BookingCtaBanner/BookingCtaBanner.style.scss
@@ -1,7 +1,7 @@
 @import '../../styles/_variables.scss';
 
 .booking-cta-banner {
-  background: $kalawala-darker-green;
+  // No band — just breathing room around a standalone button.
   padding: 28px 0;
 
   .container {
@@ -13,26 +13,20 @@
     text-align: center;
   }
 
-  &__text {
-    color: #fff;
-    font-size: 16px;
-    font-weight: 600;
-    margin: 0;
-  }
-
   &__btn {
     display: inline-block;
-    background: $kalawala-light-green;
-    color: $kalawala-darker-green;
+    background: $kalawala-darker-green;
+    color: #fff;
     font-weight: 700;
-    padding: 12px 28px;
-    border-radius: 6px;
+    font-size: 20px;
+    padding: 18px 48px;
+    border-radius: 8px;
     text-decoration: none;
     white-space: nowrap;
 
     &:hover,
     &:focus-visible {
-      background: #fff;
+      background: $kalawala-light-green;
       color: $kalawala-darker-green;
       text-decoration: none;
     }

--- a/src/components/CallToAction/CallToAction.component.tsx
+++ b/src/components/CallToAction/CallToAction.component.tsx
@@ -31,7 +31,7 @@ const CallToAction = () => {
           <div className="row">
             <div className="col-md-12 text-center" >
               <p style={{ fontWeight: 400, fontSize: 28 }}>Explore Availability and Prices Across All Our Properties in Puerto Viejo and Playa Chiquita.</p>
-              <p>Use the code <b>#norefundallowed</b> to enjoy a 10% discount on non-refundable reservations.</p>
+              <p>Select the <b>non-refundable rate</b> in the booking tool to enjoy a 10% discount.</p>
               <div 
             className='Smoobo' 
             style={{ 

--- a/src/components/CallToAction/CallToAction.componentES.tsx
+++ b/src/components/CallToAction/CallToAction.componentES.tsx
@@ -31,7 +31,7 @@ const CallToActionES = () => {
           <div className="row">
             <div className="col-md-12 text-center" >
               <p style={{ fontWeight: 400, fontSize: 28 }}>Explora la disponibilidad y los precios de todas nuestras propiedades en Puerto Viejo y Playa Chiquita.</p>
-              <p>Usa el código <b>#norefundallowed</b> para disfrutar de un 10% de descuento en reservas no reembolsables.</p>
+              <p>Elige la <b>tarifa no reembolsable</b> en el motor de reservas para disfrutar de un 10% de descuento.</p>
 
               <div
                 className='Smoobo'

--- a/src/components/Discover/Discover.component.tsx
+++ b/src/components/Discover/Discover.component.tsx
@@ -24,9 +24,10 @@ const Discover = () => {
             <div className="content-block">
               <h2>Discover Puerto Viejo from the comfort of our homes.</h2>
               <p>Reservas Kalawala offers {PORTFOLIO_PROPERTY_COUNT} remodeled homes and villas, <b>each with a fully equipped private kitchen and bathroom</b>. Houses sleep {PORTFOLIO_GUEST_RANGE.min} to {PORTFOLIO_GUEST_RANGE.max} guests, with {PORTFOLIO_BEDROOM_RANGE.min} to {PORTFOLIO_BEDROOM_RANGE.max} bedrooms and <b>air conditioning throughout</b>.</p>
-              <p>Located in the center of Puerto Viejo, all the bars and restaurants are within <b>walking distance</b>. Cocles beach can be reached by car in 2 minutes, and there are closeby bike and motorbike rentals so that also Punta Uva, Cahuita and Manzanillo are within reach, even without a car!</p>
+              <p>Our homes in the center of Puerto Viejo put you right in the heart of town, with <b>bars, restaurants and shops within walking distance</b>. Cocles beach is a 2-minute drive, and nearby bike and motorbike rentals bring Punta Uva, Cahuita and Manzanillo within reach, even without a car!</p>
+              <p>Our homes in <b>Playa Chiquita</b> sit a short ride southeast of town, in a quieter, greener setting wrapped in jungle and just minutes from some of the coast's most beautiful beaches, like Punta Uva. It's an ideal base if you're after nature and calm, with the buzz of Puerto Viejo close by whenever you want it.</p>
               <p><b>Working from home?</b> We offer <b>free WIFI</b>, with a maximum speed of <b>100Mbps</b>. We stipulated two different contracts with our internet provider, so your internet connection will be shared between fewer devices, achieving less latency during meetings.</p>
-              <p><b>Pet Friendly!</b> In all our spaces. Casa Rana and Casa Gecko are the perfect options for your pet, as they come with a garden. But a small house pet could comfortably stay in the other houses too!</p>
+              <p><b>Pet friendly:</b> Casa Rana, Casa Geco, Casa Tucano and Casa Pappagallo welcome pets. Rana and Geco are the best fit, as they have their own garden.</p>
               <div className="row">
                 <div className="col-md-6">
                   <div className="media d-flex align-items-start">
@@ -60,7 +61,7 @@ const Discover = () => {
                     </div>
                     <div className="media-body flex-grow-1" style={{ verticalAlign: "middle" }}>
                       <h3 className="media-heading mt-0 mb-1">Non Refundable Discount</h3>
-                      <p>Include discount code #norefundallowed at checkout to get an extra 10% discount, but you won't be eligible for a cancellation refund.</p>
+                      <p>Choose the non-refundable rate when you book to get an extra 10% discount, but you won't be eligible for a cancellation refund.</p>
                     </div>
                   </div>
                 </div>
@@ -72,7 +73,7 @@ const Discover = () => {
                     </div>
                     <div className="media-body flex-grow-1">
                       <h3 className="media-heading mt-0 mb-1">Flexible Cancellation Policy</h3>
-                      <p>Full refund up to one day before check-in, for any reservation that does not include the #norefundallowed discount.</p>
+                      <p>Full refund up to one day before check-in on any reservation booked at the standard rate.</p>
                     </div>
                   </div>
                 </div>

--- a/src/components/Discover/Discover.componentES.tsx
+++ b/src/components/Discover/Discover.componentES.tsx
@@ -24,9 +24,10 @@ const DiscoverES = () => {
             <div className="content-block">
               <h2>Descubre Puerto Viejo desde el confort de nuestras casas.</h2>
               <p>Reservas Kalawala ofrece {PORTFOLIO_PROPERTY_COUNT} casas y villas remodeladas, <b>cada una con cocina y baño privados totalmente equipados</b>. Las casas alojan de {PORTFOLIO_GUEST_RANGE.min} a {PORTFOLIO_GUEST_RANGE.max} huéspedes, con {PORTFOLIO_BEDROOM_RANGE.min} a {PORTFOLIO_BEDROOM_RANGE.max} habitaciones y <b>aire acondicionado en todas</b>.</p>
-              <p>Ubicado en el centro de Puerto Viejo, todos los bares y restaurantes están a <b>distancia cómodamente caminable</b>. Se puede llegar a Playa Cocles en auto en 2 minutos. También hay lugares de renta de bicicletas y motocicletas para que también Punta Uva, Cahuita y Manzanillo estén a tu alcance, ¡incluso sin un auto!</p>
+              <p>Nuestras casas en el centro de Puerto Viejo te ubican en el corazón del pueblo, con <b>bares, restaurantes y tiendas a poca distancia caminando</b>. Playa Cocles está a 2 minutos en auto, y hay lugares de renta de bicicletas y motocicletas cerca para que Punta Uva, Cahuita y Manzanillo estén a tu alcance, ¡incluso sin un auto!</p>
+              <p>Nuestras casas en <b>Playa Chiquita</b> están a pocos minutos al sureste del pueblo, en un entorno más tranquilo y verde, rodeadas de selva y a solo minutos de algunas de las playas más hermosas de la costa, como Punta Uva. Es el lugar ideal si buscas naturaleza y calma, con el ambiente de Puerto Viejo cerca cuando lo quieras.</p>
               <p><b>¿Trabajas desde casa?</b> Ofrecemos <b>WIFI gratis</b>, con una velocidad de hasta <b>100Mbps</b>. Estipulamos dos contratos diferentes con nuestro proveedor de internet, por lo que tu conexión a internet será compartida entre menos dispositivos, logrando una menor latencia durante tus reuniones.</p>
-              <p><b>Pet Friendly!</b> En todos nuestros espacios. Casa Rana y Casa Gecko son las opciones perfectas para tu mascota, ya que cuentan con jardín. ¡Pero una pequeña mascota doméstica también podría alojarse cómodamente en las otras casas</p>
+              <p><b>Pet Friendly:</b> Casa Rana, Casa Geco, Casa Tucano y Casa Pappagallo reciben mascotas. Rana y Geco son las mejores opciones, ya que cuentan con jardín propio.</p>
               <div className="row">
                 <div className="col-md-6">
                   <div className="media d-flex align-items-start">
@@ -59,7 +60,7 @@ const DiscoverES = () => {
                     </div>
                     <div className="media-body flex-grow-1" style={{ verticalAlign: "middle" }}>
                       <h3 className="media-heading mt-0 mb-1">Descuento No Reembolsable</h3>
-                      <p>Incluya el código de descuento #norefundallowed al finalizar la compra para obtener un 10% de descuento adicional, pero no será elegible para un reembolso por cancelación.</p>
+                      <p>Elija la tarifa no reembolsable al reservar para obtener un 10% de descuento adicional, pero no será elegible para un reembolso por cancelación.</p>
                     </div>
                   </div>
                 </div>
@@ -71,7 +72,7 @@ const DiscoverES = () => {
                     </div>
                     <div className="media-body flex-grow-1">
                       <h3 className="media-heading mt-0 mb-1">Política de Cancelación Flexible</h3>
-                      <p>Reembolso completo hasta un día antes del check-in, para cualquier reserva que no incluya el descuento #norefundallowed.</p>
+                      <p>Reembolso completo hasta un día antes del check-in en cualquier reserva con tarifa estándar.</p>
                     </div>
                   </div>
                 </div>

--- a/src/components/Discover/Discover.componentNam.tsx
+++ b/src/components/Discover/Discover.componentNam.tsx
@@ -60,7 +60,7 @@ const DiscoverNam = () => {
                     </div>
                     <div className="media-body flex-grow-1" style={{ verticalAlign: "middle" }}>
                       <h3 className="media-heading mt-0 mb-1">Non Refundable Discount</h3>
-                      <p>Include discount code #norefundallowed at checkout to get an extra 10% discount, but you won't be eligible for a cancellation refund.</p>
+                      <p>Choose the non-refundable rate when you book to get an extra 10% discount, but you won't be eligible for a cancellation refund.</p>
                     </div>
                   </div>
                 </div>
@@ -72,7 +72,7 @@ const DiscoverNam = () => {
                     </div>
                     <div className="media-body flex-grow-1">
                       <h3 className="media-heading mt-0 mb-1">Flexible Cancellation Policy</h3>
-                      <p>Full refund up to one day before check-in, for any reservation that does not include the #norefundallowed discount.</p>
+                      <p>Full refund up to one day before check-in on any reservation booked at the standard rate.</p>
                     </div>
                   </div>
                 </div>

--- a/src/components/Discover/Discover.componentNamES.tsx
+++ b/src/components/Discover/Discover.componentNamES.tsx
@@ -60,7 +60,7 @@ const DiscoverNamES = () => {
                     </div>
                     <div className="media-body flex-grow-1" style={{ verticalAlign: "middle" }}>
                       <h3 className="media-heading mt-0 mb-1">Descuento No Reembolsable</h3>
-                      <p>Incluye el código de descuento #norefundallowed al finalizar la compra para obtener un descuento adicional del 10%, pero no serás elegible para un reembolso por cancelación.</p>
+                      <p>Elige la tarifa no reembolsable al reservar para obtener un descuento adicional del 10%, pero no serás elegible para un reembolso por cancelación.</p>
                     </div>
                   </div>
                 </div>
@@ -72,7 +72,7 @@ const DiscoverNamES = () => {
                     </div>
                     <div className="media-body flex-grow-1">
                       <h3 className="media-heading mt-0 mb-1">Política de Cancelación Flexible</h3>
-                      <p>Reembolso completo hasta un día antes del check-in, para cualquier reserva que no incluya el descuento #norefundallowed.</p>
+                      <p>Reembolso completo hasta un día antes del check-in en cualquier reserva con tarifa estándar.</p>
                     </div>
                   </div>
                 </div>

--- a/src/components/Discover/Discover.componentRIB.tsx
+++ b/src/components/Discover/Discover.componentRIB.tsx
@@ -58,7 +58,7 @@ const DiscoverRIB = () => {
                     </div>
                     <div className="media-body flex-grow-1" style={{ verticalAlign: "middle" }}>
                       <h3 className="media-heading mt-0 mb-1">Non Refundable Discount</h3>
-                      <p>Include discount code #norefundallowed at checkout to get an extra 10% discount, but you won't be eligible for a cancellation refund.</p>
+                      <p>Choose the non-refundable rate when you book to get an extra 10% discount, but you won't be eligible for a cancellation refund.</p>
                     </div>
                   </div>
                 </div>
@@ -70,7 +70,7 @@ const DiscoverRIB = () => {
                     </div>
                     <div className="media-body flex-grow-1">
                       <h3 className="media-heading mt-0 mb-1">Flexible Cancellation Policy</h3>
-                      <p>Full refund up to one day before check-in, for any reservation that does not include the #norefundallowed discount.</p>
+                      <p>Full refund up to one day before check-in on any reservation booked at the standard rate.</p>
                     </div>
                   </div>
                 </div>

--- a/src/components/Discover/Discover.componentRIBES.tsx
+++ b/src/components/Discover/Discover.componentRIBES.tsx
@@ -57,7 +57,7 @@ const DiscoverRIBES = () => {
                     </div>
                     <div className="media-body flex-grow-1" style={{ verticalAlign: "middle" }}>
                       <h3 className="media-heading mt-0 mb-1">Descuento No Reembolsable</h3>
-                      <p>Incluya el código de descuento #norefundallowed al finalizar la compra para obtener un 10% de descuento adicional, pero no será elegible para un reembolso por cancelación.</p>
+                      <p>Elija la tarifa no reembolsable al reservar para obtener un 10% de descuento adicional, pero no será elegible para un reembolso por cancelación.</p>
                     </div>
                   </div>
                 </div>
@@ -69,7 +69,7 @@ const DiscoverRIBES = () => {
                     </div>
                     <div className="media-body flex-grow-1">
                       <h3 className="media-heading mt-0 mb-1">Política de Cancelación Flexible</h3>
-                      <p>Reembolso completo hasta un día antes del check-in, para cualquier reserva que no incluya el descuento #norefundallowed.</p>
+                      <p>Reembolso completo hasta un día antes del check-in en cualquier reserva con tarifa estándar.</p>
                     </div>
                   </div>
                 </div>

--- a/src/components/HomeReviews/HomeReviews.component.tsx
+++ b/src/components/HomeReviews/HomeReviews.component.tsx
@@ -101,26 +101,17 @@ const HomeReviews: React.FC<HomeReviewsProps> = ({ isSpanish }) => {
     return () => { if (rafRef.current) cancelAnimationFrame(rafRef.current); };
   }, [activeReview]);
 
-  // Let a vertical wheel gesture scroll the page instead of this track.
-  // Chromium redirects vertical wheel input into horizontal scroll on any
-  // element that can only scroll on the X axis — no custom handling needed
-  // to cause it, which is why a visitor scrolling straight down the page
-  // gets stuck the moment the cursor crosses this track. React attaches
-  // wheel listeners as passive by default, so calling preventDefault() from
-  // an onWheel prop is silently ignored; this has to be a real DOM listener
-  // registered with { passive: false }.
-  useEffect(() => {
-    const track = trackRef.current;
-    if (!track) return;
-    const onWheel = (e: WheelEvent) => {
-      if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
-        e.preventDefault();
-        window.scrollBy(0, e.deltaY);
-      }
-    };
-    track.addEventListener('wheel', onWheel, { passive: false });
-    return () => track.removeEventListener('wheel', onWheel);
-  }, []);
+  // No wheel handler on purpose. The old one called preventDefault() +
+  // window.scrollBy() on every wheel event so a vertical gesture over the
+  // track scrolled the page — but that replaces the compositor's native
+  // trackpad momentum with discrete main-thread jumps that fight the rAF
+  // auto-scroll loop above, which is exactly what made scrolling feel like it
+  // slowed to a crawl over this section. Instead the track is `overflow-x:
+  // hidden` on desktop (see HomeReviews.style.scss), so it is not a wheel
+  // scroll target at all: vertical wheel passes straight through to the page
+  // with full native momentum, while the marquee still animates via scrollLeft.
+  // Mobile keeps `overflow-x: auto` for native touch swipe (touch emits no
+  // wheel events, so there is nothing to hijack there).
 
   // Panel: lock body scroll + ESC to close
   useEffect(() => {

--- a/src/components/HomeReviews/HomeReviews.style.scss
+++ b/src/components/HomeReviews/HomeReviews.style.scss
@@ -31,11 +31,18 @@
   &__track {
     display: flex;
     gap: 16px;
-    overflow-x: auto;
+    // Desktop: `hidden`, not `auto`. An auto/scroll horizontal container becomes
+    // a wheel scroll target, and a vertical trackpad gesture over it gets
+    // captured (Chromium even redirects it into horizontal scroll) instead of
+    // scrolling the page. `hidden` still lets the marquee animate via
+    // scrollLeft in JS, but the element is no longer a user-scroll target, so
+    // vertical wheel passes through to the page with native momentum. Mobile
+    // switches back to `auto` below for native touch swipe.
+    overflow-x: hidden;
     -webkit-overflow-scrolling: touch;
     padding: 8px 40px 24px;
     scrollbar-width: none;
-    cursor: grab;
+    cursor: default;
 
     &:active {
       cursor: grabbing;
@@ -257,6 +264,10 @@
     &__track {
       padding: 8px 20px 20px;
       /* No scroll-snap — it conflicts with JS-driven auto-scroll */
+      /* Touch devices emit no wheel events, so there's nothing to hijack here:
+         restore native horizontal swipe (with momentum) for the marquee. */
+      overflow-x: auto;
+      cursor: grab;
     }
 
     &__card {

--- a/src/components/OurHomes/Components/HomeCard.component.tsx
+++ b/src/components/OurHomes/Components/HomeCard.component.tsx
@@ -38,15 +38,18 @@ const HomeCard: FC<IHomeCard> = ({ guestNumber, parking, name, image, houseLangC
                 </div>
                 <div className="content text-center">
                     <h3 className="highlight">{name}</h3>
-                    <div style={{ display: "block" }}>
-                        <div className="container-rounded-border border-highlight" style={{ marginRight: '6px' }}>
-                            <FontAwesomeIcon icon={faUser} fontSize={"18px"} style={{ margin: '2px 4px 2px 2px', color: '#5A6570' }} />
-                            <b className="highlight" style={{ fontSize: '18px', color: '#5A6570' }}>{`X${guestNumber}`}</b>
+                    {/* Same .icons / .icon-group markup as OtherHomesCard so the
+                        "Our Homes" and "Explore other stays" amenity rows render
+                        identically (brand-green, flat, no bordered guest pill). */}
+                    <div className="icons">
+                        <div className="icon-group">
+                            <FontAwesomeIcon icon={faUser} />
+                            <span>{`X${guestNumber}`}</span>
                         </div>
-                        <FontAwesomeIcon icon={faSnowflake} fontSize={"20px"} style={{ marginRight: '6px', color: '#5A6570' }} />
-                        <FontAwesomeIcon icon={faUtensils} fontSize={"20px"} style={{ marginRight: '6px', color: '#5A6570' }} />
-                        <FontAwesomeIcon icon={faWifi} fontSize={"20px"} style={{ color: '#5A6570' }} />
-                        <FontAwesomeIcon icon={faParking} fontSize={"20px"} style={{ marginLeft: '6px', color: '#5A6570' }} />
+                        <FontAwesomeIcon icon={faSnowflake} />
+                        <FontAwesomeIcon icon={faUtensils} />
+                        <FontAwesomeIcon icon={faWifi} />
+                        <FontAwesomeIcon icon={faParking} />
                     </div>
                 </div>
             </div>

--- a/src/components/OurHomes/Components/HomeCard.style.scss
+++ b/src/components/OurHomes/Components/HomeCard.style.scss
@@ -210,6 +210,40 @@
             margin: 0 10px !important; // Increase spacing
           }
         }
+
+        // Amenity row — kept identical to the "Explore other stays" cards (see
+        // OurOtherHomes/Components/OtherHomesCard.style.scss): flat grey icons
+        // with a guest group, no bordered pill, so both home sections read as
+        // one system instead of two differently-styled widgets.
+        .icons {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          gap: 10px;
+          font-size: 1.2rem;
+          color: #5A6570;
+          margin-top: 6px;
+
+          svg {
+            color: currentColor;
+          }
+
+          .icon-group {
+            display: flex;
+            align-items: center;
+            gap: 5px;
+          }
+
+          // Override the section-wide `.content svg { font-size: 26px !important }`
+          // mobile rule (tuned for the old inline icons) so these stay the same
+          // size as the other cards on phones too.
+          @media (max-width: 768px) {
+            svg {
+              font-size: 1.2rem !important;
+              margin: 0 !important;
+            }
+          }
+        }
       }
     }
 }

--- a/src/components/OurHomes/Components/NamCard.component.tsx
+++ b/src/components/OurHomes/Components/NamCard.component.tsx
@@ -38,14 +38,17 @@ const NamCard: FC<IHomeCard> = ({ guestNumber, name, image, houseLangCode }) => 
                 </div>
                 <div className="content text-center">
                     <h3 className="highlight">{name}</h3>
-                    <div style={{ display: "block" }}>
-                        <div className="container-rounded-border border-highlight" style={{ marginRight: '6px' }}>
-                            <FontAwesomeIcon icon={faUser} fontSize={"18px"} style={{ margin: '2px 4px 2px 2px', color: '#5A6570' }} />
-                            <b className="highlight" style={{ fontSize: '18px', color: '#5A6570' }}>{`X${guestNumber}`}</b>
+                    {/* Same .icons / .icon-group markup as OtherHomesCard so the
+                        "Our Homes" and "Explore other stays" amenity rows render
+                        identically (brand-green, flat, no bordered guest pill). */}
+                    <div className="icons">
+                        <div className="icon-group">
+                            <FontAwesomeIcon icon={faUser} />
+                            <span>{`X${guestNumber}`}</span>
                         </div>
-                        <FontAwesomeIcon icon={faSnowflake} fontSize={"20px"} style={{ marginRight: '6px', color: '#5A6570' }} />
-                        <FontAwesomeIcon icon={faUtensils} fontSize={"20px"} style={{ marginRight: '6px', color: '#5A6570' }} />
-                        <FontAwesomeIcon icon={faWifi} fontSize={"20px"} style={{ color: '#5A6570' }} />
+                        <FontAwesomeIcon icon={faSnowflake} />
+                        <FontAwesomeIcon icon={faUtensils} />
+                        <FontAwesomeIcon icon={faWifi} />
                     </div>
                 </div>
             </div>

--- a/src/components/OurHomes/Components/VillaCard.component.tsx
+++ b/src/components/OurHomes/Components/VillaCard.component.tsx
@@ -52,16 +52,19 @@ const VillaCard: FC<IHomeCard> = ({ guestNumber, name, image, houseLangCode }) =
                 </div>
                 <div className="content text-center">
                     <h3 className="highlight">{name}</h3>
-                    <div style={{ display: "block" }}>
-                        <div className="container-rounded-border border-highlight" style={{ marginRight: '6px' }}>
-                            <FontAwesomeIcon icon={faUser} fontSize={"18px"} style={{ margin: '2px 4px 2px 2px', color: '#5A6570' }} />
-                            <b className="highlight" style={{ fontSize: '18px', color: '#5A6570' }}>{`X${guestNumber}`}</b>
+                    {/* Same .icons / .icon-group markup as OtherHomesCard so the
+                        "Our Homes" and "Explore other stays" amenity rows render
+                        identically (brand-green, flat, no bordered guest pill). */}
+                    <div className="icons">
+                        <div className="icon-group">
+                            <FontAwesomeIcon icon={faUser} />
+                            <span>{`X${guestNumber}`}</span>
                         </div>
-                        <FontAwesomeIcon icon={faSwimmingPool} fontSize={"20px"} style={{ marginRight: '6px', color: '#5A6570' }} />
-                        <FontAwesomeIcon icon={faSnowflake} fontSize={"20px"} style={{ marginRight: '6px', color: '#5A6570' }} />
-                        <FontAwesomeIcon icon={faUtensils} fontSize={"20px"} style={{ marginRight: '6px', color: '#5A6570' }} />
-                        <FontAwesomeIcon icon={faWifi} fontSize={"20px"} style={{ color: '#5A6570' }} />
-                        <FontAwesomeIcon icon={faParking} fontSize={"20px"} style={{ marginLeft: '6px', color: '#5A6570' }} />
+                        <FontAwesomeIcon icon={faSwimmingPool} />
+                        <FontAwesomeIcon icon={faSnowflake} />
+                        <FontAwesomeIcon icon={faUtensils} />
+                        <FontAwesomeIcon icon={faWifi} />
+                        <FontAwesomeIcon icon={faParking} />
                     </div>
                 </div>
             </div>

--- a/src/components/OurOtherHomes/Components/OtherHomesCard.style.scss
+++ b/src/components/OurOtherHomes/Components/OtherHomesCard.style.scss
@@ -54,7 +54,17 @@
         justify-content: center;
         gap: 10px;
         font-size: 1.2rem;
-  
+        // Was inheriting the anchor's default browser-blue link colour, which
+        // reads as an off-brand third-party widget. Pin to the neutral grey the
+        // cards have always used and let the FontAwesome SVGs pick it up via
+        // currentColor so any icon added here later stays consistent without
+        // needing its own `color` prop.
+        color: #5A6570;
+
+        svg {
+          color: currentColor;
+        }
+
         .icon-group {
           display: flex;
           align-items: center;

--- a/src/components/OurOtherHomes/OurOtherHomes.style.scss
+++ b/src/components/OurOtherHomes/OurOtherHomes.style.scss
@@ -38,6 +38,7 @@
       display: flex;
       justify-content: center;
       gap: 20px; // Space between cards
+      flex-wrap: wrap; // let cards drop instead of forcing a too-wide row
     }
   }
 
@@ -46,6 +47,23 @@
     .sections-wrapper {
       flex-direction: column;
       align-items: center;
+    }
+  }
+
+  // Below ~480px two 250px cards + gap overflow a ~390px viewport, which is what
+  // pushed the whole page sideways. Drop to one full-width card per row so each
+  // photo stays large enough to sell the house (no cramped two-up, no carousel).
+  @media (max-width: 480px) {
+    .section .cards-container {
+      flex-direction: column;
+      align-items: center;
+    }
+
+    // .other-homes-card caps itself at 250px; let it use the column width on
+    // phones while still leaving a comfortable side margin.
+    .other-homes-card {
+      max-width: 340px;
+      width: 100%;
     }
   }
 }

--- a/src/components/PriceConfirmationSection/PriceConfirmationSection.component.tsx
+++ b/src/components/PriceConfirmationSection/PriceConfirmationSection.component.tsx
@@ -71,20 +71,20 @@ const PriceConfirmationSection: React.FC<PriceConfirmationSectionProps> = ({
       <p className='price-display' style={{ marginTop: '15px', marginBottom: 0 }}>
         {isSpanish ? (
           <><>
-            Código de descuento: <strong>#norefundallowed</strong>
+            Elige la <strong>tarifa no reembolsable</strong>
           </>
             <br />
             <>
-              La reservación se vuelve No Reembolsable
+              para un 10% de descuento adicional
             </>
           </>
         ) : (
           <><>
-            Discount code: <strong>#norefundallowed</strong>
+            Choose the <strong>non-refundable rate</strong>
           </>
             <br />
             <>
-              Reservation becomes Non Refundable
+              for an extra 10% discount
             </>
           </>
         )}

--- a/src/hooks/useSmoobuSizeChange.ts
+++ b/src/hooks/useSmoobuSizeChange.ts
@@ -29,8 +29,8 @@ export const useSmoobuSizeChange = (options: UseSmoobuClickOptions = {}) => {
     hasTriggeredRef.current = true;
 
     const message = isSpanishPage
-      ? 'Usa el código #norefundallowed para disfrutar de un 10% de descuento en reservas no reembolsables.'
-      : 'Use the code #norefundallowed to enjoy a 10% discount on non-refundable reservations.';
+      ? 'Elige la tarifa no reembolsable en el motor de reservas para disfrutar de un 10% de descuento.'
+      : 'Select the non-refundable rate in the booking tool to enjoy a 10% discount.';
 
     addMessageTip({
       id: 'welcome-message',

--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -7,6 +7,13 @@
 html {
     background-color: #F5F2E9;
     color: $kalawala-text-gray;
+    // Safety net against document-level sideways scroll: no section should push
+    // wider than the viewport, but if one regresses the page itself must not
+    // slide (which leaves an empty strip to the right of every section).
+    // `clip` — not `hidden` — because `overflow-x: hidden` turns this element
+    // into the scroll container for the sticky navbar and stops it sticking;
+    // `clip` clips the overflow without creating a scroll container.
+    overflow-x: clip;
 }
 
 body {
@@ -14,6 +21,7 @@ body {
     font-family: $secondary-font;
     color: $kalawala-text-gray;
     -webkit-font-smoothing: antialiased;
+    overflow-x: clip;
 }
 
 h1,


### PR DESCRIPTION
## Summary
Homepage & booking UI refinements, verified in the browser (Chrome, `localhost:3007`).

- **BookingCtaBanner** — removed the green "band" background and the `4.9/5 · book direct, no platform fees` line; kept a single, larger dark-green **Check availability** button that now sits on the page background.
- **Property cards** — reverted the amenity icons from brand dark-green back to the original grey (`#5A6570`), unified across `HomeCard` / `VillaCard` / `NamCard` / `OtherHomesCard`.
- **Rate copy** — replaced the `#norefundallowed` discount-code messaging with the "choose the non-refundable rate" wording across Discover (EN/ES + Nam/RIB variants), CallToAction, PriceConfirmationSection, and the Smoobu tip.
- **HomeReviews** — removed the wheel-event hijack; desktop track uses `overflow-x: hidden` (marquee still animates via JS) so vertical scroll keeps native momentum; mobile keeps `overflow-x: auto` for touch swipe.
- **Overflow fixes** — `overflow-x: clip` on `html`/`body` to prevent document-level sideways scroll; OurOtherHomes cards wrap and drop to one full-width card below 480px.

## Verification
- `npm start` compiles cleanly, typecheck passes ("No issues found").
- Verified in Chrome: standalone dark-green Check availability button (no band), and grey amenity icons on all cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139ygx34QGLJKsoQyxkFX2L