### PR TITLE
chore(i18n): Phase 0 SEO baseline capture

### DIFF
--- a/docs/i18n-rollout-plan.md
+++ b/docs/i18n-rollout-plan.md
@@ -15,14 +15,14 @@ resume without re-investigating the codebase.
 
 | | |
 |---|---|
-| **Current phase** | Phase 0 — not started |
+| **Current phase** | Phase 0 — in progress, partly blocked |
 | **Last updated** | 2026-08-06 |
-| **Branch(es) in flight** | none |
-| **Blocked on** | nothing |
+| **Branch(es) in flight** | `chore/i18n-phase-0-baseline` |
+| **Blocked on** | **Owner action:** Google Search Console + PostHog exports — see [`seo-baseline/README.md`](seo-baseline/README.md). The GSC export cannot be done retroactively. |
 
 Phase progress:
 
-- [ ] Phase 0 — Baseline capture and safety net
+- [ ] Phase 0 — Baseline capture and safety net *(automated parts done; GSC/PostHog exports outstanding)*
 - [ ] Phase 1 — Locale foundation (`isSpanish` → `locale`)
 - [ ] Phase 2 — Message catalogs
 - [ ] Phase 3 — Collapse duplicated page components
@@ -142,18 +142,36 @@ Each phase should be its own PR against `main`.
 ### Phase 0 — Baseline capture and safety net
 
 Do this before touching anything. Once URLs move, you cannot reconstruct what
-"before" looked like.
+"before" looked like. Everything lands in [`seo-baseline/`](seo-baseline/) —
+see its README for the detail.
 
-- [ ] Export current Google Search Console performance: 16 months, by page and by
-      query, for both EN and ES URLs. Save as CSV in `docs/seo-baseline/`.
-- [ ] Record current indexed page count per URL pattern (GSC → Pages).
-- [ ] Save the current `sitemap.xml` from production.
-- [ ] Run Lighthouse on `/`, `/HomeES`, one listing, one blog article; record scores
-      (`npm run lh`).
-- [ ] Write down current monthly organic sessions per language from PostHog.
+- [x] Save the current `sitemap.xml` and `robots.txt` from production
+      (48 URLs, 144 hreflang alternates; robots correctly advertises the sitemap).
+- [x] Capture the live status + redirect chain of all 49 routes
+      (`node scripts/check-urls.mjs capture`).
+- [x] Add `scripts/check-urls.mjs` — the same tool asserts single-hop redirects in
+      Phase 5 and Phase 10.
+- [ ] **Owner:** export GSC performance, 16 months, Pages + Queries tabs, as CSV.
+- [ ] **Owner:** record GSC indexed vs not-indexed page counts.
+- [ ] **Owner:** export PostHog monthly organic sessions, EN vs ES, 12 months.
+- [ ] Lighthouse baseline for `/`, `/HomeES`, `/Geco`, `/twodaysinpuertoviejo`.
 
-**Validation:** the baseline CSVs exist and are committed. This phase is the only
+**Validation:** the baseline files exist and are committed. This phase is the only
 insurance against "did the migration hurt us?" being unanswerable.
+
+> **Finding — every URL already costs a redirect.** All 49 routes return 200, but
+> 48 take a 301 first: `/Geco` → `/Geco/`, Apache `DirectorySlash` resolving the
+> prerendered `Geco/index.html`. Only `/` is direct.
+>
+> This changes Phase 5. A naive `/PlumeriaES` → `/es/plumeria` redirect becomes a
+> **two-hop chain**, because `DirectorySlash` then sends `/es/plumeria` →
+> `/es/plumeria/`. **Redirect targets in the 301 map must include the trailing
+> slash.**
+>
+> It also means the sitemap and every `rel="canonical"` currently point at
+> redirecting URLs (`/Geco`, while `/Geco/` is what gets served). Phase 6 should
+> settle this one way or the other — adopt the trailing slash everywhere, or
+> change `.htaccess` to serve without it.
 
 ### Phase 1 — Locale foundation
 
@@ -236,6 +254,11 @@ hardcoded legacy path remains (`grep -rn '"/\(Home\|Plumeria\|VillaMar\)' src`).
 - [ ] Redirects must be **single-hop**. `/PlumeriaES` → `/es/plumeria` directly,
       never via an intermediate. Chained redirects leak link equity and Google
       reports them.
