### PR TITLE
feat(cards): make listing cards read as clickable

### DIFF
--- a/src/components/OurHomes/Components/HomeCard.component.tsx
+++ b/src/components/OurHomes/Components/HomeCard.component.tsx
@@ -16,6 +16,9 @@ interface IHomeCard {
 
 const HomeCard: FC<IHomeCard> = ({ guestNumber, parking, name, image, houseLangCode }) => {
 
+    // Spanish house codes contain "ES" (see OurHomes.componentES filter), so the
+    // card can label its own CTA without threading a language prop from parents.
+    const isSpanish = houseLangCode.includes('ES');
     const navigate = useNavigate();
     const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
         // A real href already handles ctrl/cmd-click, middle-click and "open in
@@ -51,6 +54,7 @@ const HomeCard: FC<IHomeCard> = ({ guestNumber, parking, name, image, houseLangC
                         <FontAwesomeIcon icon={faWifi} />
                         <FontAwesomeIcon icon={faParking} />
                     </div>
+                    <span className="card-cta">{isSpanish ? 'Ver casa →' : 'View home →'}</span>
                 </div>
             </div>
 

--- a/src/components/OurHomes/Components/HomeCard.style.scss
+++ b/src/components/OurHomes/Components/HomeCard.style.scss
@@ -132,8 +132,14 @@
     .block {
       background: $kalawala-light-cream; // was #242930 — a dark-theme leftover
       padding:30px;
-      border-bottom:2px solid transparent;
-      transition: .5s all;
+      // The card and the section behind it are both white, so with no shadow the
+      // card read as flat page content, not something you could click. A resting
+      // shadow + rounded corners give it a distinct "surface", and `cursor` is a
+      // belt-and-suspenders signal on top of the anchor wrapping the whole card.
+      border-radius: 16px;
+      box-shadow: 0 2px 12px rgba(11, 48, 40, 0.08);
+      cursor: pointer;
+      transition: transform .35s ease, box-shadow .35s ease;
       margin-bottom:20px;
       position: relative;
       z-index: 1;
@@ -143,11 +149,18 @@
         padding: 20px 15px; // Reduce padding on mobile to make more room for image
       }
 
+      // Lift the whole card (not just the image) and deepen the shadow so the
+      // interactive affordance is obvious without the user having to hover to
+      // discover it.
       &:hover {
-        border-bottom:2px solid $primary-color;
+        transform: translateY(-6px);
+        box-shadow: 0 16px 32px rgba(11, 48, 40, 0.16);
       }
-      &:hover .icon-box {
-        transform: translateY(-10px);
+      &:hover .our-homes-img-m {
+        transform: scale(1.03);
+      }
+      &:hover .card-cta {
+        gap: 12px; // nudge the arrow forward on hover
       }
       // !important throughout: this same `.about .block .icon-box` selector is
       // also defined, at equal specificity, in styles/style.css and the legacy
@@ -164,9 +177,9 @@
         margin: 0 auto 24px !important;
         padding: 0 !important;
         border: none !important;
+        border-radius: 12px;
+        overflow: hidden; // clip the hover zoom on the photo below
         transform: translateZ(0px);
-        transition-duration: 0.3s;
-        transition-property: transform;
 
         &::before, &::after {
           content: none !important; // kill the legacy diamond icon frame
@@ -179,6 +192,7 @@
           margin: 0 !important;
           object-fit: cover;
           border-radius: 12px;
+          transition: transform .45s ease;
         }
       }
 
@@ -242,6 +256,26 @@
               font-size: 1.2rem !important;
               margin: 0 !important;
             }
+          }
+        }
+
+        // Explicit "View home →" affordance — the strongest single cue that the
+        // whole card is a link. The arrow is a plain text glyph, not a
+        // FontAwesome svg, so the `.content svg { font-size: 26px !important }`
+        // mobile rule above leaves it alone.
+        .card-cta {
+          display: inline-flex;
+          align-items: center;
+          gap: 8px;
+          margin-top: 18px;
+          font-weight: 600;
+          font-size: 1rem;
+          letter-spacing: 0.02em;
+          color: $primary-color;
+          transition: gap .25s ease;
+
+          @media (max-width: 768px) {
+            font-size: 1.15rem;
           }
         }
       }

