### PR TITLE
fix(nav): move mobile language flag into the collapsible menu

### DIFF
--- a/src/components/FixedNavigation/FixedNavigation.component.tsx
+++ b/src/components/FixedNavigation/FixedNavigation.component.tsx
@@ -76,9 +76,6 @@ const FixedNavigation = ({ isBlog }: IFixedNavigation) => {
           <a href="/book" className="nav-cta-btn" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("book") }}>
             Book now
           </a>
-          <div className="mobile-flag">
-            <LanguageSwitcher />
-          </div>
           <Navbar.Toggle aria-controls="basic-navbar-nav" className="dark-nav" onClick={handleToggleClick}>
             <img 
               src={SolidBars} 
@@ -96,6 +93,9 @@ const FixedNavigation = ({ isBlog }: IFixedNavigation) => {
             <Nav.Link href="/portal" className="navText" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("portal") }}>My Booking</Nav.Link>
             <Nav.Link href="https://wa.me/50684632276" className="navText" target="_blank" rel="noopener noreferrer">WhatsApp</Nav.Link>
           </Nav>
+          <div className="mobile-flag">
+            <LanguageSwitcher />
+          </div>
         <div className="navbar-flag">
             <a href="/book" className="nav-cta-btn" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("book") }}>
               Book now

--- a/src/components/FixedNavigation/FixedNavigation.componentES.tsx
+++ b/src/components/FixedNavigation/FixedNavigation.componentES.tsx
@@ -76,9 +76,6 @@ const FixedNavigationES = ({ isBlog }: IFixedNavigationES) => {
           <a href="/bookES" className="nav-cta-btn" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("bookES") }}>
             Reservar
           </a>
-          <div className="mobile-flag">
-            <LanguageSwitcher />
-          </div>
           <Navbar.Toggle aria-controls="basic-navbar-nav" className="dark-nav" onClick={handleToggleClick}>
             <img src={SolidBars} style={{ height: "25px" }} alt="Menu toggle" />
           </Navbar.Toggle>
@@ -90,6 +87,9 @@ const FixedNavigationES = ({ isBlog }: IFixedNavigationES) => {
             <Nav.Link href="/portalES" className="navText" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("portalES") }}>Mi Reserva</Nav.Link>
             <Nav.Link href="https://wa.me/50684632276" className="navText" target="_blank" rel="noopener noreferrer">WhatsApp</Nav.Link>
           </Nav>
+          <div className="mobile-flag">
+            <LanguageSwitcher />
+          </div>
         <div className="navbar-flag">
             <a href="/bookES" className="nav-cta-btn" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("bookES") }}>
               Reservar

--- a/src/components/FixedNavigation/FixedNavigation.componentNam.tsx
+++ b/src/components/FixedNavigation/FixedNavigation.componentNam.tsx
@@ -55,9 +55,6 @@ const FixedNavigationNam = ({ isBlog }: IFixedNavigation) => {
           <a href="HomeNam#body" className="nav-cta-btn" onClick={() => { handleLinkClick("HomeNam#body") }}>
             Book now
           </a>
-          <div className="mobile-flag">
-            <LanguageSwitcher />
-          </div>
           <Navbar.Toggle aria-controls="basic-navbar-nav" className="dark-nav" onClick={handleToggleClick}>
             <img src={SolidBars} style={{ height: "25px" }} alt="Menu toggle" />
           </Navbar.Toggle>
@@ -69,6 +66,9 @@ const FixedNavigationNam = ({ isBlog }: IFixedNavigation) => {
             <Nav.Link href="/portal" className="navText" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("portal") }}>My Booking</Nav.Link>
             <Nav.Link href="https://wa.me/50684632276" className="navText" target="_blank" rel="noopener noreferrer">WhatsApp</Nav.Link>
           </Nav>
+          <div className="mobile-flag">
+            <LanguageSwitcher />
+          </div>
         <div className="navbar-flag">
             <a href="HomeNam#body" className="nav-cta-btn" onClick={() => { handleLinkClick("HomeNam#body") }}>
               Book now

--- a/src/components/FixedNavigation/FixedNavigation.componentNamES.tsx
+++ b/src/components/FixedNavigation/FixedNavigation.componentNamES.tsx
@@ -55,9 +55,6 @@ const FixedNavigationNamES = ({ isBlog }: IFixedNavigation) => {
           <a href="HomeNamES#body" className="nav-cta-btn" onClick={() => { handleLinkClick("HomeNamES#body") }}>
             Reservar
           </a>
-          <div className="mobile-flag">
-            <LanguageSwitcher />
-          </div>
           <Navbar.Toggle aria-controls="basic-navbar-nav" className="dark-nav" onClick={handleToggleClick}>
             <img 
               src={SolidBars} 
@@ -75,6 +72,9 @@ const FixedNavigationNamES = ({ isBlog }: IFixedNavigation) => {
             <Nav.Link href="/portalES" className="navText" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("portalES") }}>Mi Reserva</Nav.Link>
             <Nav.Link href="https://wa.me/50684632276" className="navText" target="_blank" rel="noopener noreferrer">WhatsApp</Nav.Link>
           </Nav>