+- [ ] **Targets must carry the trailing slash** — `/es/plumeria/`, not
+      `/es/plumeria`. Per the Phase 0 finding, `DirectorySlash` adds its own 301
+      otherwise and every migrated URL becomes a two-hop chain. Either emit the
+      slash in the map, or disable `DirectorySlash` and serve without it — but
+      pick one and make the sitemap, canonicals and hreflang agree.
 - [ ] Verify the existing `ErrorDocument 404 /404.html` behaviour still works
       after the new rules (see the comments already in `public/.htaccess`).
 
@@ -411,6 +434,18 @@ what the next session should pick up.
 - Surveyed the codebase (findings recorded in Ground Truth above).
 - Locked the three decisions: path-prefix URLs, blog included, machine
   translation published as-is.
-- Nothing implemented yet. **Next session: start Phase 0** — the GSC baseline
-  export must happen before any URL work, and it is the one step that cannot be
-  done retroactively.
+- Merged as PR #38.
+
+### 2026-08-06 — Phase 0, automated half
+- Captured production `sitemap.xml` (48 URLs) and `robots.txt` into
+  `docs/seo-baseline/`. robots correctly advertises the sitemap.
+- Added `scripts/check-urls.mjs` (capture + verify modes) and captured the live
+  status of all 49 routes.
+- **Found: 48 of 49 URLs already 301 to a trailing slash** via `DirectorySlash`.
+  Recorded against Phase 5 and Phase 6 above — redirect targets must include the
+  trailing slash or every migrated URL becomes a two-hop chain. This is the
+  finding that justified doing Phase 0 properly rather than skipping to Phase 1.
+- **Next session:** Phase 0 is blocked on the owner's GSC + PostHog exports
+  (`docs/seo-baseline/README.md` has click-by-click steps). The GSC export is the
+  only irreversible item — 16-month retention means unexported data is gone.
+  Phase 1 does not depend on it and can start in parallel.

--- a/docs/i18n-rollout-plan.md
+++ b/docs/i18n-rollout-plan.md
@@ -151,10 +151,11 @@ see its README for the detail.
       (`node scripts/check-urls.mjs capture`).
 - [x] Add `scripts/check-urls.mjs` — the same tool asserts single-hop redirects in
       Phase 5 and Phase 10.
+- [x] Lighthouse baseline for `/`, `/HomeES`, `/Geco`, `/twodaysinpuertoviejo`
+      (`seo-baseline/lighthouse-2026-08-06.md` — perf 89–90, SEO 100 across the board).
 - [ ] **Owner:** export GSC performance, 16 months, Pages + Queries tabs, as CSV.
 - [ ] **Owner:** record GSC indexed vs not-indexed page counts.
 - [ ] **Owner:** export PostHog monthly organic sessions, EN vs ES, 12 months.
-- [ ] Lighthouse baseline for `/`, `/HomeES`, `/Geco`, `/twodaysinpuertoviejo`.
 
 **Validation:** the baseline files exist and are committed. This phase is the only
 insurance against "did the migration hurt us?" being unanswerable.