--- a/src/components/OurHomes/Components/NamCard.component.tsx
+++ b/src/components/OurHomes/Components/NamCard.component.tsx
@@ -16,6 +16,9 @@ interface IHomeCard {
 
 const NamCard: FC<IHomeCard> = ({ guestNumber, name, image, houseLangCode }) => {
 
+    // Spanish house codes contain "ES", so the card can label its own CTA
+    // without threading a language prop from parents.
+    const isSpanish = houseLangCode.includes('ES');
     const navigate = useNavigate();
     const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
         // A real href already handles ctrl/cmd-click, middle-click and "open in
@@ -50,6 +53,7 @@ const NamCard: FC<IHomeCard> = ({ guestNumber, name, image, houseLangCode }) => 
                         <FontAwesomeIcon icon={faUtensils} />
                         <FontAwesomeIcon icon={faWifi} />
                     </div>
+                    <span className="card-cta">{isSpanish ? 'Ver casa →' : 'View home →'}</span>
                 </div>
             </div>
 

--- a/src/components/OurHomes/Components/VillaCard.component.tsx
+++ b/src/components/OurHomes/Components/VillaCard.component.tsx
@@ -16,6 +16,9 @@ interface IHomeCard {
 
 const VillaCard: FC<IHomeCard> = ({ guestNumber, name, image, houseLangCode }) => {
 
+    // Spanish house codes contain "ES", so the card can label its own CTA
+    // without threading a language prop from parents.
+    const isSpanish = houseLangCode.includes('ES');
     const navigate = useNavigate();
     const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
         // A real href already handles ctrl/cmd-click, middle-click and "open in
@@ -66,6 +69,7 @@ const VillaCard: FC<IHomeCard> = ({ guestNumber, name, image, houseLangCode }) =
                         <FontAwesomeIcon icon={faWifi} />
                         <FontAwesomeIcon icon={faParking} />
                     </div>
+                    <span className="card-cta">{isSpanish ? 'Ver casa →' : 'View home →'}</span>
                 </div>
             </div>
 

--- a/src/components/OurOtherHomes/Components/OtherHomesCard.component.tsx
+++ b/src/components/OurOtherHomes/Components/OtherHomesCard.component.tsx
@@ -14,6 +14,9 @@ interface IOtherHomesCard {
 }
 
 const OtherHomesCard: FC<IOtherHomesCard> = ({ guestNumber, name, image, redirectPath }) => {
+    // Spanish routes end in "ES" (e.g. /PlumeriaES), so the card labels its own
+    // CTA without a language prop.
+    const isSpanish = !!redirectPath?.endsWith('ES');
     const navigate = useNavigate();
 
     const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
@@ -48,6 +51,7 @@ const OtherHomesCard: FC<IOtherHomesCard> = ({ guestNumber, name, image, redirec
                     <FontAwesomeIcon icon={faWifi} />
                     <FontAwesomeIcon icon={faParking} />
                 </div>
+                <span className="card-cta">{isSpanish ? 'Ver casa →' : 'View home →'}</span>
             </div>
         </a>
     );

--- a/src/components/OurOtherHomes/Components/OtherHomesCard.componentRib.tsx
+++ b/src/components/OurOtherHomes/Components/OtherHomesCard.componentRib.tsx
@@ -14,6 +14,9 @@ interface IOtherHomesCard {
 }
 
 const OtherHomesCardRib: FC<IOtherHomesCard> = ({ guestNumber, name, image, redirectPath }) => {
+    // Spanish routes end in "ES" (e.g. /VillaMarES), so the card labels its own
+    // CTA without a language prop.
+    const isSpanish = !!redirectPath?.endsWith('ES');
     const navigate = useNavigate();
 
     const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
@@ -49,6 +52,7 @@ const OtherHomesCardRib: FC<IOtherHomesCard> = ({ guestNumber, name, image, redi
                     <FontAwesomeIcon icon={faWifi} />
                     <FontAwesomeIcon icon={faParking} />
                 </div>
+                <span className="card-cta">{isSpanish ? 'Ver casa →' : 'View home →'}</span>
             </div>
         </a>
     );

--- a/src/components/OurOtherHomes/Components/OtherHomesCard.style.scss
+++ b/src/components/OurOtherHomes/Components/OtherHomesCard.style.scss
@@ -11,8 +11,8 @@
     padding: 1rem;
     background: $primary-bg;
     border-radius: 8px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    transition: transform 0.2s ease-in-out;
+    box-shadow: 0 2px 12px rgba(11, 48, 40, 0.08);
+    transition: transform 0.25s ease-in-out, box-shadow 0.25s ease-in-out;
     text-decoration: none;
     cursor: pointer;
 
@@ -71,10 +71,29 @@
           gap: 5px;
         }
       }
+
+      // Explicit "View home →" affordance, matching the "Our Homes" cards so both
+      // sections read as one system. Plain text arrow, brand-green.
+      .card-cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 12px;
+        font-weight: 600;
+        font-size: 0.95rem;
+        letter-spacing: 0.02em;
+        color: $primary-color;
+        transition: gap .25s ease;
+      }
     }
-  
+
     &:hover {
-      transform: translateY(-5px);
+      transform: translateY(-6px);
+      box-shadow: 0 16px 32px rgba(11, 48, 40, 0.16);
+    }
+
+    &:hover .card-cta {
+      gap: 12px;
     }
   }
   


### PR DESCRIPTION
## Problem
The listing cards didn't look clickable. They were flat white blocks on a white section with no shadow, and the only interactivity cue was a hover-only bottom border — undiscoverable without already hovering.

## Change
Applied a consistent "clickable card" treatment to **all** listing cards (HomeCard, VillaCard, NamCard, and the "Explore other stays" OtherHomesCard):

- **Resting surface** — rounded corners + soft shadow so the card lifts off the same-white background; explicit `cursor: pointer`.
- **Whole-card hover** — the card rises (`translateY(-6px)`) with a deeper shadow (replacing the old image-only lift), plus a gentle photo zoom.
- **"View home →" CTA** — brand-green call-to-action whose arrow slides forward on hover.

Each card derives its own language (Spanish house codes contain `ES`; Spanish routes end in `ES`), so no language prop threads through the parent variants.

## Verification
Ran the dev server and confirmed the cards render with the shadow + CTA and read as clickable at rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)