### PR TITLE
fix(booking-api): close booking-engine race conditions (R1–R9)

### DIFF
--- a/booking-api/src/bookingSessions.test.ts
+++ b/booking-api/src/bookingSessions.test.ts
@@ -1,4 +1,8 @@
-import { BookingSessionQuotedProperty, RdsBookingSessionRepository } from "./bookingSessions";
+import {
+  BookingSessionQuotedProperty,
+  InMemoryBookingSessionRepository,
+  RdsBookingSessionRepository,
+} from "./bookingSessions";
 
 const QUOTED_PROPERTIES: BookingSessionQuotedProperty[] = [
   {
@@ -425,4 +429,69 @@ test("RdsBookingSessionRepository.throwMissingOrInvalidTransition throws not-fou
   await expect(
     repo.markPaypalOrderCreated({ bookingSessionId: BASE_ROW.id, paypalOrderId: "PAYPAL-ORDER-X" })
   ).rejects.toThrow(`Booking session ${BASE_ROW.id} was not found.`);
+});
+
+// ─── Race-condition regression: staff deposit reject guard (R6) ───────────────
+
+describe("markStaffRejected (R6)", () => {
+  async function seedManualDepositHoldActive(sessions: InMemoryBookingSessionRepository) {
+    const session = await sessions.createQuotedSession({
+      arrivalDate: "2026-05-01",
+      departureDate: "2026-05-05",
+      guests: 2,
+      language: "en",
+      quotedProperties: QUOTED_PROPERTIES,
+    });
+    const propertyId = QUOTED_PROPERTIES[0].propertyId;
+    await sessions.markHoldCreating({
+      bookingSessionId: session.id,
+      propertyId,
+      paymentMethod: "manual_deposit",
+      ratePlan: "flexible",
+      price: QUOTED_PROPERTIES[0],
+      guest: { firstName: "Test", lastName: "Guest", email: "test@example.com" },
+      portalPasswordHash: "hash",
+      expiresAt: "2026-04-18T13:00:00.000Z",
+    });
+    await sessions.markHoldActive({ bookingSessionId: session.id, expiresAt: "2026-04-18T13:00:00.000Z" });
+    return session;
+  }
+
+  it("cancels a hold_active manual-deposit booking", async () => {
+    const sessions = new InMemoryBookingSessionRepository();
+    const session = await seedManualDepositHoldActive(sessions);
+
+    const rejected = await sessions.markStaffRejected({
+      bookingSessionId: session.id,
+      reason: "deposit_not_received",
+      cancelledAt: "2026-04-16T10:00:00.000Z",
+    });
+
+    expect(rejected).toBeDefined();
+    expect(rejected?.status).toBe("cancelled");
+  });
+
+  it("returns undefined (and does NOT cancel) once the booking has been confirmed", async () => {
+    const sessions = new InMemoryBookingSessionRepository();
+    const session = await seedManualDepositHoldActive(sessions);
+
+    // A concurrent staff confirm lands first.
+    await sessions.markDepositConfirmed({
+      bookingSessionId: session.id,
+      confirmedAt: "2026-04-16T09:59:00.000Z",
+      confirmedBy: "staff_link",
+      tokenJti: "jti-1",
+    });
+
+    const rejected = await sessions.markStaffRejected({
+      bookingSessionId: session.id,
+      reason: "deposit_not_received",
+      cancelledAt: "2026-04-16T10:00:00.000Z",
+    });
+
+    // Guard refuses the transition — the caller must skip the Smoobu cancel.
+    expect(rejected).toBeUndefined();
+    const after = await sessions.getById(session.id);
+    expect(after?.status).toBe("booking_confirmed");
+  });
 });

--- a/booking-api/src/bookingSessions.ts
+++ b/booking-api/src/bookingSessions.ts
@@ -185,6 +185,18 @@ export interface BookingSessionRepository {
     confirmedBy: string;
     tokenJti: string;
   }): Promise<BookingSessionRecord>;
+  /**
+   * Staff rejecting a manual-deposit booking whose transfer never arrived. Unlike
+   * markCancelled (whose guard admits booking_confirmed, for guest cancellations),
+   * this only fires from hold_active — so it can never cancel a booking that was
+   * confirmed concurrently. Returns `undefined` on 0 rows: the caller must treat
+   * that as "no longer rejectable" and NOT perform the Smoobu cancellation (R6).
+   */
+  markStaffRejected(input: {
+    bookingSessionId: string;
+    reason: string;
+    cancelledAt: string;
+  }): Promise<BookingSessionRecord | undefined>;
   setDepositReceiptS3Key(input: { bookingSessionId: string; s3Key: string }): Promise<BookingSessionRecord>;
   updateGuests(input: { bookingSessionId: string; guests: number }): Promise<BookingSessionRecord>;
   listByStatus?(status: BookingSessionStatus): Promise<BookingSessionRecord[]>;
@@ -678,6 +690,31 @@ export class RdsBookingSessionRepository implements BookingSessionRepository {
     return this.throwMissingOrInvalidTransition(input.bookingSessionId, "booking_confirmed", "cancelled");
   }
 