--- a/docs/seo-baseline/README.md
+++ b/docs/seo-baseline/README.md
@@ -1,0 +1,118 @@
+# SEO baseline — captured before the i18n URL migration
+
+Phase 0 of [`../i18n-rollout-plan.md`](../i18n-rollout-plan.md).
+
+**Why this exists:** the rollout moves every URL on the site to a locale prefix
+(`/Plumeria` → `/en/plumeria`). Once that ships, there is no way to reconstruct
+what traffic and indexing looked like beforehand. This directory is the only
+record of "before", and it is what the post-launch comparison in Phase 10 is
+measured against.
+
+Captured **2026-08-06**, against production, at commit `095d7ad`.
+
+---
+
+## What is already here
+
+| File | What it is |
+|---|---|
+| `sitemap-2026-08-06.xml` | Live sitemap as served. 48 URLs, 144 `xhtml:link` hreflang alternates. |
+| `robots-2026-08-06.txt` | Live robots.txt. Confirmed it advertises the sitemap correctly. |
+| `url-status-2026-08-06.json` | Every route in `reactSnap.include` traced against production: final status, redirect hop count, full chain. |
+
+Regenerate the URL trace at any time with:
+
+```bash
+node scripts/check-urls.mjs capture
+```
+
+After Phase 5 lands the 301 map, the same script asserts that every one of these
+URLs still resolves in **at most one hop**:
+
+```bash
+node scripts/check-urls.mjs verify docs/seo-baseline/url-status-2026-08-06.json
+```
+
+---
+
+## Finding: every URL already costs a redirect
+
+All 49 routes return 200, but **48 of them take a 301 first**. Only `/` is direct.
+
+```
+https://www.reservaskalawala.com/Geco
+  -> 301 https://www.reservaskalawala.com/Geco/
+```
+
+This is Apache `mod_dir`'s `DirectorySlash`: the build emits `Geco/index.html`,
+so a request for `/Geco` is redirected to `/Geco/` before it is served.
+
+Two consequences, both of which predate the i18n work:
+
+1. **The sitemap and the canonical tags point at redirecting URLs.** The sitemap
+   lists `/Geco`, and `ListingGeco.page.tsx` declares
+   `<link rel="canonical" href="https://www.reservaskalawala.com/Geco" />` — but
+   the served URL is `/Geco/`. Every hreflang alternate has the same mismatch.
+   Google resolves this, but it is a muddled signal for free.
+
+2. **It breaks the Phase 5 single-hop rule by default.** A naive
+   `/PlumeriaES` → `/es/plumeria` redirect becomes a two-hop chain, because
+   `DirectorySlash` then sends `/es/plumeria` → `/es/plumeria/`. Redirect targets
+   in the 301 map **must include the trailing slash**, or every migrated URL
+   chains. This is the single most useful thing this baseline turned up.
+
+Decide during Phase 6 whether canonical URLs and the sitemap adopt the trailing
+slash (matching what is served) or whether `.htaccess` is changed to serve
+without it. Either is fine; the current split is not.
+
+---
+
+## Still to capture — needs your account access
+
+I cannot reach Google Search Console or PostHog. These are the parts of Phase 0
+that need you, and the GSC export is the one that **cannot be done later**.
+
+### 1. Google Search Console — performance export
+
+<https://search.google.com/search-console> → property `reservaskalawala.com`
+
+- **Performance → Search results**, set the date range to **16 months** (the
+  maximum retained; anything older is already gone).
+- Export twice, via the **Export** button top-right → *Download CSV*:
+  - **Pages** tab → save as `gsc-pages-16mo-2026-08-06.csv`
+  - **Queries** tab → save as `gsc-queries-16mo-2026-08-06.csv`
+- Drop both files in this directory.
+
+### 2. Google Search Console — indexing snapshot
+
+- **Indexing → Pages**. Record the number of **indexed** vs **not indexed** pages
+  and the breakdown by reason.
+- A screenshot saved as `gsc-indexing-2026-08-06.png` is enough.
+
+### 3. PostHog — organic sessions by language
+
+- Monthly organic sessions for the last 12 months, split EN vs ES (the URL suffix
+  `ES` separates them today — after the migration it will be the `/es/` prefix).
+- Save as `posthog-sessions-2026-08-06.csv`.
+
+### Why 16 months
+
+Search Console retains 16 months and silently drops everything older. Whatever is
+not exported before the migration is not recoverable afterwards, which is why
+this is the first task in the plan rather than a later one.
+
+---
+
+## Lighthouse
+
+Scores for `/`, `/HomeES`, `/Geco` and `/twodaysinpuertoviejo` go in
+`lighthouse-2026-08-06.md` when captured:
+
+```bash
+npm run build          # needs the full prerender; Lighthouse serves build/
+node scripts/lighthouse-run.mjs --runs=3 --label=i18n-baseline
+```
+
+Unlike the GSC export, this one **is** reproducible later — the script runs
+against a build from any commit, so a missed Lighthouse baseline can be
+recreated from git history. Do not let it block the phase.

--- a/docs/seo-baseline/lighthouse-2026-08-06.md
+++ b/docs/seo-baseline/lighthouse-2026-08-06.md
@@ -1,0 +1,25 @@
+# Lighthouse — i18n-baseline
+
+Median of 3 run(s) per route. gzip on, /static/ immutable.
+
+| Route | Perf | A11y | BP | SEO | FCP | LCP | TBT | CLS | SI |
+|---|---|---|---|---|---|---|---|---|---|
+| `/` | 90 | 96 | 96 | 100 | 1.7 s | 3.6 s | 0 ms | 0 | 1.7 s |
+| `/Geco` | 90 | 96 | 96 | 100 | 1.5 s | 3.6 s | 0 ms | 0 | 1.5 s |
+| `/HomeES` | 90 | 96 | 96 | 100 | 1.7 s | 3.6 s | 10 ms | 0 | 1.7 s |
+| `/twodaysinpuertoviejo` | 89 | 100 | 75 | 100 | 1.4 s | 3.8 s | 0 ms | 0 | 1.4 s |
+
+Reports: lighthouse-reports\i18n-baseline
+
+Captured 2026-08-06 at commit `095d7ad`, mobile emulation, median of 3 runs.
+
+Reproduce with:
+
+```bash
+npm run build
+node scripts/lighthouse-run.mjs --runs=3 --label=i18n-baseline
+```
+
+Note: `/twodaysinpuertoviejo` scores 75 on Best Practices against 96 elsewhere.
+That gap predates the i18n work — worth a look on its own, but it is recorded
+here only as the "before" number, not as something the rollout should fix.

