### PR TITLE
ci: serialise cPanel deploys and retry the FTP upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,6 +129,18 @@ jobs:
     name: Build & Deploy
     runs-on: ubuntu-latest
     needs: [secret-scan, audit, typecheck, e2e-tests]
+    # Serialise the upload. There is one cPanel account and one
+    # .ftp-deploy-sync-state.json living on it, so two deploys in flight race on
+    # both the connection limit and the state file. Merges land in bursts — #32
+    # and #34 went in 2.5 minutes apart on 2026-08-06 and their deploy jobs ran
+    # within three minutes of each other — so this is not theoretical.
+    #
+    # cancel-in-progress stays false deliberately: cancelling a running upload
+    # strands the server half-synced behind a stale state file, which is exactly
+    # the mess the FIN-packet failure below produced.
+    concurrency:
+      group: deploy-cpanel
+      cancel-in-progress: false
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -198,7 +210,54 @@ jobs:
         env:
           SMOOBU_WEBHOOK_SECRET: ${{ secrets.SMOOBU_WEBHOOK_SECRET }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+      # The cPanel FTPS server hangs up mid-sync under load. On 2026-08-06 run
+      # 31111950802 died 2.4 seconds into the transfer with "Server sent FIN
+      # packet unexpectedly, closing connection" after replacing 10 of 50 files,
+      # leaving the site half-updated until the next merge happened to re-sync
+      # it. The action opens a fresh data connection per file, which is the exact
+      # pattern shared-host anti-flood limits are tuned to cut off — so expect
+      # this to recur rather than treating it as a one-off.
+      #
+      # Retrying is safe because the sync is idempotent: the action re-reads the
+      # server's state file, re-hashes the local build and re-uploads whatever is
+      # still stale. A second attempt just finishes the run, redoing the files
+      # the first attempt already copied at no cost beyond bandwidth.
+      #
+      # v4.3.4 has no retry input and its `with` block cannot be shared between
+      # steps, hence the duplication. Raising the `timeout` input would not help:
+      # the server closed the connection, it did not stall.
       - name: Upload to cPanel
+        id: upload
+        continue-on-error: true
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.4
+        with:
+          server: ${{ secrets.FTP_SERVER }}
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          protocol: ftps
+          port: 21
+          local-dir: ./build/
+          server-dir: ./
+          dangerous-clean-slate: false
+          exclude: |
+            **/.git**
+            **/.git*/
+            **/node_modules/**
+            **/.gitignore
+            **/.gitattributes
+
+      # Anti-flood blocks hold for roughly a minute, so an immediate retry would
+      # walk straight back into the same wall. Wait it out first.
+      - name: Back off before retrying upload
+        if: steps.upload.outcome == 'failure'
+        run: |
+          echo "::warning::FTP upload failed, retrying in 60s. See step log above."
+          sleep 60
+
+      # No continue-on-error here — if the retry also fails the deploy is
+      # genuinely broken and the job should go red.
+      - name: Upload to cPanel (retry)
+        if: steps.upload.outcome == 'failure'
         uses: SamKirkland/FTP-Deploy-Action@v4.3.4
         with:
           server: ${{ secrets.FTP_SERVER }}


### PR DESCRIPTION
## What broke

[Run 31111950802](https://github.com/TommasoRibaudo/kalawala-web/actions/runs/31111950802) (merge of #32) failed on `Upload to cPanel`:

```
replacing "bushoursES/index.html"
--------------  🔥🔥🔥 an error occurred  🔥🔥🔥  --------------
Error: Server sent FIN packet unexpectedly, closing connection.
    at TLSSocket.<anonymous> (.../FTP-Deploy-Action/v4.3.4/dist/index.js:5098:56)
```

Nothing in the repo was at fault — checkout, `npm ci`, the react-snap build and the PHP config step all passed. `FIN packet` means the cPanel FTPS server hung up; it is not a timeout and not a client error. It died 2.4 seconds into the transfer having replaced 10 of 50 files (`404.html` → `bushoursES/index.html`, alphabetical). The action opens a fresh data connection per file, so that is ~10 connections in 2.4s — the pattern shared-host anti-flood limits exist to cut off.

The two red herrings in that run: the `E2E Tests: exit code 1` annotation (that job is deliberately `continue-on-error`, report-only) and the Node 20 deprecation warnings (present on the green runs too).

## Why it mattered

The action writes `.ftp-deploy-sync-state.json` **only after a complete sync**, so the crash left the server holding 10 new files while the state file still described the pre-#32 state. That is a genuinely inconsistent deploy, and nothing in the pipeline would have noticed.

It self-healed by luck: the next merge ([#31112154301](https://github.com/TommasoRibaudo/kalawala-web/actions/runs/31112154301), 2.5 min later) did a full 178-file re-sync. Impact was small this time because every `static/js/*.chunk.js` logged *"File content is the same, doing nothing"* — the 50 stale files were all prerendered `index.html`, so there was no HTML/JS version skew. A release that also changed the JS chunks would not have been so lucky.

## Changes

**1. Job-level `concurrency` on `deploy`.** One FTP account, one state file on it — two deploys in flight race on both. Merges land in bursts (#32 and #34 were 2.5 minutes apart; their deploy jobs ran within three minutes of each other, though their upload phases happened to miss each other). `cancel-in-progress: false` is deliberate: cancelling a running upload produces exactly the half-synced-behind-a-stale-state-file condition this PR is fixing.

**2. One retry after a 60s backoff.** The sync is idempotent — the action re-reads the server state file, re-hashes the local build and re-uploads whatever is still stale — so a second attempt simply finishes the run. The backoff is there because anti-flood blocks hold for roughly a minute and a bare retry would hit the same wall. The retry step has no `continue-on-error`, so a second failure still goes red.

`v4.3.4` has no retry input and a `with` block cannot be shared between steps, so the config is spelled out twice. I verified the two blocks are identical after parsing.

## Deliberately not done

Raising the `timeout` input. The server closed the connection rather than stalling, so a longer timeout would have changed nothing.

## Validation

Diff is +59/-0, `.github/workflows/main.yml` only. Parsed the result with PyYAML and asserted the deploy job's structure: `concurrency` group present with `cancel-in-progress: false`, `upload` step carries the id and `continue-on-error`, both follow-ups gate on `steps.upload.outcome == 'failure'`, and the two `with` blocks compare equal. The retry path itself only exercises on a real FTP drop, so it is untested end-to-end by nature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