+          <div className="mobile-flag">
+            <LanguageSwitcher />
+          </div>
         <div className="navbar-flag">
             <a href="HomeNamES#body" className="nav-cta-btn" onClick={() => { handleLinkClick("HomeNamES#body") }}>
               Reservar

--- a/src/components/FixedNavigation/FixedNavigation.componentRIB.tsx
+++ b/src/components/FixedNavigation/FixedNavigation.componentRIB.tsx
@@ -55,9 +55,6 @@ const FixedNavigationRib = ({ isBlog }: IFixedNavigation) => {
           <a href="HomeVillas#callToAction" className="nav-cta-btn" onClick={() => { handleLinkClick("HomeVillas#callToAction") }}>
             Book now
           </a>
-          <div className="mobile-flag">
-            <LanguageSwitcher />
-          </div>
           <Navbar.Toggle aria-controls="basic-navbar-nav" className="dark-nav" onClick={handleToggleClick}>
             <img src={SolidBars} style={{ height: "25px" }} alt="Menu toggle" />
           </Navbar.Toggle>
@@ -69,6 +66,9 @@ const FixedNavigationRib = ({ isBlog }: IFixedNavigation) => {
             <Nav.Link href="/portal" className="navText" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("portal") }}>My Booking</Nav.Link>
             <Nav.Link href="https://wa.me/50684632276" className="navText" target="_blank" rel="noopener noreferrer">WhatsApp</Nav.Link>
           </Nav>
+          <div className="mobile-flag">
+            <LanguageSwitcher />
+          </div>
         <div className="navbar-flag">
             <a href="HomeVillas#callToAction" className="nav-cta-btn" onClick={() => { handleLinkClick("HomeVillas#callToAction") }}>
               Book now

--- a/src/components/FixedNavigation/FixedNavigation.componentRIBES.tsx
+++ b/src/components/FixedNavigation/FixedNavigation.componentRIBES.tsx
@@ -55,9 +55,6 @@ const FixedNavigationRibES = ({ isBlog }: IFixedNavigationES) => {
           <a href="HomeVillasES#callToActionES" className="nav-cta-btn" onClick={() => { handleLinkClick("HomeVillasES#callToActionES") }}>
             Reservar
           </a>
-          <div className="mobile-flag">
-            <LanguageSwitcher />
-          </div>
           <Navbar.Toggle aria-controls="basic-navbar-nav" className="dark-nav" onClick={handleToggleClick}>
             <img src={SolidBars} style={{ height: "25px" }} alt="Menu toggle" />
           </Navbar.Toggle>
@@ -69,6 +66,9 @@ const FixedNavigationRibES = ({ isBlog }: IFixedNavigationES) => {
             <Nav.Link href="/portalES" className="navText" onClick={(e: React.MouseEvent) => { e.preventDefault(); handleLinkClick("portalES") }}>Mi Reserva</Nav.Link>
             <Nav.Link href="https://wa.me/50684632276" className="navText" target="_blank" rel="noopener noreferrer">WhatsApp</Nav.Link>
           </Nav>
+          <div className="mobile-flag">
+            <LanguageSwitcher />
+          </div>
         <div className="navbar-flag">
             <a href="HomeVillasES#callToActionES" className="nav-cta-btn" onClick={() => { handleLinkClick("HomeVillasES#callToActionES") }}>
               Reservar

--- a/src/components/FixedNavigation/FixedNavigation.style.scss
+++ b/src/components/FixedNavigation/FixedNavigation.style.scss
@@ -145,9 +145,17 @@
     /* Hide desktop flag on mobile */
   }
 
+  /* The flag now lives inside the collapsible menu (not the top bar), so it
+     reads as its own menu row: full-width, left-aligned to match the nav
+     links, with a top divider separating it from the last link above. */
   .mobile-flag {
     display: flex;
-    /* Show mobile flag */
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 14px 0 2px;
+    margin-top: 6px;
+    border-top: 1px solid rgba(0, 0, 0, 0.1);
   }
 
   /* The CTA pill added a fourth element (logo, CTA, flag, hamburger) to a


### PR DESCRIPTION
## What

On mobile, the language switcher (flag) previously sat in the always-visible header bar, wedged between the **Book now** CTA and the hamburger. This moves it **inside the collapsible menu** so it renders as its own row at the bottom of the open dropdown — below the nav links, separated by a divider.

## Changes

- Moved the `.mobile-flag` block out of `.mobile-controls` (header bar) into `Navbar.Collapse` across all **six** `FixedNavigation` variants (EN/ES × default/Nam/RIB).
- Restyled `.mobile-flag` in the shared stylesheet so inside the menu it's a full-width, left-aligned row with a top divider — matching the nav-link styling above it.
- Reused the existing `.mobile-flag` class, so only one SCSS block changed.
- **Desktop is untouched** — it still uses the top-right `.navbar-flag` switcher.

## Verification

Ran the app locally and inspected the open mobile menu: links stack vertically, the flag sits as its own row at the bottom with a divider, the header bar no longer shows the flag, and the desktop switcher is correctly hidden on mobile. Compiled with no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)