--- a/docs/seo-baseline/robots-2026-08-06.txt
+++ b/docs/seo-baseline/robots-2026-08-06.txt
@@ -1,0 +1,46 @@
+# https://www.robotstxt.org/robotstxt.html
+
+# Allow all standard search engines
+User-agent: *
+Disallow:
+
+# Explicitly allow AI crawlers for search/retrieval
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: Meta-ExternalAgent
+Allow: /
+
+# Block training-only crawlers that don't drive search visibility
+User-agent: CCBot
+Disallow: /
+
+# Sitemap
+Sitemap: https://www.reservaskalawala.com/sitemap.xml

--- a/docs/seo-baseline/sitemap-2026-08-06.xml
+++ b/docs/seo-baseline/sitemap-2026-08-06.xml
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://www.reservaskalawala.com/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/HomeES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/HomeES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/HomeES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/Geco</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Geco"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/GecoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Geco"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/GecoES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Geco"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/GecoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Geco"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/Rana</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Rana"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/RanaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Rana"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/RanaES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Rana"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/RanaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Rana"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/Tucano</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Tucano"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/TucanoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Tucano"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/TucanoES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Tucano"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/TucanoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Tucano"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/Pappagallo</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Pappagallo"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/PappagalloES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Pappagallo"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/PappagalloES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Pappagallo"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/PappagalloES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Pappagallo"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/Delfin</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Delfin"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/DelfinES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Delfin"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/DelfinES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Delfin"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/DelfinES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Delfin"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/Areka</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Areka"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/ArekaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Areka"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/ArekaES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Areka"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/ArekaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Areka"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/Giulia</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Giulia"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/GiuliaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Giulia"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/GiuliaES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Giulia"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/GiuliaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Giulia"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/Plumeria</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Plumeria"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/PlumeriaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Plumeria"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/PlumeriaES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Plumeria"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/PlumeriaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Plumeria"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/VillaMar</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/VillaMar"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/VillaMarES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/VillaMar"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/VillaMarES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/VillaMar"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/VillaMarES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/VillaMar"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/VillaCoral</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/VillaCoral"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/VillaCoralES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/VillaCoral"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/VillaCoralES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/VillaCoral"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/VillaCoralES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/VillaCoral"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/HomeNam</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/HomeNam"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/HomeNamES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/HomeNam"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/HomeNamES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/HomeNam"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/HomeNamES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/HomeNam"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/HomeVillas</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/HomeVillas"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/HomeVillasES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/HomeVillas"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/HomeVillasES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/HomeVillas"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/HomeVillasES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/HomeVillas"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/blog</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/blog"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/blogES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/blog"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/blogES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/blog"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/blogES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/blog"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/twodaysinpuertoviejo</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/twodaysinpuertoviejo"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/twodaysinpuertoviejoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/twodaysinpuertoviejo"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/twodaysinpuertoviejoES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/twodaysinpuertoviejo"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/twodaysinpuertoviejoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/twodaysinpuertoviejo"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/gettingtogandoca</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/gettingtogandoca"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/gettingtogandocaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/gettingtogandoca"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/gettingtogandocaES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/gettingtogandoca"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/gettingtogandocaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/gettingtogandoca"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/travellingtopuertoviejo</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/travellingtopuertoviejo"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/travellingtopuertoviejoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/travellingtopuertoviejo"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/travellingtopuertoviejoES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/travellingtopuertoviejo"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/travellingtopuertoviejoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/travellingtopuertoviejo"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/puertoviejobyplane</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/puertoviejobyplane"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/puertoviejobyplaneES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/puertoviejobyplane"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/puertoviejobyplaneES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/puertoviejobyplane"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/puertoviejobyplaneES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/puertoviejobyplane"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/TenHoursInPuerto</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/TenHoursInPuerto"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/TenHoursInPuertoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/TenHoursInPuerto"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/TenHoursInPuertoES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/TenHoursInPuerto"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/TenHoursInPuertoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/TenHoursInPuerto"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/bushours</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/bushours"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/bushoursES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/bushours"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/bushoursES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/bushours"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/bushoursES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/bushours"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/cahuitaparkwhattodo</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/cahuitaparkwhattodo"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/cahuitaparkwhattodoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/cahuitaparkwhattodo"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/cahuitaparkwhattodoES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/cahuitaparkwhattodo"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/cahuitaparkwhattodoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/cahuitaparkwhattodo"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/indigenousTravelPV</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/indigenousTravelPV"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/indigenousTravelPVES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/indigenousTravelPV"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/indigenousTravelPVES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/indigenousTravelPV"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/indigenousTravelPVES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/indigenousTravelPV"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/bestTimeToVisitPuerto</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/bestTimeToVisitPuerto"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/bestTimeToVisitPuertoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/bestTimeToVisitPuerto"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/bestTimeToVisitPuertoES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/bestTimeToVisitPuerto"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/bestTimeToVisitPuertoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/bestTimeToVisitPuerto"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/puertoHiddenGems</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/puertoHiddenGems"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/puertoHiddenGemsES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/puertoHiddenGems"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/puertoHiddenGemsES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/puertoHiddenGems"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/puertoHiddenGemsES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/puertoHiddenGems"/>
+  </url>
+</urlset>

