### PR TITLE
fix(prerender): fix FontAwesome hydration mismatch (partial hydration cleanup)

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,10 +96,7 @@
   },
   "reactSnap": {
     "source": "build",
-    "minifyHtml": {
-      "collapseWhitespace": false,
-      "removeComments": true
-    },
+    "minifyHtml": false,
     "puppeteerArgs": [
       "--no-sandbox",
       "--disable-setuid-sandbox"


### PR DESCRIPTION
## Summary

The homepage (and every pre-rendered route) logs React hydration errors on load — `#418` ×2 and `#423`. These are **hydration mismatches**: react-snap's pre-rendered HTML disagrees with React's first client render, so React throws away the pre-rendered DOM and re-renders the whole root.

This PR fixes **one confirmed cause**. It does **not** fully clear the console yet — see *Remaining work*.

## Root cause (this PR)

- `@fortawesome/react-fontawesome@0.2.2` renders every icon's `className` with a **trailing space** (`"svg-inline--fa fa-calendar-days "`) — its `(className || '').split(' ')` appends an empty class.
- react-snap runs the output through `html-minifier`, which **trims trailing whitespace from attribute values regardless of options** (verified: it strips it even with `collapseWhitespace: false`).
- Result: the pre-rendered HTML has no trailing space, React's client render does → **all 54 icons mismatch** on every pre-rendered route → `#418`/`#423`.

## Fix

Set `reactSnap.minifyHtml: false` so react-snap serializes the exact DOM React produced. `collapseWhitespace` was already `false`, so the only active minification was `removeComments`; size impact is negligible (gzip absorbs it) and hydration fidelity is worth far more than that in a prerender + hydrate setup.

## Verification

Reproduced the live failure locally (`build-local` + `react-snap` via system Chrome + `serve`), diffed server-vs-client DOM, and read the un-minified warnings with a development-React build. This change removes the FontAwesome divergences — the first server/client mismatch moves from byte ~1,500 to ~123,000.

## Remaining work (follow-up)

A **second, independent** hydration mismatch remains in the Home / Suspense region (surfaces via `MessageTipContainer`). Ruled out during investigation: cookie banner (`isPrerender`-guarded), random popup (25–50 s delay, never baked into the crawl), `WelcomeSlider` (already static), `fetchPriority` (renders identically on both sides). Until that is fixed, the console will not be fully clean. Filing as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFBjnztKk6LcSAHznZUQGt