### PR TITLE
feat(help-me-choose): make "Find your Ideal Stay" cards read as clickable

### DIFF
--- a/src/components/HelpMeChoose/HelpMeChoose.component.tsx
+++ b/src/components/HelpMeChoose/HelpMeChoose.component.tsx
@@ -20,7 +20,14 @@ interface IHelpMeChoose {
 const HelpMeChoose: React.FC<IHelpMeChoose> = ({ title, titleHighlight, options }) => {
     const navigate = useNavigate();
 
-    const handleClick = (houseLangCode: string) => {
+    const handleClick = (event: React.MouseEvent<HTMLAnchorElement>, houseLangCode: string) => {
+        // A real href already handles ctrl/cmd-click, middle-click and "open in
+        // new tab" correctly — only take over plain left-clicks so those keep
+        // working, and use the SPA transition (no full reload) for everything else.
+        if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+            return;
+        }
+        event.preventDefault();
         navigate(`/${houseLangCode}`);
         setTimeout(() => {
             window.scrollTo(0, 0);
@@ -34,22 +41,29 @@ const HelpMeChoose: React.FC<IHelpMeChoose> = ({ title, titleHighlight, options 
                     <h2>{title} {titleHighlight && <span className="color">{titleHighlight}</span>}</h2>
                 </div>
                 <div className="help-me-choose-cards">
-                    {options.map((option) => (
-                        <div 
-                            key={option.houseLangCode} 
-                            className="help-me-choose-card"
-                            onClick={() => handleClick(option.houseLangCode)}
-                        >
-                            <div className="card-image-wrapper">
-                                <img src={option.image} alt={option.houseName} width={1000} height={667} loading="lazy" decoding="async" srcSet={cdnSrcSet(option.image)} sizes="(max-width: 575px) 86vw, (max-width: 991px) 320px, 250px" />
-                            </div>
-                            <div className="card-content">
-                                <span className="card-emoji">{option.emoji}</span>
-                                <span className="card-label">{option.label}</span>
-                                <span className="card-house-name">{option.houseName}</span>
-                            </div>
-                        </div>
-                    ))}
+                    {options.map((option) => {
+                        // Spanish house codes contain "ES" — same convention HomeCard
+                        // uses to label its own CTA without a language prop.
+                        const isSpanish = option.houseLangCode.includes('ES');
+                        return (
+                            <a
+                                key={option.houseLangCode}
+                                className="help-me-choose-card"
+                                href={`/${option.houseLangCode}`}
+                                onClick={(event) => handleClick(event, option.houseLangCode)}
+                            >
+                                <div className="card-image-wrapper">
+                                    <img src={option.image} alt={option.houseName} width={1000} height={667} loading="lazy" decoding="async" srcSet={cdnSrcSet(option.image)} sizes="(max-width: 575px) 86vw, (max-width: 991px) 320px, 250px" />
+                                </div>
+                                <div className="card-content">
+                                    <span className="card-emoji">{option.emoji}</span>
+                                    <span className="card-label">{option.label}</span>
+                                    <span className="card-house-name">{option.houseName}</span>
+                                    <span className="card-cta">{isSpanish ? 'Ver casa →' : 'View home →'}</span>
+                                </div>
+                            </a>
+                        );
+                    })}
                 </div>
             </div>
         </section>

--- a/src/components/HelpMeChoose/HelpMeChoose.style.scss
+++ b/src/components/HelpMeChoose/HelpMeChoose.style.scss
@@ -43,6 +43,12 @@
         }
     }
 
+    // Matches the listing-card treatment in OurHomes/Components/HomeCard.style.scss
+    // so both home sections read as one system. The card and the section behind it
+    // are both white ($section-bg and $kalawala-light-cream are each #FFFFFF), so
+    // without a shadow this read as flat page content rather than something you
+    // could click — the only affordance was a hover-only image lift you had to
+    // hover to discover.
     .help-me-choose-card {
         background: $section-bg;
         overflow: visible;
@@ -51,6 +57,17 @@
         min-width: 250px;
         max-width: 350px;
         padding: 15px;
+        // It is a real anchor now, so reset the link defaults and give keyboard
+        // users the same focus ring the listing cards have.
+        text-decoration: none;
+        border-radius: 16px;
+        box-shadow: 0 2px 12px rgba(11, 48, 40, 0.08);
+        transition: transform .35s ease, box-shadow .35s ease;
+
+        &:focus-visible {
+            outline: 2px solid $primary-color;
+            outline-offset: 2px;
+        }
 
         @media (max-width: 1023px) {
             flex: 0 1 calc(50% - 10px);
@@ -63,22 +80,33 @@
             max-width: 100%;
         }
 
-        &:hover .card-image-wrapper {
-            transform: translateY(-10px);
+        // Lift the whole card rather than just the image, so the affordance is
+        // visible at rest and obvious on hover.
+        &:hover {
+            transform: translateY(-6px);
+            box-shadow: 0 16px 32px rgba(11, 48, 40, 0.16);
+        }
+
+        &:hover .card-image-wrapper img {
+            transform: scale(1.03);
+        }
+
+        &:hover .card-cta {
+            gap: 12px; // nudge the arrow forward on hover
         }
 
         .card-image-wrapper {
             width: 100%;
             height: 180px;
-            overflow: hidden;
+            overflow: hidden; // clips the hover zoom on the photo below
             margin-bottom: 15px;
-            transition: transform 0.3s ease;
 
             img {
                 width: 100%;
                 height: 100%;
                 object-fit: cover;
                 border-radius: 8px;
+                transition: transform .45s ease;
             }
         }
 
@@ -102,6 +130,20 @@
 
             .card-house-name {
                 display: none;
+            }
+
+            // Explicit "View home →" affordance — the strongest single cue that
+            // the whole card is a link. Kept identical to HomeCard's .card-cta.
+            .card-cta {
+                display: inline-flex;
+                align-items: center;
+                gap: 8px;
+                margin-top: 14px;
+                font-weight: 600;
+                font-size: 1rem;
+                letter-spacing: 0.02em;
+                color: $primary-color;
+                transition: gap .25s ease;
             }
         }
     }


### PR DESCRIPTION
## Why

`ead99cc` (#35) gave the listing cards a resting surface, hover lift and a brand-green "View home →" CTA. The "Find your Ideal Stay" chooser was not part of that pass, so the two home sections stopped matching — its cards kept exactly the treatment that commit set out to replace: flat on a white section, with the only affordance a hover-only image lift you had to hover to discover.

Like the listing cards, these are white-on-white (`$section-bg` and `$kalawala-light-cream` are both `#FFFFFF`), so #35 solved it with a shadow rather than a background change. Same approach here.

## Two gaps, not one

**Visual** — no resting surface, so nothing signalled the card was a link.

**Semantic** — the cards were still `<div onClick>`, so they had also been missed by the earlier `fix(a11y): make property cards real links instead of div onClick` (`27c5ef7`). That meant no keyboard access, no focus ring, and no `href` for ctrl/cmd-click, middle-click, "copy link address", or crawlers.

The ask was about the look, but "similarly clickable" to `HomeCard` means being a real link, so both are fixed here. Flagging it because it makes this more than a styling change.

## Changes

Two files under `src/components/HelpMeChoose/`:

- `<div onClick>` → `<a href={/${houseLangCode}}>`, using the same guarded handler as `HomeCard` so modified clicks (ctrl/cmd/shift/alt, middle-click) fall through to the browser and plain left-clicks stay client-side
- `.card-cta` — `View home →` / `Ver casa →`, derived from the `ES` suffix on the house code, the same convention `HomeCard` uses to avoid threading a language prop
- Values copied from `HomeCard.style.scss` so the two sections stay one system: `border-radius: 16px`, resting `0 2px 12px rgba(11,48,40,.08)`, hover `translateY(-6px)` + `0 16px 32px rgba(11,48,40,.16)`, photo `scale(1.03)`, CTA arrow nudge
- `text-decoration: none` and a `:focus-visible` ring, matching the listing cards

Single shared component, so all four Home variants (EN/ES × default/nam) pick this up with no per-variant edits.

## Validation

`npx tsc --noEmit` exits 0. `npx sass` compiles the stylesheet clean — the `@import` deprecation warnings are repo-wide and pre-existing.

Then checked in the running dev server rather than trusting the CSS:

- All 4 cards render as `<A>` with hrefs `/VillaMar`, `/Delfin`, `/Rana`, `/Plumeria`
- `/HomeES` renders `Ver casa →` with `/VillaMarES`, `/DelfinES`, `/RanaES`, `/PlumeriaES`
- Keyboard: focusable, `:focus-visible` matches, computed outline `rgb(11, 48, 40) solid 2px`
- Hover lift and deeper shadow confirmed visually against a resting neighbour
- Scrolled to the Our Homes section to confirm the two now read as one system

## Noticed, not touched

On hover the Our Homes cards still pick up a green bottom border from `styles/scss/templates/_about_us.scss`, which defines `.about .block:hover { border-bottom }` at equal specificity. #35 removed that rule from `HomeCard.style.scss` but not from the legacy file, so it still applies. Out of scope here — these styles are scoped under `.help-me-choose-section` and cannot reach `.about .block`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