--- a/docs/seo-baseline/url-status-2026-08-06.json
+++ b/docs/seo-baseline/url-status-2026-08-06.json
@@ -1,0 +1,638 @@
+{
+  "origin": "https://www.reservaskalawala.com",
+  "capturedAt": "2026-08-06T20:02:24.788Z",
+  "results": [
+    {
+      "route": "/",
+      "url": "https://www.reservaskalawala.com/",
+      "status": 200,
+      "hops": 0,
+      "chain": [],
+      "final": "https://www.reservaskalawala.com/"
+    },
+    {
+      "route": "/404",
+      "url": "https://www.reservaskalawala.com/404",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/404/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/404/"
+    },
+    {
+      "route": "/Geco",
+      "url": "https://www.reservaskalawala.com/Geco",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/Geco/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/Geco/"
+    },
+    {
+      "route": "/Rana",
+      "url": "https://www.reservaskalawala.com/Rana",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/Rana/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/Rana/"
+    },
+    {
+      "route": "/Tucano",
+      "url": "https://www.reservaskalawala.com/Tucano",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/Tucano/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/Tucano/"
+    },
+    {
+      "route": "/Pappagallo",
+      "url": "https://www.reservaskalawala.com/Pappagallo",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/Pappagallo/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/Pappagallo/"
+    },
+    {
+      "route": "/Delfin",
+      "url": "https://www.reservaskalawala.com/Delfin",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/Delfin/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/Delfin/"
+    },
+    {
+      "route": "/Areka",
+      "url": "https://www.reservaskalawala.com/Areka",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/Areka/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/Areka/"
+    },
+    {
+      "route": "/Giulia",
+      "url": "https://www.reservaskalawala.com/Giulia",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/Giulia/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/Giulia/"
+    },
+    {
+      "route": "/Plumeria",
+      "url": "https://www.reservaskalawala.com/Plumeria",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/Plumeria/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/Plumeria/"
+    },
+    {
+      "route": "/VillaMar",
+      "url": "https://www.reservaskalawala.com/VillaMar",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/VillaMar/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/VillaMar/"
+    },
+    {
+      "route": "/VillaCoral",
+      "url": "https://www.reservaskalawala.com/VillaCoral",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/VillaCoral/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/VillaCoral/"
+    },
+    {
+      "route": "/HomeES",
+      "url": "https://www.reservaskalawala.com/HomeES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/HomeES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/HomeES/"
+    },
+    {
+      "route": "/GecoES",
+      "url": "https://www.reservaskalawala.com/GecoES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/GecoES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/GecoES/"
+    },
+    {
+      "route": "/RanaES",
+      "url": "https://www.reservaskalawala.com/RanaES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/RanaES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/RanaES/"
+    },
+    {
+      "route": "/TucanoES",
+      "url": "https://www.reservaskalawala.com/TucanoES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/TucanoES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/TucanoES/"
+    },
+    {
+      "route": "/PappagalloES",
+      "url": "https://www.reservaskalawala.com/PappagalloES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/PappagalloES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/PappagalloES/"
+    },
+    {
+      "route": "/DelfinES",
+      "url": "https://www.reservaskalawala.com/DelfinES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/DelfinES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/DelfinES/"
+    },
+    {
+      "route": "/ArekaES",
+      "url": "https://www.reservaskalawala.com/ArekaES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/ArekaES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/ArekaES/"
+    },
+    {
+      "route": "/GiuliaES",
+      "url": "https://www.reservaskalawala.com/GiuliaES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/GiuliaES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/GiuliaES/"
+    },
+    {
+      "route": "/PlumeriaES",
+      "url": "https://www.reservaskalawala.com/PlumeriaES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/PlumeriaES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/PlumeriaES/"
+    },
+    {
+      "route": "/VillaMarES",
+      "url": "https://www.reservaskalawala.com/VillaMarES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/VillaMarES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/VillaMarES/"
+    },
+    {
+      "route": "/VillaCoralES",
+      "url": "https://www.reservaskalawala.com/VillaCoralES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/VillaCoralES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/VillaCoralES/"
+    },
+    {
+      "route": "/HomeNam",
+      "url": "https://www.reservaskalawala.com/HomeNam",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/HomeNam/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/HomeNam/"
+    },
+    {
+      "route": "/HomeNamES",
+      "url": "https://www.reservaskalawala.com/HomeNamES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/HomeNamES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/HomeNamES/"
+    },
+    {
+      "route": "/HomeVillas",
+      "url": "https://www.reservaskalawala.com/HomeVillas",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/HomeVillas/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/HomeVillas/"
+    },
+    {
+      "route": "/HomeVillasES",
+      "url": "https://www.reservaskalawala.com/HomeVillasES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/HomeVillasES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/HomeVillasES/"
+    },
+    {
+      "route": "/blog",
+      "url": "https://www.reservaskalawala.com/blog",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/blog/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/blog/"
+    },
+    {
+      "route": "/blogES",
+      "url": "https://www.reservaskalawala.com/blogES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/blogES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/blogES/"
+    },
+    {
+      "route": "/twodaysinpuertoviejo",
+      "url": "https://www.reservaskalawala.com/twodaysinpuertoviejo",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/twodaysinpuertoviejo/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/twodaysinpuertoviejo/"
+    },
+    {
+      "route": "/gettingtogandoca",
+      "url": "https://www.reservaskalawala.com/gettingtogandoca",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/gettingtogandoca/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/gettingtogandoca/"
+    },
+    {
+      "route": "/travellingtopuertoviejo",
+      "url": "https://www.reservaskalawala.com/travellingtopuertoviejo",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/travellingtopuertoviejo/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/travellingtopuertoviejo/"
+    },
+    {
+      "route": "/puertoviejobyplane",
+      "url": "https://www.reservaskalawala.com/puertoviejobyplane",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/puertoviejobyplane/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/puertoviejobyplane/"
+    },
+    {
+      "route": "/TenHoursInPuerto",
+      "url": "https://www.reservaskalawala.com/TenHoursInPuerto",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/TenHoursInPuerto/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/TenHoursInPuerto/"
+    },
+    {
+      "route": "/bushours",
+      "url": "https://www.reservaskalawala.com/bushours",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/bushours/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/bushours/"
+    },
+    {
+      "route": "/cahuitaparkwhattodo",
+      "url": "https://www.reservaskalawala.com/cahuitaparkwhattodo",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/cahuitaparkwhattodo/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/cahuitaparkwhattodo/"
+    },
+    {
+      "route": "/indigenousTravelPV",
+      "url": "https://www.reservaskalawala.com/indigenousTravelPV",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/indigenousTravelPV/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/indigenousTravelPV/"
+    },
+    {
+      "route": "/bestTimeToVisitPuerto",
+      "url": "https://www.reservaskalawala.com/bestTimeToVisitPuerto",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/bestTimeToVisitPuerto/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/bestTimeToVisitPuerto/"
+    },
+    {
+      "route": "/puertoHiddenGems",
+      "url": "https://www.reservaskalawala.com/puertoHiddenGems",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/puertoHiddenGems/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/puertoHiddenGems/"
+    },
+    {
+      "route": "/twodaysinpuertoviejoES",
+      "url": "https://www.reservaskalawala.com/twodaysinpuertoviejoES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/twodaysinpuertoviejoES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/twodaysinpuertoviejoES/"
+    },
+    {
+      "route": "/gettingtogandocaES",
+      "url": "https://www.reservaskalawala.com/gettingtogandocaES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/gettingtogandocaES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/gettingtogandocaES/"
+    },
+    {
+      "route": "/travellingtopuertoviejoES",
+      "url": "https://www.reservaskalawala.com/travellingtopuertoviejoES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/travellingtopuertoviejoES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/travellingtopuertoviejoES/"
+    },
+    {
+      "route": "/puertoviejobyplaneES",
+      "url": "https://www.reservaskalawala.com/puertoviejobyplaneES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/puertoviejobyplaneES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/puertoviejobyplaneES/"
+    },
+    {
+      "route": "/TenHoursInPuertoES",
+      "url": "https://www.reservaskalawala.com/TenHoursInPuertoES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/TenHoursInPuertoES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/TenHoursInPuertoES/"
+    },
+    {
+      "route": "/bushoursES",
+      "url": "https://www.reservaskalawala.com/bushoursES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/bushoursES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/bushoursES/"
+    },
+    {
+      "route": "/cahuitaparkwhattodoES",
+      "url": "https://www.reservaskalawala.com/cahuitaparkwhattodoES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/cahuitaparkwhattodoES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/cahuitaparkwhattodoES/"
+    },
+    {
+      "route": "/indigenousTravelPVES",
+      "url": "https://www.reservaskalawala.com/indigenousTravelPVES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/indigenousTravelPVES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/indigenousTravelPVES/"
+    },
+    {
+      "route": "/bestTimeToVisitPuertoES",
+      "url": "https://www.reservaskalawala.com/bestTimeToVisitPuertoES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/bestTimeToVisitPuertoES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/bestTimeToVisitPuertoES/"
+    },
+    {
+      "route": "/puertoHiddenGemsES",
+      "url": "https://www.reservaskalawala.com/puertoHiddenGemsES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/puertoHiddenGemsES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/puertoHiddenGemsES/"
+    }
+  ]
+}