+  async markStaffRejected(input: {
+    bookingSessionId: string;
+    reason: string;
+    cancelledAt: string;
+  }): Promise<BookingSessionRecord | undefined> {
+    const result = await this.pool.query<BookingSessionRow>(
+      `
+        update booking_sessions
+        set
+          status = 'cancelled',
+          cancelled_at = coalesce(cancelled_at, $3),
+          cancellation_reason = coalesce(cancellation_reason, $2),
+          cancelled_by = coalesce(cancelled_by, 'staff'),
+          updated_at = now()
+        where id = $1
+          and status = 'hold_active'
+          and payment_method = 'manual_deposit'
+        returning ${BOOKING_SESSION_COLUMNS}
+      `,
+      [input.bookingSessionId, input.reason, input.cancelledAt]
+    );
+
+    return result.rows[0] ? mapBookingSessionRow(result.rows[0]) : undefined;
+  }
+
   async setDepositReceiptS3Key(input: { bookingSessionId: string; s3Key: string }): Promise<BookingSessionRecord> {
     const result = await this.pool.query<BookingSessionRow>(
       `
@@ -955,6 +992,26 @@ export class InMemoryBookingSessionRepository implements BookingSessionRepositor
       cancelledAt: existing.cancelledAt ?? input.cancelledAt,
       cancellationReason: existing.cancellationReason ?? input.reason,
       cancelledBy: existing.cancelledBy ?? input.cancelledBy,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  async markStaffRejected(input: {
+    bookingSessionId: string;
+    reason: string;
+    cancelledAt: string;
+  }): Promise<BookingSessionRecord | undefined> {
+    const existing = this.sessionsById.get(input.bookingSessionId);
+    if (!existing || existing.status !== "hold_active" || existing.paymentMethod !== "manual_deposit") {
+      return undefined;
+    }
+
+    return this.save({
+      ...existing,
+      status: "cancelled",
+      cancelledAt: existing.cancelledAt ?? input.cancelledAt,
+      cancellationReason: existing.cancellationReason ?? input.reason,
+      cancelledBy: existing.cancelledBy ?? "staff",
       updatedAt: new Date().toISOString(),
     });
   }

--- a/booking-api/src/concurrencyHolds.test.ts
+++ b/booking-api/src/concurrencyHolds.test.ts
@@ -275,3 +275,38 @@ test("RDS overlap constraint error (23P01) is mapped to 409 property_no_longer_a
     retryable: false,
   });
 });
+
+// ─── Race-condition regression: orphaned Smoobu reservation cleanup (R4) ──────
+
+test("R4: cancels the just-created Smoobu reservation when hold activation fails", async () => {
+  const fetchFn = happySmoobuFetch();
+  global.fetch = fetchFn as typeof fetch;
+  const config = createTestConfig();
+  // Simulate the DB failing right after the Smoobu reservation was created.
+  jest.spyOn(holds, "activateHold").mockRejectedValue(new Error("db unavailable"));
+  const handler = createBookingApiHandler(config);
+
+  const search = await handler(searchEvent("device-r4"));
+  const body = JSON.parse(search.body);
+
+  const holdRequest = {
+    quoteId: body.quoteId,
+    bookingSessionId: body.bookingSessionId,
+    propertyId: body.properties[0].propertyId,
+    paymentMethod: "paypal",
+    guest: { firstName: "Ana", lastName: "Mora", email: "ana@example.com" },
+    portalPassword: "correct horse battery staple",
+    termsAccepted: true,
+  };
+
+  const resp = await handler(holdEvent(holdRequest, "r4-idempotency-key-000001", "203.0.113.9"));
+  expect(resp.statusCode).toBeGreaterThanOrEqual(500);
+
+  // The reservation created on Smoobu (id 9900099) must be cancelled in the catch.
+  const deleteCall = fetchFn.mock.calls.find(
+    ([url, init]) =>
+      String((init as RequestInit | undefined)?.method ?? "").toUpperCase() === "DELETE" &&
+      new URL(url.toString()).pathname === "/api/reservations/9900099"
+  );
+  expect(deleteCall).toBeDefined();
+});

--- a/booking-api/src/config.test.ts
+++ b/booking-api/src/config.test.ts
@@ -1,0 +1,26 @@
+import { loadConfig } from "./config";
+
+// ─── Race-condition regression: stale idempotency-lock window (R5) ────────────
+
+describe("loadConfig — idempotency lock window validation (R5)", () => {
+  it("accepts the defaults", () => {
+    expect(() => loadConfig({} as NodeJS.ProcessEnv)).not.toThrow();
+  });
+
+  it("throws when the stale-lock window is shorter than the worst-case Smoobu round-trip", () => {
+    // 5s lock vs. default 8s timeout × (3 retries + 1) × 2 + margin → misconfigured.
+    expect(() =>
+      loadConfig({ BOOKING_API_STALE_IDEMPOTENCY_LOCK_SECONDS: "5" } as NodeJS.ProcessEnv)
+    ).toThrow(/STALE_IDEMPOTENCY_LOCK/);
+  });
+
+  it("accepts a small stale-lock window when Smoobu timeouts are correspondingly small", () => {
+    expect(() =>
+      loadConfig({
+        BOOKING_API_STALE_IDEMPOTENCY_LOCK_SECONDS: "30",
+        SMOOBU_TIMEOUT_MS: "1000",
+        SMOOBU_MAX_RETRIES: "0",
+      } as NodeJS.ProcessEnv)
+    ).not.toThrow();
+  });
+});

--- a/booking-api/src/config.ts
+++ b/booking-api/src/config.ts
@@ -100,7 +100,7 @@ function parseLogLevel(value: string | undefined): LogLevel {
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): BookingApiConfig {
   const secrets = createSecretProvider(env);
-  return {
+  const config: BookingApiConfig = {
     allowedOrigins: splitCsv(env.BOOKING_API_ALLOWED_ORIGINS),
     maxBodyBytes: parseMaxBodyBytes(env.BOOKING_API_MAX_BODY_BYTES),
     secrets,
@@ -178,6 +178,29 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): BookingApiConf
       debug: parseBoolean(env.SERVER_CONVERSIONS_DEBUG, false),
     },
   };
+
+  validateIdempotencyLockWindow(config);
+  return config;
+}
+
+/**
+ * The stale-idempotency-lock window is how long an in-progress idempotency key may
+ * sit before a retry is allowed to reclaim it (holds.ts reserveIdempotencyKey). If
+ * that window is shorter than the worst-case time a hold request spends calling
+ * Smoobu, a merely-slow original request can be reclaimed and run concurrently with
+ * its retry — firing two Smoobu reservation creations (R5). Fail fast on misconfig.
+ */
+function validateIdempotencyLockWindow(config: BookingApiConfig): void {
+  const staleLockMs = config.hold.staleIdempotencyLockSeconds * 1_000;
+  // Smoobu availability recheck + reservation create, each up to timeoutMs across
+  // all retry attempts, plus margin for backoff and local work.
+  const worstCaseSmoobuMs = config.smoobu.timeoutMs * (config.smoobu.maxRetries + 1) * 2;
+  const requiredMs = worstCaseSmoobuMs + 5_000;
+  if (staleLockMs <= requiredMs) {
+    throw new Error(
+      `BOOKING_API_STALE_IDEMPOTENCY_LOCK_SECONDS (${config.hold.staleIdempotencyLockSeconds}s = ${staleLockMs}ms) must exceed the worst-case Smoobu round-trip (${requiredMs}ms) so a slow hold request is not reclaimed and run concurrently with its retry. Increase it or lower SMOOBU_TIMEOUT_MS / SMOOBU_MAX_RETRIES.`
+    );
+  }
 }
 
 function parseSmoobuHoldChannelId(value: string | undefined): SmoobuHoldChannelId {

--- a/booking-api/src/depositConfirm.ts
+++ b/booking-api/src/depositConfirm.ts
@@ -135,6 +135,31 @@ export async function handleStaffDepositReviewSubmit(
   const hold = await holds.getByBookingSessionId(session.id);
 
   if (payload.act === "deposit_reject") {
+    // Guard the destructive Smoobu cancel behind a local compare-and-swap FIRST.
+    // markStaffRejected only fires from hold_active, so if a guest's deposit was
+    // confirmed concurrently (between resolveToken's read and now) this returns
+    // undefined and we abort WITHOUT releasing the reservation — otherwise a late
+    // reject would cancel a paid booking and put its dates back on sale (R6).
+    const rejectedSession = await sessions.markStaffRejected({
+      bookingSessionId: session.id,
+      reason: "deposit_not_received",
+      cancelledAt: new Date().toISOString(),
+    });
+
+    if (!rejectedSession) {
+      const current = (await sessions.getById(session.id)) ?? session;
+      return htmlResponse(
+        current.status === "booking_confirmed" ? 200 : 409,
+        renderPage({
+          heading: current.status === "booking_confirmed" ? "Already confirmed" : "No longer actionable",
+          body: `<p>Reservation <strong>${escapeHtml(session.reservationPublicId)}</strong> is <strong>${escapeHtml(
+            current.status
+          )}</strong> and can no longer be rejected.</p>`,
+        }),
+        request.responseHeaders
+      );
+    }
+
     if (hold?.smoobuReservationId) {
       try {
         const smoobuClient = await createSmoobuClient(config);
@@ -146,12 +171,6 @@ export async function handleStaffDepositReviewSubmit(
       }
     }
 
-    await sessions.markCancelled({
-      bookingSessionId: session.id,
-      reason: "deposit_not_received",
-      cancelledBy: "staff",
-      cancelledAt: new Date().toISOString(),
-    });
     if (hold) {
       await holds.cancelHold(hold.id);
     }
@@ -192,16 +211,26 @@ export async function handleStaffDepositReviewSubmit(
     tokenJti: payload.jti,
   });
 
-  // Promote the Smoobu reservation from Blocked channel to Homepage (website) —
-  // the same mechanism PayPal captures use, see smoobuPromotion.ts. This also
-  // moves the hold to `converted`, taking it out of the expiry worker's reach:
-  // listExpiredHolds sweeps creating|active holds past expires_at, so a confirmed
-  // booking left `active` would have its Smoobu reservation cancelled at the TTL.
+  // Move the hold to `converted` immediately, taking it out of the expiry
+  // worker's reach: listExpiredHolds sweeps creating|active holds past
+  // expires_at, so a confirmed booking left `active` would have its Smoobu
+  // reservation cancelled at the TTL. This runs synchronously and reliably,
+  // *before* the best-effort Smoobu promotion below (R1).
   if (hold) {
+    const confirmedHold = await holds.markHoldConfirmed(hold.id).catch(() => hold);
+    if (confirmedHold.status !== "converted") {
+      request.observability.logger.error("booking_confirmed_hold_already_expired", {
+        bookingSessionId: session.id,
+        holdId: hold.id,
+        holdStatus: confirmedHold.status,
+      });
+    }
+    // Promote the Smoobu reservation from Blocked channel to Homepage (website) —
+    // the same mechanism PayPal captures use, see smoobuPromotion.ts.
     await promoteSmoobuReservation(
       {
         session: confirmedSession,
-        hold,
+        hold: confirmedHold,
         notice: `Kalawala manual deposit CONFIRMED by staff on ${confirmedAt}. Reservation ${session.reservationPublicId}.`,
         amountCents: confirmedSession.totalAmountCents ?? 0,
       },

--- a/booking-api/src/happyPath.test.ts
+++ b/booking-api/src/happyPath.test.ts
@@ -337,7 +337,9 @@ test("happy path: health → search → hold → paypal order → capture → po
   const confirmedSession = await bookingSessions.getById(bookingSessionId);
   expect(confirmedSession?.status).toBe("booking_confirmed");
   const confirmedHold = await holds.getByBookingSessionId(bookingSessionId);
-  expect(confirmedHold?.status).toBe("active");
+  // On capture the hold is moved to `converted` immediately (before the Smoobu
+  // promotion), taking it out of the expiry sweep's reach — see R1 / markHoldConfirmed.
+  expect(confirmedHold?.status).toBe("converted");
   const confirmedPayment = await payments.getByBookingSessionId(bookingSessionId);
   expect(confirmedPayment?.status).toBe("captured");
   expect(confirmedPayment?.paypalCaptureId).toBe("HP-CAP-001");

--- a/booking-api/src/holdExpiry.test.ts
+++ b/booking-api/src/holdExpiry.test.ts
@@ -358,3 +358,28 @@ describe("processExpiredHolds", () => {
     );
   });
 });
+
+describe("processExpiredHolds — race-condition regression (R1)", () => {
+  it("does not expire or cancel a hold whose session is already booking_confirmed", async () => {
+    const holds = new InMemoryHoldRepository();
+    const sessions = new InMemoryBookingSessionRepository();
+    const smoobuClient = createMockSmoobuClient();
+
+    const { session } = await seedActiveHold(holds, sessions, { expiresAt: PAST });
+
+    // Payment landed and the session is confirmed, but the hold was left `active`
+    // (e.g. the Smoobu promotion failed after capture). The expiry sweep must not
+    // cancel this now-paid booking's reservation.
+    await sessions.markPaypalOrderCreated({ bookingSessionId: session.id, paypalOrderId: "PP-R1" });
+    await sessions.markBookingConfirmed({ bookingSessionId: session.id, confirmedAt: NOW });
+
+    const deps = createDeps({ holds, bookingSessions: sessions, smoobuClient });
+    const result = await processExpiredHolds(deps);
+
+    expect(smoobuClient.cancelReservation).not.toHaveBeenCalled();
+    expect(result.expired).toBe(0);
+    expect(result.smoobuCancelled).toBe(0);
+    const after = await holds.getByBookingSessionId(session.id);
+    expect(after?.status).toBe("active");
+  });
+});

--- a/booking-api/src/holdExpiry.ts
+++ b/booking-api/src/holdExpiry.ts
@@ -87,6 +87,19 @@ async function processOneHold(
 ): Promise<void> {
   const { holds, bookingSessions, smoobuClient, logger } = deps;
 
+  // 0. Never expire — and never cancel the Smoobu reservation of — a booking that
+  // has already been confirmed/paid. The RDS `listExpiredHolds` already excludes
+  // these via a join, but the in-memory repo cannot, and a confirmation may have
+  // landed between the sweep's claim and now. The session status is authoritative.
+  const guardSession = await bookingSessions.getById(hold.bookingSessionId).catch(() => undefined);
+  if (guardSession?.status === "booking_confirmed") {
+    logger.info("hold_expiry_skipped_confirmed", {
+      holdId: hold.id,
+      bookingSessionId: hold.bookingSessionId,
+    });
+    return;
+  }
+
   // 1. Mark hold as expired in DB
   try {
     await holds.expireHold(hold.id);

--- a/booking-api/src/holds.test.ts
+++ b/booking-api/src/holds.test.ts
@@ -364,7 +364,7 @@ test("RdsHoldRepository.listExpiredHolds atomically claims rows with skip-locked
 
   expect(records).toHaveLength(1);
   expect(records[0]).toMatchObject({ status: "expired", smoobuReservationId: 987654 });
-  expect(query).toHaveBeenCalledWith(expect.stringContaining("for update skip locked"), [
+  expect(query).toHaveBeenCalledWith(expect.stringContaining("for update of h skip locked"), [
     "2026-04-15T19:01:00.000Z",
   ]);
   expect(query).toHaveBeenCalledWith(expect.stringContaining("update holds"), [

--- a/booking-api/src/holds.ts
+++ b/booking-api/src/holds.ts
@@ -155,6 +155,16 @@ export interface HoldRepository {
     newSmoobuReservationId: number;
     newSmoobuChannelId: SmoobuChannelId;
   }): Promise<HoldRecord>;
+  /**
+   * Moves an active hold to `converted` in place, keeping its current Smoobu
+   * reservation id and channel. Called synchronously the instant a booking is
+   * confirmed (PayPal capture / staff deposit), *before* the Smoobu-side
+   * promotion runs, so the hold leaves the expiry sweep's reach
+   * (`status in ('creating','active')`) even if promotion later fails. Idempotent:
+   * a hold already `converted` is returned unchanged. A hold the sweep already
+   * expired is returned as-is (the caller logs it for recovery).
+   */
+  markHoldConfirmed(holdId: string): Promise<HoldRecord>;
   expireHold(holdId: string): Promise<HoldRecord>;
   cancelHold(holdId: string): Promise<HoldRecord>;
   listExpiredHolds(now: string): Promise<HoldRecord[]>;
@@ -458,7 +468,7 @@ export class RdsHoldRepository implements HoldRepository {
           smoobu_channel_id = $3,
           updated_at = now()
         where id = $1
-          and status = 'active'
+          and status in ('active', 'converted')
         returning ${HOLD_COLUMNS}
       `,
       [input.holdId, input.newSmoobuReservationId, input.newSmoobuChannelId]
@@ -471,16 +481,53 @@ export class RdsHoldRepository implements HoldRepository {
     return this.throwMissingOrInvalidTransition(input.holdId, "active", "converted");
   }
 
+  async markHoldConfirmed(holdId: string): Promise<HoldRecord> {
+    const result = await this.pool.query<HoldRow>(
+      `
+        update holds
+        set
+          status = 'converted',
+          converted_at = coalesce(converted_at, now()),
+          updated_at = now()
+        where id = $1
+          and status in ('active', 'converted')
+        returning ${HOLD_COLUMNS}
+      `,
+      [holdId]
+    );
+
+    if (result.rows[0]) {
+      return mapHoldRow(result.rows[0]);
+    }
+
+    // The hold is no longer active/converted — almost always because the expiry
+    // sweep won an exact-instant race and flipped it to `expired`. Return it as-is
+    // so the caller can log for recovery; the Smoobu-side promotion still runs and
+    // re-creates the reservation for the (already paid) booking.
+    const existing = await this.getById(holdId);
+    if (existing) {
+      return existing;
+    }
+
+    throw new ApiError(500, "hold_state_invalid", `Hold ${holdId} is missing.`);
+  }
+
   async listExpiredHolds(now: string): Promise<HoldRecord[]> {
     const result = await this.pool.query<HoldRow>(
       `
         with expired_candidates as (
-          select id
-          from holds
-          where status in ('creating', 'active')
-            and expires_at <= $1
-          order by expires_at asc
-          for update skip locked
+          select h.id
+          from holds h
+          left join booking_sessions bs on bs.id = h.booking_session_id
+          where h.status in ('creating', 'active')
+            and h.expires_at <= $1
+            -- Never expire (and cancel the Smoobu reservation of) a booking that
+            -- has already been paid/confirmed. The hold can still read 'active'
+            -- here if the confirming path's promotion has not yet flipped it — the
+            -- session status is the authoritative signal. See markHoldConfirmed.
+            and coalesce(bs.status, 'quoted') <> 'booking_confirmed'
+          order by h.expires_at asc
+          for update of h skip locked
         )
         update holds
         set
@@ -708,6 +755,21 @@ export class InMemoryHoldRepository implements HoldRepository {
     return updated;
   }
 
+  async markHoldConfirmed(holdId: string): Promise<HoldRecord> {
+    const existing = this.getRequiredHold(holdId);
+    if (existing.status !== "active" && existing.status !== "converted") {
+      // Sweep won the race (expired/cancelled) — return as-is for the caller to log.
+      return existing;
+    }
+    const updated: HoldRecord = {
+      ...existing,
+      status: "converted",
+      updatedAt: new Date().toISOString(),
+    };
+    this.holdsById.set(updated.id, updated);
+    return updated;
+  }
+
   async expireHold(holdId: string): Promise<HoldRecord> {
     const existing = this.getRequiredHold(holdId);
     const updated: HoldRecord = {
@@ -842,6 +904,11 @@ export async function createSmoobuBackedHold(
   await reserveHoldIdempotency(config, holds, idempotencyKey, requestHash, flavour.idempotencyScope);
 
   let creatingHold: HoldRecord | undefined;
+  // Hoisted so the catch can clean up a Smoobu reservation that was created just
+  // before a later step (activateHold / markHoldActive) threw — otherwise it is
+  // orphaned, silently blocking the calendar (R4).
+  let smoobuClient: Awaited<ReturnType<typeof createSmoobuClient>> | undefined;
+  let createdSmoobuReservationId: number | undefined;
   try {
     const session = await requireQuotedSession(bookingSessions, holdRequest);
     const property = requireProperty(holdRequest.propertyId);
@@ -859,7 +926,7 @@ export async function createSmoobuBackedHold(
         retryable: false,
       });
     }
-    const smoobuClient = await createSmoobuClient(config);
+    smoobuClient = await createSmoobuClient(config);
     const recheckedPrice = await recheckPropertyAvailability(holdRequest, session, property, smoobuClient, customerId, request.observability);
 
     // When non-refundable, the recheck includes the #norefundallowed discount
@@ -936,6 +1003,7 @@ export async function createSmoobuBackedHold(
       request.observability
     );
     const smoobuReservationId = parseSmoobuReservationId(createdReservation.data);
+    createdSmoobuReservationId = smoobuReservationId;
 
     const activeHold = await holds.activateHold({
       holdId: creatingHold.id,
@@ -1016,6 +1084,18 @@ export async function createSmoobuBackedHold(
 
     return jsonResponse(200, responseBody, request.responseHeaders);
   } catch (error) {
+    // If the Smoobu reservation was created but a later step failed, cancel it so
+    // it does not orphan and block the calendar. Best-effort: a failure here is
+    // logged and left for the reconciliation/expiry sweeps (R4).
+    if (createdSmoobuReservationId && smoobuClient) {
+      await smoobuClient.cancelReservation(createdSmoobuReservationId, request.observability).catch((cancelError) => {
+        request.observability.logger.error("hold_create_orphan_cancel_failed", {
+          bookingSessionId: holdRequest.bookingSessionId,
+          smoobuReservationId: createdSmoobuReservationId,
+          error: cancelError instanceof Error ? cancelError.message : String(cancelError),
+        });
+      });
+    }
     if (creatingHold) {
       await holds.failHold({
         holdId: creatingHold.id,

--- a/booking-api/src/paymentReconciliation.test.ts
+++ b/booking-api/src/paymentReconciliation.test.ts
@@ -587,3 +587,27 @@ describe("reconcilePendingPayments", () => {
     );
   });
 });
+
+describe("reconcilePendingPayments — race-condition regression (R9)", () => {
+  it("confirms a session left in paypal_order_created after its payment was captured", async () => {
+    const sessions = new InMemoryBookingSessionRepository();
+    const payments = new InMemoryPaymentRepository();
+
+    const { session } = await seedPendingPayment(sessions, payments);
+    // The payment captured but the session confirmation never landed — a crash
+    // between markCaptured and markBookingConfirmed. The main scan filters on
+    // payment status ('order_created') and can never re-pick this.
+    await payments.markCaptured({
+      bookingSessionId: session.id,
+      paypalCaptureId: "CAP-R9",
+      capturedAt: NOW,
+    });
+
+    const deps = createDeps({ payments, bookingSessions: sessions });
+    const result = await reconcilePendingPayments(deps);
+
+    expect(result.confirmed).toBe(1);
+    const after = await sessions.getById(session.id);
+    expect(after?.status).toBe("booking_confirmed");
+  });
+});

--- a/booking-api/src/paymentReconciliation.ts
+++ b/booking-api/src/paymentReconciliation.ts
@@ -76,16 +76,21 @@ export async function reconcilePendingPayments(
   const pendingPayments = await payments.listByStatus("order_created");
   result.processed = pendingPayments.length;
 
-  if (pendingPayments.length === 0) {
+  if (pendingPayments.length > 0) {
+    logger.info("payment_reconciliation_started", { count: pendingPayments.length, now });
+    for (const payment of pendingPayments) {
+      await reconcileOnePayment(payment, deps, result, now, staleThresholdMs);
+    }
+  } else {
     logger.debug("payment_reconciliation_empty", { now });
-    return result;
   }
 
-  logger.info("payment_reconciliation_started", { count: pendingPayments.length, now });
-
-  for (const payment of pendingPayments) {
-    await reconcileOnePayment(payment, deps, result, now, staleThresholdMs);
-  }
+  // Recover sessions stranded mid-confirm (R9): the payment was captured but the
+  // session never advanced to booking_confirmed — a crash between markCaptured and
+  // markBookingConfirmed in the capture endpoint or webhook. The main scan above
+  // filters on *payment* status ('order_created') and can never re-pick these,
+  // since their payment already reads 'captured'.
+  await recoverStrandedConfirmations(deps, result, now);
 
   logger.info("payment_reconciliation_completed", {
     processed: result.processed,
@@ -237,6 +242,36 @@ async function confirmFromReconciliation(
       errorCode: "db_update_failed",
       message: errMsg,
     });
+  }
+}
+
+/**
+ * Confirms sessions that were left in `paypal_order_created` even though their
+ * payment already reached `captured` — a crash between markCaptured and
+ * markBookingConfirmed. Enumerating by *session* status keeps the candidate set
+ * small and current (only genuinely pending sessions), and confirmFromReconciliation
+ * re-uses the idempotent markCaptured + CAS markBookingConfirmed path.
+ */
+async function recoverStrandedConfirmations(
+  deps: ReconciliationDependencies,
+  result: ReconciliationResult,
+  now: string
+): Promise<void> {
+  const { payments, bookingSessions, logger } = deps;
+  if (!bookingSessions.listByStatus) {
+    return;
+  }
+
+  const strandedSessions = await bookingSessions.listByStatus("paypal_order_created");
+  for (const session of strandedSessions) {
+    const payment = await payments.getByBookingSessionId(session.id);
+    if (payment?.status === "captured" && payment.paypalCaptureId) {
+      logger.warn("payment_reconciliation_recovering_stranded_confirm", {
+        bookingSessionId: session.id,
+        paypalCaptureId: payment.paypalCaptureId,
+      });
+      await confirmFromReconciliation(payment, payment.paypalCaptureId, now, deps, result);
+    }
   }
 }
 

--- a/booking-api/src/paypalOrders.test.ts
+++ b/booking-api/src/paypalOrders.test.ts
@@ -1,4 +1,5 @@
 import { createBookingApiHandler } from "./app";
+import { derivePaypalRequestId } from "./paypalOrders";
 import { InMemoryBookingSessionRepository } from "./bookingSessions";
 import { InMemoryHoldRepository } from "./holds";
 import { InMemoryPaymentRepository } from "./payments";
@@ -393,12 +394,14 @@ test("POST /api/paypal/order sends PayPal-Request-Id header and correct order pa
   expect(orderCall).toBeDefined();
   const orderInit = orderCall?.[1];
 
-  // PayPal-Request-Id must be set and be a UUID
+  // PayPal-Request-Id must be set and be a deterministic (sha256-hex) id derived
+  // from the Idempotency-Key + session, so a retried createOrder is deduped by
+  // PayPal rather than creating a second order (R7).
   expect(orderInit?.headers).toMatchObject({
     Authorization: "Bearer pp-access-token",
   });
   const paypalRequestId = (orderInit?.headers as Record<string, string>)["PayPal-Request-Id"];
-  expect(paypalRequestId).toMatch(/^[0-9a-f-]{36}$/i);
+  expect(paypalRequestId).toMatch(/^[0-9a-f]{64}$/i);
 
   // Order payload correctness
   const orderPayload = JSON.parse(orderInit?.body as string);
@@ -437,8 +440,8 @@ test("POST /api/paypal/order advances session status to paypal_order_created", a
   const payment = await payments.getByBookingSessionId(bookingSessionId);
   expect(payment?.status).toBe("order_created");
   expect(payment?.paypalOrderId).toBe("PAY-ORDER-123");
-  expect(payment?.paypalRequestIdOrder).toMatch(/^[0-9a-f-]{36}$/i);
-  expect(payment?.paypalRequestIdCapture).toMatch(/^[0-9a-f-]{36}$/i);
+  expect(payment?.paypalRequestIdOrder).toMatch(/^[0-9a-f]{64}$/i);
+  expect(payment?.paypalRequestIdCapture).toMatch(/^[0-9a-f]{64}$/i);
   // The two request IDs must be different
   expect(payment?.paypalRequestIdOrder).not.toBe(payment?.paypalRequestIdCapture);
 });
@@ -813,4 +816,60 @@ test("POST /api/paypal/capture requires Idempotency-Key header", async () => {
   expect(response.statusCode).toBe(400);
   const body = JSON.parse(response.body);
   expect(body.error.code).toBe("missing_idempotency_key");
+});
+
+// ─── Race-condition regression tests ────────────────────────────────────────
+
+test("R3: capture returns 200 (not 500) when the session was confirmed by a concurrent actor", async () => {
+  global.fetch = makeHappyPathFetch() as typeof fetch;
+  const handler = createBookingApiHandler(config);
+  const { bookingSessionId } = await setupSessionWithActiveHold(handler);
+
+  await handler(makeOrderEvent({ bookingSessionId }));
+
+  // Simulate a racing PayPal webhook / reconciliation that confirms the session
+  // *between* the capture handler's session read and its markBookingConfirmed:
+  // the real transition succeeds (session → booking_confirmed) and then the
+  // capture endpoint's own CAS finds 0 rows and throws. R3 must swallow that and
+  // return the confirmed booking rather than a 500.
+  const realMarkConfirmed = bookingSessions.markBookingConfirmed.bind(bookingSessions);
+  jest
+    .spyOn(bookingSessions, "markBookingConfirmed")
+    .mockImplementationOnce(async (input) => {
+      await realMarkConfirmed(input);
+      throw new Error(
+        `Cannot transition booking session ${input.bookingSessionId} to booking_confirmed: expected paypal_order_created, got booking_confirmed.`
+      );
+    });
+
+  const captureResp = await handler(
+    makeCaptureEvent({ bookingSessionId, paypalOrderId: "PAY-ORDER-123" })
+  );
+
+  expect(captureResp.statusCode).toBe(200);
+  const body = JSON.parse(captureResp.body);
+  expect(body.booking.status).toBe("booking_confirmed");
+
+  const session = await bookingSessions.getById(bookingSessionId);
+  expect(session?.status).toBe("booking_confirmed");
+});
+
+test("R7: PayPal-Request-Id is deterministic per (idempotency key, session, phase)", () => {
+  const a = derivePaypalRequestId("idem-key-1", "session-1", "order");
+  const b = derivePaypalRequestId("idem-key-1", "session-1", "order");
+  // Stable across retries → PayPal dedupes a retried createOrder.
+  expect(a).toBe(b);
+
+  // Order and capture phases differ.
+  expect(derivePaypalRequestId("idem-key-1", "session-1", "order")).not.toBe(
+    derivePaypalRequestId("idem-key-1", "session-1", "capture")
+  );
+  // Different sessions differ even with a reused idempotency key.
+  expect(derivePaypalRequestId("idem-key-1", "session-1", "order")).not.toBe(
+    derivePaypalRequestId("idem-key-1", "session-2", "order")
+  );
+  // Different keys differ.
+  expect(derivePaypalRequestId("idem-key-1", "session-1", "order")).not.toBe(
+    derivePaypalRequestId("idem-key-2", "session-1", "order")
+  );
 });

--- a/booking-api/src/paypalOrders.ts
+++ b/booking-api/src/paypalOrders.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto";
+import { createHash } from "crypto";
 import { BookingSessionRecord, BookingSessionRepository } from "./bookingSessions";
 import { createEmailClient } from "./email";
 import { HoldRepository } from "./holds";
@@ -11,6 +11,14 @@ import { createPayPalClient, PayPalProviderError } from "./paypalClient";
 import { BOOKING_PROPERTIES_BY_ID, listingUrlForLanguage } from "./propertyCatalog";
 import { promoteSmoobuReservation } from "./smoobuPromotion";
 import { ApiResponse, BookingApiConfig, RouteObservability, RouteRequest } from "./types";
+
+/**
+ * Stable PayPal-Request-Id for a given client Idempotency-Key + session + phase.
+ * Same inputs → same id, so a retried createOrder is deduplicated by PayPal.
+ */
+export function derivePaypalRequestId(idempotencyKey: string, bookingSessionId: string, phase: "order" | "capture"): string {
+  return createHash("sha256").update(`${idempotencyKey}:${bookingSessionId}:${phase}`).digest("hex");
+}
 
 function getHoldRepository(config: BookingApiConfig): HoldRepository {
   if (!config.holds) {
@@ -69,9 +77,14 @@ export async function handleCreatePayPalOrder(
     throw new ApiError(409, "hold_no_longer_active", "The hold is no longer active.");
   }
 
-  // Pre-assign both idempotency keys so retries to PayPal are safe
-  const paypalRequestIdOrder = randomUUID();
-  const paypalRequestIdCapture = randomUUID();
+  // Derive the PayPal-Request-Id deterministically from the client's
+  // Idempotency-Key and the session, rather than a fresh UUID per attempt. If a
+  // retry reaches createOrder again (e.g. the previous attempt created the order
+  // on PayPal but crashed before persisting the payment row), PayPal sees the
+  // same request id and returns the *same* order instead of creating a duplicate
+  // (R7). The capture id is likewise stable and persisted for the capture step.
+  const paypalRequestIdOrder = derivePaypalRequestId(idempotencyKey, session.id, "order");
+  const paypalRequestIdCapture = derivePaypalRequestId(idempotencyKey, session.id, "capture");
 
   const paypalClient = await createPayPalClient(config);
 
@@ -258,10 +271,24 @@ export async function handleCapturePayPalOrder(
     capturedAt,
   });
 
-  const confirmedSession = await sessions.markBookingConfirmed({
-    bookingSessionId: session.id,
-    confirmedAt: capturedAt,
-  });
+  let confirmedSession: BookingSessionRecord;
+  try {
+    confirmedSession = await sessions.markBookingConfirmed({
+      bookingSessionId: session.id,
+      confirmedAt: capturedAt,
+    });
+  } catch (error) {
+    // A concurrent webhook or the reconciliation sweep may have confirmed this
+    // session first; markBookingConfirmed's CAS then matches 0 rows and throws.
+    // The payment did succeed, so treat an already-confirmed session as success
+    // instead of surfacing a 500 to the guest (R3).
+    const latest = await sessions.getById(session.id);
+    if (latest?.status === "booking_confirmed") {
+      confirmedSession = latest;
+    } else {
+      throw error;
+    }
+  }
 
   // Also reported from the webhook and the reconciliation sweep. Meta dedupes on
   // event_id and GA4 on transaction_id, so the booking still counts exactly once.
@@ -301,10 +328,22 @@ export async function handleCapturePayPalOrder(
   const holds = getHoldRepository(config);
   const hold = await holds.getByBookingSessionId(session.id).catch(() => undefined);
   if (hold) {
+    // Move the hold to `converted` before the best-effort promotion runs, so the
+    // expiry sweep can never cancel this now-paid booking's Smoobu reservation
+    // even if promotion fails (R1). Fatal-safe: on any error we still attempt
+    // promotion with the hold we have.
+    const confirmedHold = await holds.markHoldConfirmed(hold.id).catch(() => hold);
+    if (confirmedHold.status !== "converted") {
+      request.observability.logger.error("booking_confirmed_hold_already_expired", {
+        bookingSessionId: session.id,
+        holdId: hold.id,
+        holdStatus: confirmedHold.status,
+      });
+    }
     await promoteSmoobuReservation(
       {
         session,
-        hold,
+        hold: confirmedHold,
         notice: buildPaypalConfirmedNotice(session, captureResult.captureId, capturedAt),
         amountCents: captureResult.amountCents,
       },

--- a/booking-api/src/paypalWebhooks.ts
+++ b/booking-api/src/paypalWebhooks.ts
@@ -372,7 +372,7 @@ export async function handlePayPalWebhook(
   // 4. Dedupe — idempotent insert
   const webhookEvents = getWebhookEventRepository(config);
   const payloadHash = sha256(request.rawBody);
-  const { inserted } = await webhookEvents.insertIfNew({
+  const { inserted, record } = await webhookEvents.insertIfNew({
     provider: "paypal",
     externalEventId,
     eventType,
@@ -380,7 +380,12 @@ export async function handlePayPalWebhook(
     payload: event,
   });
 
-  if (!inserted) {
+  // Only treat a redelivery as a duplicate once it has actually been *processed*.
+  // If a prior delivery inserted the row but crashed before markProcessed, the
+  // status is still 'pending'/'failed' and we must reprocess — otherwise a missed
+  // capture confirmation would be silently swallowed (R8). Downstream transitions
+  // are all CAS-guarded, so reprocessing an already-applied event is a no-op.
+  if (!inserted && record.status === "processed") {
     request.observability.recordStateTransition({
       entityType: "webhook_event",
       toState: "duplicate",
@@ -587,6 +592,15 @@ async function handleCaptureCompleted(
     if (holds) {
       const hold = await holds.getByBookingSessionId(session.id).catch(() => undefined);
       if (hold) {
+        // Take the hold out of the expiry sweep's reach before promotion (R1).
+        const confirmedHold = await holds.markHoldConfirmed(hold.id).catch(() => hold);
+        if (confirmedHold.status !== "converted") {
+          request.observability.logger.error("booking_confirmed_hold_already_expired", {
+            bookingSessionId: session.id,
+            holdId: hold.id,
+            holdStatus: confirmedHold.status,
+          });
+        }
         // Extract amount from webhook event; fall back to session totalAmountCents
         const captureAmount = capture?.amount?.value
           ? Math.round(parseFloat(capture.amount.value) * 100)
@@ -595,7 +609,7 @@ async function handleCaptureCompleted(
         await promoteSmoobuReservation(
           {
             session,
-            hold,
+            hold: confirmedHold,
             notice: buildPaypalConfirmedNotice(session, captureId, confirmedAt),
             amountCents: captureAmount,
           },

--- a/booking-api/src/smoobuPromotion.test.ts
+++ b/booking-api/src/smoobuPromotion.test.ts
@@ -1,0 +1,206 @@
+import { BookingSessionRecord } from "./bookingSessions";
+import { InMemoryHoldRepository } from "./holds";
+import { promoteSmoobuReservation } from "./smoobuPromotion";
+import { StaticSecretProvider } from "./secrets";
+import { BookingApiConfig, RouteObservability } from "./types";
+
+const GECO_PROPERTY_ID = "b8a1f2e7-86d3-4c30-8f6a-8046a5f9a111";
+const GECO_APARTMENT_ID = 301061;
+const PAPPAGALLO_PROPERTY_ID = "a75f112f-5aa4-46a7-9f64-1a3b5f30b54c";
+const PAPPAGALLO_APARTMENT_ID = 301058;
+const RANA_PROPERTY_ID = "d06f7d50-cbbe-4ec6-954c-3e0f9ac2f2e7";
+const OLD_RESERVATION_ID = 555001;
+const REBLOCK_RESERVATION_ID = 555999;
+const NEW_WEBSITE_RESERVATION_ID = 556100;
+
+const originalFetch = global.fetch;
+
+function createConfig(): BookingApiConfig {
+  return {
+    allowedOrigins: ["https://kalawala.test"],
+    maxBodyBytes: 64 * 1024,
+    secrets: new StaticSecretProvider({
+      smoobuApiKey: "smoobu-secret-value",
+      smoobuApiSecret: "smoobu-api-secret-value",
+      smoobuWebhookSecret: "smoobu-webhook-secret-value",
+      paypalClientId: "paypal-client-id-value",
+      paypalClientSecret: "paypal-client-secret-value",
+      paypalWebhookId: "paypal-webhook-id-value",
+      bookingEncryptionKeyBase64: Buffer.alloc(32, 7).toString("base64"),
+      portalSessionSecret: "portal-session-secret-value",
+      rdsConnectionString: "postgres://booking_user:pw@db.test:5432/kalawala",
+    }),
+    smoobu: {
+      baseUrl: "https://login.smoobu.com",
+      customerId: 9,
+      timeoutMs: 8_000,
+      maxRetries: 0,
+      baseBackoffMs: 250,
+      maxBackoffMs: 2_000,
+      maxRateLimitDelayMs: 60_000,
+      holdChannelId: 11,
+    },
+    paypal: { baseUrl: "https://api-m.sandbox.paypal.com", timeoutMs: 10_000, orderReturnUrl: "", orderCancelUrl: "" },
+    hold: { defaultTtlMinutes: 60, idempotencyTtlMinutes: 1440, staleIdempotencyLockSeconds: 120 },
+    abuseProtection: { enabled: false, captchaChallengesEnabled: false, maxTrackedBuckets: 100 },
+    email: { fromAddress: "test@kalawala.com", region: "us-east-1", disabled: true },
+    observability: { serviceName: "booking-api", environment: "test", logLevel: "silent", metricsEnabled: false },
+  };
+}
+
+function createObservability(): RouteObservability {
+  return {
+    logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    recordProviderCall: jest.fn(),
+    recordStateTransition: jest.fn(),
+    recordSecurityEvent: jest.fn(),
+  };
+}
+
+function createSession(): BookingSessionRecord {
+  return {
+    id: "22222222-2222-4222-8222-222222222222",
+    reservationPublicId: "KWL-ABCDEFGH",
+    propertyId: GECO_PROPERTY_ID,
+    arrivalDate: "2026-05-01",
+    departureDate: "2026-05-05",
+    guests: 2,
+    language: "en",
+    guest: { firstName: "Ana", lastName: "Mora", email: "ana@example.com" },
+    totalAmountCents: 40000,
+  } as unknown as BookingSessionRecord;
+}
+
+async function seedConvertedHold(holds: InMemoryHoldRepository): Promise<string> {
+  const hold = await holds.createCreatingHold({
+    bookingSessionId: "22222222-2222-4222-8222-222222222222",
+    propertyId: GECO_PROPERTY_ID,
+    arrivalDate: "2026-05-01",
+    departureDate: "2026-05-05",
+    expiresAt: "2026-06-01T00:00:00.000Z",
+    smoobuChannelId: 11,
+    smoobuCreatePayloadHash: "hash",
+  });
+  await holds.activateHold({ holdId: hold.id, smoobuReservationId: OLD_RESERVATION_ID });
+  await holds.markHoldConfirmed(hold.id);
+  return hold.id;
+}
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  jest.restoreAllMocks();
+});
+
+// ─── Race-condition regression: promotion never leaves dates unblocked (R2) ───
+
+test("R2: re-blocks the dates when the website reservation fails after the old block was deleted", async () => {
+  // DELETE old block → ok. POST channel 70 (website) → fail. POST channel 11 (re-block) → ok.
+  global.fetch = jest.fn(async (url: string | URL, init?: RequestInit) => {
+    const { pathname } = new URL(url.toString());
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    if (method === "DELETE" && pathname.startsWith("/api/reservations/")) {
+      return new Response(JSON.stringify({ success: true }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    if (method === "POST" && pathname === "/api/reservations") {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      if (body.channelId === 70) {
+        return new Response(JSON.stringify({ detail: "unavailable" }), { status: 500, headers: { "content-type": "application/json" } });
+      }
+      // Re-block on the Blocked channel (11) succeeds.
+      return new Response(JSON.stringify({ id: REBLOCK_RESERVATION_ID }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    return new Response(JSON.stringify({ detail: "unexpected" }), { status: 500, headers: { "content-type": "application/json" } });
+  }) as typeof fetch;
+
+  const holds = new InMemoryHoldRepository();
+  const holdId = await seedConvertedHold(holds);
+  const hold = (await holds.getByBookingSessionId("22222222-2222-4222-8222-222222222222"))!;
+
+  const result = await promoteSmoobuReservation(
+    { session: createSession(), hold, notice: "confirmed", amountCents: 40000 },
+    holds,
+    createConfig(),
+    createObservability()
+  );
+
+  expect(result.promoted).toBe(false);
+  expect(result.error).toBe("create_after_delete_failed_reblocked");
+  expect(result.newSmoobuReservationId).toBe(REBLOCK_RESERVATION_ID);
+
+  // The hold now points at the restored (blocked) reservation, not the deleted one.
+  const after = await holds.getByBookingSessionId("22222222-2222-4222-8222-222222222222");
+  expect(after?.smoobuReservationId).toBe(REBLOCK_RESERVATION_ID);
+  expect(after?.smoobuChannelId).toBe(11);
+  expect(holdId).toBe(after?.id);
+});
+
+// ─── Regression: promote onto the HOLD's property, never a drifted session ────
+// Reproduces the KWL-MWRCRU5G incident: a Casa Pappagallo deposit hold whose
+// booking session had a drifted propertyId (Rana) was confirmed/sold onto Rana's
+// apartment. Promotion must key the apartment off the hold, not the session.
+
+test("promotes onto the hold's apartment even when session.propertyId has drifted", async () => {
+  const createPayloads: Array<Record<string, unknown>> = [];
+  global.fetch = jest.fn(async (url: string | URL, init?: RequestInit) => {
+    const { pathname } = new URL(url.toString());
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    if (method === "DELETE" && pathname.startsWith("/api/reservations/")) {
+      return new Response(JSON.stringify({ success: true }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    if (method === "POST" && pathname === "/api/reservations") {
+      createPayloads.push(JSON.parse(String(init?.body ?? "{}")));
+      return new Response(JSON.stringify({ id: NEW_WEBSITE_RESERVATION_ID }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    return new Response(JSON.stringify({ detail: "unexpected" }), { status: 500, headers: { "content-type": "application/json" } });
+  }) as typeof fetch;
+
+  const holds = new InMemoryHoldRepository();
+  // The blocked hold the guest actually created: Casa Pappagallo.
+  const hold = await holds.createCreatingHold({
+    bookingSessionId: "22222222-2222-4222-8222-222222222222",
+    propertyId: PAPPAGALLO_PROPERTY_ID,
+    arrivalDate: "2026-09-12",
+    departureDate: "2026-09-13",
+    expiresAt: "2026-08-05T00:00:00.000Z",
+    smoobuChannelId: 11,
+    smoobuCreatePayloadHash: "hash",
+  });
+  await holds.activateHold({ holdId: hold.id, smoobuReservationId: OLD_RESERVATION_ID });
+  await holds.markHoldConfirmed(hold.id);
+  const confirmedHold = (await holds.getByBookingSessionId("22222222-2222-4222-8222-222222222222"))!;
+
+  // Session whose propertyId has drifted to Rana (the bug's precondition).
+  const session = {
+    id: "22222222-2222-4222-8222-222222222222",
+    reservationPublicId: "KWL-MWRCRU5G",
+    propertyId: RANA_PROPERTY_ID,
+    arrivalDate: "2026-09-12",
+    departureDate: "2026-09-13",
+    guests: 3,
+    language: "es",
+    guest: { firstName: "Melissa", lastName: "Monge", email: "meelim043@example.com" },
+    totalAmountCents: 19400,
+  } as unknown as BookingSessionRecord;
+
+  const observability = createObservability();
+  const result = await promoteSmoobuReservation(
+    { session, hold: confirmedHold, notice: "confirmed", amountCents: 19400 },
+    holds,
+    createConfig(),
+    observability
+  );
+
+  expect(result.promoted).toBe(true);
+  // The website reservation must be created on Pappagallo (the hold), NOT Rana.
+  expect(createPayloads).toHaveLength(1);
+  expect(createPayloads[0].apartmentId).toBe(PAPPAGALLO_APARTMENT_ID);
+  expect(createPayloads[0].apartmentId).not.toBe(GECO_APARTMENT_ID);
+
+  // And the drift is surfaced for investigation.
+  expect(observability.logger.error).toHaveBeenCalledWith(
+    "smoobu_promotion_property_mismatch",
+    expect.objectContaining({ holdPropertyId: PAPPAGALLO_PROPERTY_ID, sessionPropertyId: RANA_PROPERTY_ID })
+  );
+});

--- a/booking-api/src/smoobuPromotion.ts
+++ b/booking-api/src/smoobuPromotion.ts
@@ -70,11 +70,29 @@ export async function promoteSmoobuReservation(
     return { promoted: false, error: "no_smoobu_reservation_id" };
   }
 
-  const property = BOOKING_PROPERTIES_BY_ID.get(session.propertyId ?? "");
+  // The apartment we promote onto MUST be the one the blocked hold already
+  // occupies (hold.propertyId) — never a re-derivation from the mutable
+  // session.propertyId. The hold's property is immutable, matches the reservation
+  // being replaced, and matches the property named in the staff email. Trusting
+  // session.propertyId here let a Pappagallo deposit (KWL-MWRCRU5G) be sold onto
+  // Rana when the session's property drifted during a multi-home booking. If the
+  // two disagree, promote correctly AND surface it for investigation.
+  if (session.propertyId && session.propertyId !== hold.propertyId) {
+    logger.error("smoobu_promotion_property_mismatch", {
+      bookingSessionId: session.id,
+      holdId: hold.id,
+      holdPropertyId: hold.propertyId,
+      sessionPropertyId: session.propertyId,
+      action: "manual_intervention_required",
+    });
+  }
+
+  const property = BOOKING_PROPERTIES_BY_ID.get(hold.propertyId);
   if (!property) {
     logger.warn("smoobu_promotion_skipped_no_property", {
       bookingSessionId: session.id,
-      propertyId: session.propertyId,
+      holdId: hold.id,
+      propertyId: hold.propertyId,
     });
     return { promoted: false, error: "property_not_found" };
   }
@@ -131,16 +149,13 @@ export async function promoteSmoobuReservation(
       oldSmoobuReservationId: hold.smoobuReservationId,
       error: err instanceof Error ? err.message : String(err),
     });
-    // The old reservation was deleted but the new one failed. This is a
-    // problem — the dates are now unblocked on Smoobu. Log as critical.
-    logger.error("smoobu_promotion_dates_unblocked", {
-      bookingSessionId: session.id,
-      arrivalDate: session.arrivalDate,
-      departureDate: session.departureDate,
-      propertyId: session.propertyId,
-      action: "manual_intervention_required",
-    });
-    return { promoted: false, error: "create_after_delete_failed" };
+    // The old blocked reservation was deleted but the website one failed — the
+    // dates would be back on sale for a booking that is already paid. Smoobu
+    // rejects creating a reservation over a still-existing block, so we can't
+    // create-before-delete; instead we compensate by re-blocking the dates so
+    // the inventory stays held. A later promotion retry can finish the move to
+    // the website channel (R2).
+    return reblockAfterCreateFailure(smoobuClient, holds, hold, session, property, notice, amountCents, observability, logger);
   }
 
   // Step 3: Update local hold to converted with new reservation ID
@@ -252,6 +267,66 @@ async function fallbackUpdateReservation(
       error: updateErr instanceof Error ? updateErr.message : String(updateErr),
     });
     return { promoted: false, error: "delete_and_update_both_failed" };
+  }
+}
+
+/**
+ * Compensating action when the website reservation could not be created after the
+ * old blocked reservation was already deleted. Re-creates a Blocked-channel
+ * reservation so the (paid) booking's dates are not put back on sale, and points
+ * the local hold at the restored reservation. If even this fails, logs a critical
+ * alert for manual intervention.
+ */
+const BLOCKED_CHANNEL_ID: SmoobuChannelId = 11;
+
+async function reblockAfterCreateFailure(
+  smoobuClient: SmoobuClient,
+  holds: HoldRepository,
+  hold: HoldRecord,
+  session: BookingSessionRecord,
+  property: BookingProperty,
+  notice: string,
+  amountCents: number,
+  observability: RouteObservability,
+  logger: ObservabilityLogger
+): Promise<PromoteSmoobuReservationResult> {
+  try {
+    const payload = {
+      ...buildConfirmedReservationPayload(session, property, `RE-BLOCKED after failed promotion. ${notice}`, amountCents),
+      channelId: BLOCKED_CHANNEL_ID,
+    };
+    const response = await smoobuClient.createReservation<SmoobuCreateReservationResponse>(payload, observability);
+    const reblockId = parseSmoobuReservationId(response.data);
+
+    // Point the hold at the restored reservation (still on the blocked channel) so
+    // it is not orphaned and a later promotion retry can pick it up.
+    await holds
+      .convertHold({ holdId: hold.id, newSmoobuReservationId: reblockId, newSmoobuChannelId: BLOCKED_CHANNEL_ID })
+      .catch((convertErr) => {
+        logger.warn("smoobu_promotion_reblock_hold_update_failed", {
+          bookingSessionId: session.id,
+          holdId: hold.id,
+          reblockId,
+          error: convertErr instanceof Error ? convertErr.message : String(convertErr),
+        });
+      });
+
+    logger.warn("smoobu_promotion_reblocked_after_create_failure", {
+      bookingSessionId: session.id,
+      oldSmoobuReservationId: hold.smoobuReservationId,
+      reblockId,
+    });
+    return { promoted: false, error: "create_after_delete_failed_reblocked", newSmoobuReservationId: reblockId };
+  } catch (reblockErr) {
+    logger.error("smoobu_promotion_dates_unblocked", {
+      bookingSessionId: session.id,
+      arrivalDate: session.arrivalDate,
+      departureDate: session.departureDate,
+      propertyId: session.propertyId,
+      error: reblockErr instanceof Error ? reblockErr.message : String(reblockErr),
+      action: "manual_intervention_required",
+    });
+    return { promoted: false, error: "create_after_delete_failed" };
   }
 }
 

--- a/booking-api/src/smoobuWebhooks.test.ts
+++ b/booking-api/src/smoobuWebhooks.test.ts
@@ -422,3 +422,31 @@ test("POST /api/webhooks/smoobu returns 401 when webhook secret is wrong", async
   const body = JSON.parse(response.body);
   expect(body.error.code).toBe("webhook_unauthorized");
 });
+
+// ─── Race-condition regression: webhook reprocess gate (R8) ───────────────────
+
+test("R8: a redelivery of an event left un-processed is reprocessed, not swallowed as duplicate", async () => {
+  const handler = createBookingApiHandler(config);
+  const payload = { action: "newReservation", data: { id: 778899, apartmentId: 2 } };
+
+  // Simulate the first delivery crashing after insertIfNew but before markProcessed:
+  // the stored webhook_event row is left 'pending'.
+  jest.spyOn(webhookEvents, "markProcessed").mockImplementationOnce(async () => {});
+
+  const first = await handler(makeSmoobuWebhookRequest(payload));
+  expect(first.statusCode).toBe(200);
+  expect(JSON.parse(first.body).duplicate).toBeUndefined();
+
+  // Redelivery: because the stored event is still 'pending', the handler must
+  // reprocess it rather than short-circuit it as a duplicate. (Old behavior would
+  // return { duplicate: true } and silently drop the work.)
+  const second = await handler(makeSmoobuWebhookRequest(payload));
+  expect(second.statusCode).toBe(200);
+  expect(JSON.parse(second.body).duplicate).toBeUndefined();
+
+  // Now that it has been processed, a further redelivery IS a duplicate — the gate
+  // still dedupes and does not reprocess forever.
+  const third = await handler(makeSmoobuWebhookRequest(payload));
+  expect(third.statusCode).toBe(200);
+  expect(JSON.parse(third.body).duplicate).toBe(true);
+});

--- a/booking-api/src/smoobuWebhooks.ts
+++ b/booking-api/src/smoobuWebhooks.ts
@@ -53,7 +53,7 @@ export async function handleSmoobuWebhook(
   const webhookEvents = getWebhookEventRepository(config);
   const payloadHash = sha256(request.rawBody);
 
-  const { inserted } = await webhookEvents.insertIfNew({
+  const { inserted, record } = await webhookEvents.insertIfNew({
     provider: "smoobu",
     externalEventId: dedupeKey,
     eventType: payload.action,
@@ -61,7 +61,10 @@ export async function handleSmoobuWebhook(
     payload: body,
   });
 
-  if (!inserted) {
+  // Only short-circuit a redelivery once it has actually been processed; a row
+  // left 'pending'/'failed' by a crashed prior delivery must be reprocessed
+  // rather than swallowed (R8). Action handlers are idempotent / CAS-guarded.
+  if (!inserted && record.status === "processed") {
     request.observability.recordStateTransition({
       entityType: "webhook_event",
       toState: "duplicate",


### PR DESCRIPTION
## Summary

Hardens the hold → confirm → expiry lifecycle in the booking API against concurrent execution paths that could double-book a property, orphan a Smoobu reservation, or cancel a booking that was already paid. Each fix is annotated in-code with its `R#` tag.

| # | Race | Fix |
|---|------|-----|
| **R1** | Expiry sweep cancels a Smoobu reservation for a booking confirmed moments earlier | Mark the hold `converted` synchronously the instant a booking is confirmed (PayPal capture, webhook, staff deposit), *before* the best-effort promotion — new `HoldRepository.markHoldConfirmed`. Expiry sweep also excludes `booking_confirmed` sessions (RDS join + in-memory guard). |
| **R2** | Website reservation create fails after the blocked one was deleted → dates back on sale for a paid booking | Compensate by re-blocking the dates and pointing the hold at the restored reservation; a later promotion retry finishes the move. |
| **R3** | Capture returns 500 when a webhook / reconciliation confirmed the session first | Treat an already-`booking_confirmed` session as success. |
| **R4** | A hold step throws after the Smoobu reservation was created → orphaned block on the calendar | Cancel the just-created reservation on the error path (best-effort, logged). |
| **R5** | Stale-idempotency-lock window shorter than the worst-case Smoobu round-trip → slow request reclaimed and run concurrently with its retry | Validate the window at config load and fail fast on misconfig. |
| **R6** | Late staff deposit-reject cancels a concurrently confirmed booking | Guard the destructive Smoobu cancel behind a `hold_active` CAS (`markStaffRejected`). |
| **R7** | Retried `createOrder` creates a duplicate PayPal order | Derive a deterministic `PayPal-Request-Id` from the client `Idempotency-Key` + session + phase. |
| **R8** | Webhook redelivery swallowed after a prior delivery crashed before `markProcessed` | Only short-circuit once the event row is actually `processed`; reprocess `pending`/`failed`. Downstream transitions are CAS-guarded, so reprocessing is a no-op. |
| **R9** | Session stranded in `paypal_order_created` though its payment reached `captured` | Reconciliation recovers these by session status via the idempotent confirm path. |

Also: Smoobu promotion now targets the immutable `hold.propertyId` (never the mutable `session.propertyId`) and alerts on mismatch.

## Testing

- `npm run typecheck` — clean
- `npm test` — 39 suites, 502 tests passing (new coverage in `config.test.ts`, `smoobuPromotion.test.ts`, and additions across the hold/payment/webhook suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)