### PR TITLE
fix(booking-api): bump brace-expansion to ^5.0.9 to unblock Deploy Backend audit gate

### DIFF
--- a/booking-api/package-lock.json
+++ b/booking-api/package-lock.json
@@ -3403,9 +3403,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/booking-api/package.json
+++ b/booking-api/package.json
@@ -40,6 +40,6 @@
     "pg": "^8.20.0"
   },
   "overrides": {
-    "brace-expansion": "^5.0.8"
+    "brace-expansion": "^5.0.9"
   }
 }


### PR DESCRIPTION
## Problem
The **Deploy Backend** workflow (`deploy-backend.yml`) fails at the **Audit dependencies** step, which blocks Terraform + Lambda deploy. This has been failing on `main` and on feature branches since ~Aug 5.

```
brace-expansion  4.0.0 - 5.0.8   Severity: high
DoS via unbounded intermediate arrays (GHSA-rgw5-rvv9-x895)
##[error]Critical or high vulnerabilities found in booking-api dependencies
```

- Transitive **dev-dependency only**: `jest`/`ts-jest` → `glob`/`minimatch` → `brace-expansion`. No runtime/Lambda impact.
- Not introduced by any recent PR — the advisory (and patched `5.0.9`) were published recently; the gate re-audits every run and started failing then.
- The frontend workflow (`main.yml`) only gates on **critical**, so it was unaffected; the backend gate fails on **high or critical**.

## Fix
The existing `booking-api` override was `"brace-expansion": "^5.0.8"`, which predated the patched release. Bumped to `^5.0.9` and refreshed the lockfile.

```
brace-expansion 5.0.8 => 5.0.9
```

## Verification
```
$ cd booking-api && npm audit --audit-level=high
found 0 vulnerabilities   (exit 0)
$ npm ls brace-expansion
brace-expansion@5.0.9 overridden
```
Diff is 2 files: `booking-api/package.json` (1 line) + `booking-api/package-lock.json` (brace-expansion version/resolved only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)