--- a/scripts/check-urls.mjs
+++ b/scripts/check-urls.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * URL inventory checker for the i18n rollout (docs/i18n-rollout-plan.md).
+ *
+ * Two modes:
+ *
+ *   capture   Walk every route in package.json -> reactSnap.include against a
+ *             live origin and record final status + redirect hop count into
+ *             docs/seo-baseline/url-status-<date>.json.
+ *
+ *   verify    Re-walk a saved baseline and fail if any URL stopped resolving,
+ *             or (once Phase 5 lands the 301 map) takes more than one hop.
+ *             Chained redirects leak link equity and Google reports them, so
+ *             hop count is asserted, not just the final status.
+ *
+ * Phase 0 uses capture. Phase 5 and Phase 10 use verify.
+ *
+ *   node scripts/check-urls.mjs capture
+ *   node scripts/check-urls.mjs verify docs/seo-baseline/url-status-2026-08-06.json
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const ORIGIN = process.env.ORIGIN || 'https://www.reservaskalawala.com';
+const CONCURRENCY = 4; // polite against a shared cPanel host
+
+/** Follow redirects by hand so we can count hops rather than just see the end. */
+async function trace(url) {
+  const chain = [];
+  let current = url;
+
+  for (let i = 0; i < 10; i++) {
+    let res;
+    try {
+      res = await fetch(current, { redirect: 'manual' });
+    } catch (err) {
+      return { url, status: 0, hops: chain.length, chain, error: String(err.cause?.code || err.message) };
+    }
+
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get('location');
+      if (!location) return { url, status: res.status, hops: chain.length, chain, error: 'redirect without location' };
+      current = new URL(location, current).toString();
+      chain.push({ status: res.status, to: current });
+      continue;
+    }
+    return { url, status: res.status, hops: chain.length, chain, final: current };
+  }
+  return { url, status: 0, hops: chain.length, chain, error: 'too many redirects' };
+}
+
+async function pool(items, worker) {
+  const results = new Array(items.length);
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(CONCURRENCY, items.length) }, async () => {
+      while (next < items.length) {
+        const i = next++;
+        results[i] = await worker(items[i]);
+      }
+    }),
+  );
+  return results;
+}
+
+function routes() {
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+  const list = pkg.reactSnap?.include || [];
+  if (!list.length) {
+    console.error('[check-urls] reactSnap.include is empty.');
+    process.exit(1);
+  }
+  return list;
+}
+
+async function capture() {
+  const list = routes();
+  console.log(`[check-urls] capturing ${list.length} routes against ${ORIGIN}`);
+
+  const results = await pool(list, async (route) => {
+    const r = await trace(ORIGIN + (route === '/' ? '/' : route));
+    console.log(`  ${String(r.status).padEnd(3)} ${r.hops ? `(${r.hops} hop) ` : ''}${route}${r.error ? ` -- ${r.error}` : ''}`);
+    return { route, ...r };
+  });
+
+  const stamp = new Date().toISOString().slice(0, 10);
+  const outDir = path.join(ROOT, 'docs', 'seo-baseline');
+  fs.mkdirSync(outDir, { recursive: true });
+  const out = path.join(outDir, `url-status-${stamp}.json`);
+  fs.writeFileSync(out, JSON.stringify({ origin: ORIGIN, capturedAt: new Date().toISOString(), results }, null, 2));
+
+  const ok = results.filter((r) => r.status === 200).length;
+  const redirected = results.filter((r) => r.hops > 0).length;
+  const broken = results.filter((r) => r.status !== 200);
+
+  console.log(`\n[check-urls] ${ok}/${results.length} returned 200, ${redirected} redirected`);
+  if (broken.length) {
+    console.log('[check-urls] NOT 200:');
+    for (const b of broken) console.log(`  ${b.status} ${b.route} ${b.error || ''}`);
+  }
+  console.log(`[check-urls] wrote ${path.relative(ROOT, out)}`);
+}
+
+async function verify(baselinePath) {
+  if (!baselinePath || !fs.existsSync(baselinePath)) {
+    console.error('[check-urls] verify needs a baseline file: node scripts/check-urls.mjs verify <file>');
+    process.exit(1);
+  }
+  const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
+  console.log(`[check-urls] verifying ${baseline.results.length} baseline URLs against ${ORIGIN}`);
+
+  const failures = [];
+  await pool(baseline.results, async (entry) => {
+    const r = await trace(entry.url.replace(baseline.origin, ORIGIN));
+    if (r.status !== 200) {
+      failures.push(`${r.status} ${entry.route} (was ${entry.status})`);
+    } else if (r.hops > 1) {
+      // A single 301 to the new locale-prefixed URL is expected post-Phase 5.
+      // More than one means a redirect chain.
+      failures.push(`${r.hops} hops ${entry.route} -> ${r.final}`);
+    }
+  });
+
+  if (failures.length) {
+    console.error(`\n[check-urls] ${failures.length} FAILED:`);
+    for (const f of failures) console.error(`  ${f}`);
+    process.exit(1);
+  }
+  console.log('\n[check-urls] all baseline URLs resolve in at most one hop.');
+}
+
+const [mode, arg] = process.argv.slice(2);
+if (mode === 'capture') await capture();
+else if (mode === 'verify') await verify(arg);
+else {
+  console.error('usage: node scripts/check-urls.mjs capture | verify <baseline.json>');
+  process.exit(1);
+}


### PR DESCRIPTION
Phase 0 of `docs/i18n-rollout-plan.md`. Captures the pre-migration state before any URL moves — once the locale prefixes land, "before" cannot be reconstructed.

Docs and one script. No application code.

## Captured

| File | What |
|---|---|
| `docs/seo-baseline/sitemap-2026-08-06.xml` | Live sitemap — 48 URLs, 144 hreflang alternates |
| `docs/seo-baseline/robots-2026-08-06.txt` | Live robots.txt — confirmed it advertises the sitemap correctly |
| `docs/seo-baseline/url-status-2026-08-06.json` | All 49 routes traced against production: status, hop count, full redirect chain |
| `docs/seo-baseline/lighthouse-2026-08-06.md` | Median of 3 mobile runs — perf 89–90, SEO 100 |

Adds `scripts/check-urls.mjs` with `capture` and `verify` modes. `verify` re-walks a saved baseline and fails on anything that stops resolving or takes more than one hop — that is the mechanism Phase 5 needs to prove the 301 map is chain-free, so it is written once here rather than twice.

## The finding that justified doing this properly

**48 of 49 URLs already 301 to a trailing slash.** `/Geco` → `/Geco/`, Apache `DirectorySlash` resolving the prerendered `Geco/index.html`. Only `/` is direct.

Two consequences, both recorded against the relevant phases in the plan:

1. **Phase 5 would have produced two-hop chains by default.** A naive `/PlumeriaES` → `/es/plumeria` redirect gets a second hop from `DirectorySlash` to `/es/plumeria/`. Redirect targets must carry the trailing slash. The plan's single-hop rule would have been violated on every migrated URL without this.
2. **The sitemap and every `rel="canonical"` currently point at redirecting URLs** — the sitemap lists `/Geco` while `/Geco/` is what gets served. Phase 6 should settle this in one direction.

## Still outstanding — needs your account access

`docs/seo-baseline/README.md` has click-by-click steps. The GSC export is the only irreversible item in the phase: Search Console retains 16 months and silently drops everything older.

- GSC Performance → 16 months → export Pages and Queries as CSV
- GSC Indexing → Pages → indexed vs not-indexed counts
- PostHog → monthly organic sessions, EN vs ES, 12 months

Phase 1 does not depend on any of these and can start in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
