### PR TITLE
refactor(i18n): Phase 1 — replace isSpanish boolean with a Locale type

### DIFF
--- a/docs/i18n-rollout-plan.md
+++ b/docs/i18n-rollout-plan.md
@@ -15,14 +15,14 @@ resume without re-investigating the codebase.
 
 | | |
 |---|---|
-| **Current phase** | Phase 0 — not started |
+| **Current phase** | Phase 0 — in progress, partly blocked |
 | **Last updated** | 2026-08-06 |
-| **Branch(es) in flight** | none |
-| **Blocked on** | nothing |
+| **Branch(es) in flight** | `chore/i18n-phase-0-baseline` |
+| **Blocked on** | **Owner action:** Google Search Console + PostHog exports — see [`seo-baseline/README.md`](seo-baseline/README.md). The GSC export cannot be done retroactively. |
 
 Phase progress:
 
-- [ ] Phase 0 — Baseline capture and safety net
+- [ ] Phase 0 — Baseline capture and safety net *(automated parts done; GSC/PostHog exports outstanding)*
 - [ ] Phase 1 — Locale foundation (`isSpanish` → `locale`)
 - [ ] Phase 2 — Message catalogs
 - [ ] Phase 3 — Collapse duplicated page components
@@ -142,18 +142,36 @@ Each phase should be its own PR against `main`.
 ### Phase 0 — Baseline capture and safety net
 
 Do this before touching anything. Once URLs move, you cannot reconstruct what
-"before" looked like.
+"before" looked like. Everything lands in [`seo-baseline/`](seo-baseline/) —
+see its README for the detail.
 
-- [ ] Export current Google Search Console performance: 16 months, by page and by
-      query, for both EN and ES URLs. Save as CSV in `docs/seo-baseline/`.
-- [ ] Record current indexed page count per URL pattern (GSC → Pages).
-- [ ] Save the current `sitemap.xml` from production.
-- [ ] Run Lighthouse on `/`, `/HomeES`, one listing, one blog article; record scores
-      (`npm run lh`).
-- [ ] Write down current monthly organic sessions per language from PostHog.
+- [x] Save the current `sitemap.xml` and `robots.txt` from production
+      (48 URLs, 144 hreflang alternates; robots correctly advertises the sitemap).
+- [x] Capture the live status + redirect chain of all 49 routes
+      (`node scripts/check-urls.mjs capture`).
+- [x] Add `scripts/check-urls.mjs` — the same tool asserts single-hop redirects in
+      Phase 5 and Phase 10.
+- [ ] **Owner:** export GSC performance, 16 months, Pages + Queries tabs, as CSV.
+- [ ] **Owner:** record GSC indexed vs not-indexed page counts.
+- [ ] **Owner:** export PostHog monthly organic sessions, EN vs ES, 12 months.
+- [ ] Lighthouse baseline for `/`, `/HomeES`, `/Geco`, `/twodaysinpuertoviejo`.
 
-**Validation:** the baseline CSVs exist and are committed. This phase is the only
+**Validation:** the baseline files exist and are committed. This phase is the only
 insurance against "did the migration hurt us?" being unanswerable.
+
+> **Finding — every URL already costs a redirect.** All 49 routes return 200, but
+> 48 take a 301 first: `/Geco` → `/Geco/`, Apache `DirectorySlash` resolving the
+> prerendered `Geco/index.html`. Only `/` is direct.
+>
+> This changes Phase 5. A naive `/PlumeriaES` → `/es/plumeria` redirect becomes a
+> **two-hop chain**, because `DirectorySlash` then sends `/es/plumeria` →
+> `/es/plumeria/`. **Redirect targets in the 301 map must include the trailing
+> slash.**
+>
+> It also means the sitemap and every `rel="canonical"` currently point at
+> redirecting URLs (`/Geco`, while `/Geco/` is what gets served). Phase 6 should
+> settle this one way or the other — adopt the trailing slash everywhere, or
+> change `.htaccess` to serve without it.
 
 ### Phase 1 — Locale foundation
 
@@ -236,6 +254,11 @@ hardcoded legacy path remains (`grep -rn '"/\(Home\|Plumeria\|VillaMar\)' src`).
 - [ ] Redirects must be **single-hop**. `/PlumeriaES` → `/es/plumeria` directly,
       never via an intermediate. Chained redirects leak link equity and Google
       reports them.
+- [ ] **Targets must carry the trailing slash** — `/es/plumeria/`, not
+      `/es/plumeria`. Per the Phase 0 finding, `DirectorySlash` adds its own 301
+      otherwise and every migrated URL becomes a two-hop chain. Either emit the
+      slash in the map, or disable `DirectorySlash` and serve without it — but
+      pick one and make the sitemap, canonicals and hreflang agree.
 - [ ] Verify the existing `ErrorDocument 404 /404.html` behaviour still works
       after the new rules (see the comments already in `public/.htaccess`).
 
@@ -411,6 +434,18 @@ what the next session should pick up.
 - Surveyed the codebase (findings recorded in Ground Truth above).
 - Locked the three decisions: path-prefix URLs, blog included, machine
   translation published as-is.
-- Nothing implemented yet. **Next session: start Phase 0** — the GSC baseline
-  export must happen before any URL work, and it is the one step that cannot be
-  done retroactively.
+- Merged as PR #38.
+
+### 2026-08-06 — Phase 0, automated half
+- Captured production `sitemap.xml` (48 URLs) and `robots.txt` into
+  `docs/seo-baseline/`. robots correctly advertises the sitemap.
+- Added `scripts/check-urls.mjs` (capture + verify modes) and captured the live
+  status of all 49 routes.
+- **Found: 48 of 49 URLs already 301 to a trailing slash** via `DirectorySlash`.
+  Recorded against Phase 5 and Phase 6 above — redirect targets must include the
+  trailing slash or every migrated URL becomes a two-hop chain. This is the
+  finding that justified doing Phase 0 properly rather than skipping to Phase 1.
+- **Next session:** Phase 0 is blocked on the owner's GSC + PostHog exports
+  (`docs/seo-baseline/README.md` has click-by-click steps). The GSC export is the
+  only irreversible item — 16-month retention means unexported data is gone.
+  Phase 1 does not depend on it and can start in parallel.

--- a/docs/i18n-rollout-plan.md
+++ b/docs/i18n-rollout-plan.md
@@ -176,17 +176,29 @@ insurance against "did the migration hurt us?" being unanswerable.
 
 ### Phase 1 — Locale foundation
 
-- [ ] Add `src/i18n/locales.ts`: `Locale` union type, `LOCALES`, display names,
-      flag codes, `DEFAULT_LOCALE`.
-- [ ] Add `useLocale()` hook + `LocaleProvider`, reading from the route param
-      (falls back to `en` until Phase 4 lands the routes).
-- [ ] Mechanically replace `isSpanish: boolean` with `locale: Locale` across all
-      69 files. At this stage every call site passes `'en'` or `'es'` — behaviour
-      is unchanged.
-- [ ] Replace the 49 inline `isSpanish ? a : b` ternaries with catalog lookups
-      (Phase 2 provides the catalog; stub it with an `en`/`es` map first).
-- [ ] Delete `isSpanishPath()` string math from `Flag.component.tsx`; locale now
-      comes from the route, not from guessing at a suffix.
+- [x] Add `src/i18n/locales.ts`: `Locale` union type, `LOCALES` (all six),
+      `DEFAULT_LOCALE`, `RELEASED_LOCALES`, `LOCALE_META` (native names + flag codes).
+- [x] Add `useLocale()` hook, plus `detectLocaleFromPath()` as the single source
+      of truth for "what language is this URL?".
+- [x] Mechanically replace `isSpanish: boolean` with `locale: Locale`.
+      **Zero `isSpanish` identifiers remain in `src/`.**
+- [x] Collapse the nine hand-rolled Spanish-route checks onto `detectLocaleFromPath`.
+- [x] Delete `isSpanishPath()` string math from `Flag.component.tsx`.
+- [ ] ~~Replace the 49 inline ternaries with catalog lookups~~ — **moved to Phase 2**,
+      see the scope note below.
+
+> **Scope change, made deliberately.** The original Phase 1 also converted the 49
+> inline `isSpanish ? a : b` ternaries to catalog lookups. That was moved to
+> Phase 2, because designing the catalog API is not a mechanical change and
+> mixing it into a 60-file rename makes the diff unreviewable — which this
+> phase's own note warns against. The ternaries are now `locale === 'es' ? a : b`:
+> behaviour-identical, and DE/FR/IT/PT correctly fall through to English until
+> Phase 2 gives them real lookups.
+>
+> Two shims are left standing on purpose, both marked `@deprecated` in code:
+> `useLanguageDetection()` (now delegating to `useLocale()`, so it can no longer
+> drift) and `useRandomPopup`'s `isSpanishPage` boolean. Their callers branch on
+> a boolean in many places; converting them belongs with Phase 2.
 
 **Validation:** `npx tsc --noEmit` clean; `npm run test:e2e`; manual pass over
 `/` and `/HomeES` confirming zero visual change. The TypeScript union is doing

--- a/docs/i18n-rollout-plan.md
+++ b/docs/i18n-rollout-plan.md
@@ -151,10 +151,11 @@ see its README for the detail.
       (`node scripts/check-urls.mjs capture`).
 - [x] Add `scripts/check-urls.mjs` — the same tool asserts single-hop redirects in
       Phase 5 and Phase 10.
+- [x] Lighthouse baseline for `/`, `/HomeES`, `/Geco`, `/twodaysinpuertoviejo`
+      (`seo-baseline/lighthouse-2026-08-06.md` — perf 89–90, SEO 100 across the board).
 - [ ] **Owner:** export GSC performance, 16 months, Pages + Queries tabs, as CSV.
 - [ ] **Owner:** record GSC indexed vs not-indexed page counts.
 - [ ] **Owner:** export PostHog monthly organic sessions, EN vs ES, 12 months.
-- [ ] Lighthouse baseline for `/`, `/HomeES`, `/Geco`, `/twodaysinpuertoviejo`.
 
 **Validation:** the baseline files exist and are committed. This phase is the only
 insurance against "did the migration hurt us?" being unanswerable.

--- a/docs/seo-baseline/README.md
+++ b/docs/seo-baseline/README.md
@@ -1,0 +1,118 @@
+# SEO baseline — captured before the i18n URL migration
+
+Phase 0 of [`../i18n-rollout-plan.md`](../i18n-rollout-plan.md).
+
+**Why this exists:** the rollout moves every URL on the site to a locale prefix
+(`/Plumeria` → `/en/plumeria`). Once that ships, there is no way to reconstruct
+what traffic and indexing looked like beforehand. This directory is the only
+record of "before", and it is what the post-launch comparison in Phase 10 is
+measured against.
+
+Captured **2026-08-06**, against production, at commit `095d7ad`.
+
+---
+
+## What is already here
+
+| File | What it is |
+|---|---|
+| `sitemap-2026-08-06.xml` | Live sitemap as served. 48 URLs, 144 `xhtml:link` hreflang alternates. |
+| `robots-2026-08-06.txt` | Live robots.txt. Confirmed it advertises the sitemap correctly. |
+| `url-status-2026-08-06.json` | Every route in `reactSnap.include` traced against production: final status, redirect hop count, full chain. |
+
+Regenerate the URL trace at any time with:
+
+```bash
+node scripts/check-urls.mjs capture
+```
+
+After Phase 5 lands the 301 map, the same script asserts that every one of these
+URLs still resolves in **at most one hop**:
+
+```bash
+node scripts/check-urls.mjs verify docs/seo-baseline/url-status-2026-08-06.json
+```
+
+---
+
+## Finding: every URL already costs a redirect
+
+All 49 routes return 200, but **48 of them take a 301 first**. Only `/` is direct.
+
+```
+https://www.reservaskalawala.com/Geco
+  -> 301 https://www.reservaskalawala.com/Geco/
+```
+
+This is Apache `mod_dir`'s `DirectorySlash`: the build emits `Geco/index.html`,
+so a request for `/Geco` is redirected to `/Geco/` before it is served.
+
+Two consequences, both of which predate the i18n work:
+
+1. **The sitemap and the canonical tags point at redirecting URLs.** The sitemap
+   lists `/Geco`, and `ListingGeco.page.tsx` declares
+   `<link rel="canonical" href="https://www.reservaskalawala.com/Geco" />` — but
+   the served URL is `/Geco/`. Every hreflang alternate has the same mismatch.
+   Google resolves this, but it is a muddled signal for free.
+
+2. **It breaks the Phase 5 single-hop rule by default.** A naive
+   `/PlumeriaES` → `/es/plumeria` redirect becomes a two-hop chain, because
+   `DirectorySlash` then sends `/es/plumeria` → `/es/plumeria/`. Redirect targets
+   in the 301 map **must include the trailing slash**, or every migrated URL
+   chains. This is the single most useful thing this baseline turned up.
+
+Decide during Phase 6 whether canonical URLs and the sitemap adopt the trailing
+slash (matching what is served) or whether `.htaccess` is changed to serve
+without it. Either is fine; the current split is not.
+
+---
+
+## Still to capture — needs your account access
+
+I cannot reach Google Search Console or PostHog. These are the parts of Phase 0
+that need you, and the GSC export is the one that **cannot be done later**.
+
+### 1. Google Search Console — performance export
+
+<https://search.google.com/search-console> → property `reservaskalawala.com`
+
+- **Performance → Search results**, set the date range to **16 months** (the
+  maximum retained; anything older is already gone).
+- Export twice, via the **Export** button top-right → *Download CSV*:
+  - **Pages** tab → save as `gsc-pages-16mo-2026-08-06.csv`
+  - **Queries** tab → save as `gsc-queries-16mo-2026-08-06.csv`
+- Drop both files in this directory.
+
+### 2. Google Search Console — indexing snapshot
+
+- **Indexing → Pages**. Record the number of **indexed** vs **not indexed** pages
+  and the breakdown by reason.
+- A screenshot saved as `gsc-indexing-2026-08-06.png` is enough.
+
+### 3. PostHog — organic sessions by language
+
+- Monthly organic sessions for the last 12 months, split EN vs ES (the URL suffix
+  `ES` separates them today — after the migration it will be the `/es/` prefix).
+- Save as `posthog-sessions-2026-08-06.csv`.
+
+### Why 16 months
+
+Search Console retains 16 months and silently drops everything older. Whatever is
+not exported before the migration is not recoverable afterwards, which is why
+this is the first task in the plan rather than a later one.
+
+---
+
+## Lighthouse
+
+Scores for `/`, `/HomeES`, `/Geco` and `/twodaysinpuertoviejo` go in
+`lighthouse-2026-08-06.md` when captured:
+
+```bash
+npm run build          # needs the full prerender; Lighthouse serves build/
+node scripts/lighthouse-run.mjs --runs=3 --label=i18n-baseline
+```
+
+Unlike the GSC export, this one **is** reproducible later — the script runs
+against a build from any commit, so a missed Lighthouse baseline can be
+recreated from git history. Do not let it block the phase.

--- a/docs/seo-baseline/lighthouse-2026-08-06.md
+++ b/docs/seo-baseline/lighthouse-2026-08-06.md
@@ -1,0 +1,25 @@
+# Lighthouse — i18n-baseline
+
+Median of 3 run(s) per route. gzip on, /static/ immutable.
+
+| Route | Perf | A11y | BP | SEO | FCP | LCP | TBT | CLS | SI |
+|---|---|---|---|---|---|---|---|---|---|
+| `/` | 90 | 96 | 96 | 100 | 1.7 s | 3.6 s | 0 ms | 0 | 1.7 s |
+| `/Geco` | 90 | 96 | 96 | 100 | 1.5 s | 3.6 s | 0 ms | 0 | 1.5 s |
+| `/HomeES` | 90 | 96 | 96 | 100 | 1.7 s | 3.6 s | 10 ms | 0 | 1.7 s |
+| `/twodaysinpuertoviejo` | 89 | 100 | 75 | 100 | 1.4 s | 3.8 s | 0 ms | 0 | 1.4 s |
+
+Reports: lighthouse-reports\i18n-baseline
+
+Captured 2026-08-06 at commit `095d7ad`, mobile emulation, median of 3 runs.
+
+Reproduce with:
+
+```bash
+npm run build
+node scripts/lighthouse-run.mjs --runs=3 --label=i18n-baseline
+```
+
+Note: `/twodaysinpuertoviejo` scores 75 on Best Practices against 96 elsewhere.
+That gap predates the i18n work — worth a look on its own, but it is recorded
+here only as the "before" number, not as something the rollout should fix.

--- a/docs/seo-baseline/robots-2026-08-06.txt
+++ b/docs/seo-baseline/robots-2026-08-06.txt
@@ -1,0 +1,46 @@
+# https://www.robotstxt.org/robotstxt.html
+
+# Allow all standard search engines
+User-agent: *
+Disallow:
+
+# Explicitly allow AI crawlers for search/retrieval
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: Meta-ExternalAgent
+Allow: /
+
+# Block training-only crawlers that don't drive search visibility
+User-agent: CCBot
+Disallow: /
+
+# Sitemap
+Sitemap: https://www.reservaskalawala.com/sitemap.xml

--- a/docs/seo-baseline/sitemap-2026-08-06.xml
+++ b/docs/seo-baseline/sitemap-2026-08-06.xml
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://www.reservaskalawala.com/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/HomeES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/HomeES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/HomeES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/Geco</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Geco"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/GecoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Geco"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/GecoES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Geco"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/GecoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Geco"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/Rana</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Rana"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/RanaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Rana"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/RanaES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Rana"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/RanaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Rana"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/Tucano</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Tucano"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/TucanoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Tucano"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/TucanoES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Tucano"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/TucanoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Tucano"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/Pappagallo</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Pappagallo"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/PappagalloES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Pappagallo"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/PappagalloES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Pappagallo"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/PappagalloES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Pappagallo"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/Delfin</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Delfin"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/DelfinES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Delfin"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/DelfinES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Delfin"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/DelfinES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Delfin"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/Areka</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Areka"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/ArekaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Areka"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/ArekaES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Areka"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/ArekaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Areka"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/Giulia</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Giulia"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/GiuliaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Giulia"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/GiuliaES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Giulia"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/GiuliaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Giulia"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/Plumeria</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Plumeria"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/PlumeriaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Plumeria"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/PlumeriaES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/Plumeria"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/PlumeriaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/Plumeria"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/VillaMar</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/VillaMar"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/VillaMarES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/VillaMar"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/VillaMarES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/VillaMar"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/VillaMarES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/VillaMar"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/VillaCoral</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/VillaCoral"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/VillaCoralES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/VillaCoral"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/VillaCoralES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/VillaCoral"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/VillaCoralES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/VillaCoral"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/HomeNam</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/HomeNam"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/HomeNamES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/HomeNam"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/HomeNamES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/HomeNam"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/HomeNamES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/HomeNam"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/HomeVillas</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/HomeVillas"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/HomeVillasES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/HomeVillas"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/HomeVillasES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/HomeVillas"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/HomeVillasES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/HomeVillas"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/blog</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/blog"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/blogES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/blog"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/blogES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/blog"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/blogES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/blog"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/twodaysinpuertoviejo</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/twodaysinpuertoviejo"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/twodaysinpuertoviejoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/twodaysinpuertoviejo"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/twodaysinpuertoviejoES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/twodaysinpuertoviejo"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/twodaysinpuertoviejoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/twodaysinpuertoviejo"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/gettingtogandoca</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/gettingtogandoca"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/gettingtogandocaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/gettingtogandoca"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/gettingtogandocaES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/gettingtogandoca"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/gettingtogandocaES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/gettingtogandoca"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/travellingtopuertoviejo</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/travellingtopuertoviejo"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/travellingtopuertoviejoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/travellingtopuertoviejo"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/travellingtopuertoviejoES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/travellingtopuertoviejo"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/travellingtopuertoviejoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/travellingtopuertoviejo"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/puertoviejobyplane</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/puertoviejobyplane"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/puertoviejobyplaneES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/puertoviejobyplane"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/puertoviejobyplaneES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/puertoviejobyplane"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/puertoviejobyplaneES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/puertoviejobyplane"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/TenHoursInPuerto</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/TenHoursInPuerto"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/TenHoursInPuertoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/TenHoursInPuerto"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/TenHoursInPuertoES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/TenHoursInPuerto"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/TenHoursInPuertoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/TenHoursInPuerto"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/bushours</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/bushours"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/bushoursES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/bushours"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/bushoursES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/bushours"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/bushoursES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/bushours"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/cahuitaparkwhattodo</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/cahuitaparkwhattodo"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/cahuitaparkwhattodoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/cahuitaparkwhattodo"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/cahuitaparkwhattodoES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/cahuitaparkwhattodo"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/cahuitaparkwhattodoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/cahuitaparkwhattodo"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/indigenousTravelPV</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/indigenousTravelPV"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/indigenousTravelPVES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/indigenousTravelPV"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/indigenousTravelPVES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/indigenousTravelPV"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/indigenousTravelPVES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/indigenousTravelPV"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/bestTimeToVisitPuerto</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/bestTimeToVisitPuerto"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/bestTimeToVisitPuertoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/bestTimeToVisitPuerto"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/bestTimeToVisitPuertoES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/bestTimeToVisitPuerto"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/bestTimeToVisitPuertoES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/bestTimeToVisitPuerto"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/puertoHiddenGems</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/puertoHiddenGems"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/puertoHiddenGemsES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/puertoHiddenGems"/>
+  </url>
+  <url>
+    <loc>https://www.reservaskalawala.com/puertoHiddenGemsES</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.reservaskalawala.com/puertoHiddenGems"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://www.reservaskalawala.com/puertoHiddenGemsES"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.reservaskalawala.com/puertoHiddenGems"/>
+  </url>
+</urlset>

--- a/docs/seo-baseline/url-status-2026-08-06.json
+++ b/docs/seo-baseline/url-status-2026-08-06.json
@@ -1,0 +1,638 @@
+{
+  "origin": "https://www.reservaskalawala.com",
+  "capturedAt": "2026-08-06T20:02:24.788Z",
+  "results": [
+    {
+      "route": "/",
+      "url": "https://www.reservaskalawala.com/",
+      "status": 200,
+      "hops": 0,
+      "chain": [],
+      "final": "https://www.reservaskalawala.com/"
+    },
+    {
+      "route": "/404",
+      "url": "https://www.reservaskalawala.com/404",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/404/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/404/"
+    },
+    {
+      "route": "/Geco",
+      "url": "https://www.reservaskalawala.com/Geco",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/Geco/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/Geco/"
+    },
+    {
+      "route": "/Rana",
+      "url": "https://www.reservaskalawala.com/Rana",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/Rana/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/Rana/"
+    },
+    {
+      "route": "/Tucano",
+      "url": "https://www.reservaskalawala.com/Tucano",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/Tucano/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/Tucano/"
+    },
+    {
+      "route": "/Pappagallo",
+      "url": "https://www.reservaskalawala.com/Pappagallo",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/Pappagallo/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/Pappagallo/"
+    },
+    {
+      "route": "/Delfin",
+      "url": "https://www.reservaskalawala.com/Delfin",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/Delfin/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/Delfin/"
+    },
+    {
+      "route": "/Areka",
+      "url": "https://www.reservaskalawala.com/Areka",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/Areka/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/Areka/"
+    },
+    {
+      "route": "/Giulia",
+      "url": "https://www.reservaskalawala.com/Giulia",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/Giulia/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/Giulia/"
+    },
+    {
+      "route": "/Plumeria",
+      "url": "https://www.reservaskalawala.com/Plumeria",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/Plumeria/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/Plumeria/"
+    },
+    {
+      "route": "/VillaMar",
+      "url": "https://www.reservaskalawala.com/VillaMar",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/VillaMar/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/VillaMar/"
+    },
+    {
+      "route": "/VillaCoral",
+      "url": "https://www.reservaskalawala.com/VillaCoral",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/VillaCoral/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/VillaCoral/"
+    },
+    {
+      "route": "/HomeES",
+      "url": "https://www.reservaskalawala.com/HomeES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/HomeES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/HomeES/"
+    },
+    {
+      "route": "/GecoES",
+      "url": "https://www.reservaskalawala.com/GecoES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/GecoES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/GecoES/"
+    },
+    {
+      "route": "/RanaES",
+      "url": "https://www.reservaskalawala.com/RanaES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/RanaES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/RanaES/"
+    },
+    {
+      "route": "/TucanoES",
+      "url": "https://www.reservaskalawala.com/TucanoES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/TucanoES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/TucanoES/"
+    },
+    {
+      "route": "/PappagalloES",
+      "url": "https://www.reservaskalawala.com/PappagalloES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/PappagalloES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/PappagalloES/"
+    },
+    {
+      "route": "/DelfinES",
+      "url": "https://www.reservaskalawala.com/DelfinES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/DelfinES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/DelfinES/"
+    },
+    {
+      "route": "/ArekaES",
+      "url": "https://www.reservaskalawala.com/ArekaES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/ArekaES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/ArekaES/"
+    },
+    {
+      "route": "/GiuliaES",
+      "url": "https://www.reservaskalawala.com/GiuliaES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/GiuliaES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/GiuliaES/"
+    },
+    {
+      "route": "/PlumeriaES",
+      "url": "https://www.reservaskalawala.com/PlumeriaES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/PlumeriaES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/PlumeriaES/"
+    },
+    {
+      "route": "/VillaMarES",
+      "url": "https://www.reservaskalawala.com/VillaMarES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/VillaMarES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/VillaMarES/"
+    },
+    {
+      "route": "/VillaCoralES",
+      "url": "https://www.reservaskalawala.com/VillaCoralES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/VillaCoralES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/VillaCoralES/"
+    },
+    {
+      "route": "/HomeNam",
+      "url": "https://www.reservaskalawala.com/HomeNam",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/HomeNam/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/HomeNam/"
+    },
+    {
+      "route": "/HomeNamES",
+      "url": "https://www.reservaskalawala.com/HomeNamES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/HomeNamES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/HomeNamES/"
+    },
+    {
+      "route": "/HomeVillas",
+      "url": "https://www.reservaskalawala.com/HomeVillas",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/HomeVillas/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/HomeVillas/"
+    },
+    {
+      "route": "/HomeVillasES",
+      "url": "https://www.reservaskalawala.com/HomeVillasES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/HomeVillasES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/HomeVillasES/"
+    },
+    {
+      "route": "/blog",
+      "url": "https://www.reservaskalawala.com/blog",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/blog/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/blog/"
+    },
+    {
+      "route": "/blogES",
+      "url": "https://www.reservaskalawala.com/blogES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/blogES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/blogES/"
+    },
+    {
+      "route": "/twodaysinpuertoviejo",
+      "url": "https://www.reservaskalawala.com/twodaysinpuertoviejo",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/twodaysinpuertoviejo/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/twodaysinpuertoviejo/"
+    },
+    {
+      "route": "/gettingtogandoca",
+      "url": "https://www.reservaskalawala.com/gettingtogandoca",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/gettingtogandoca/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/gettingtogandoca/"
+    },
+    {
+      "route": "/travellingtopuertoviejo",
+      "url": "https://www.reservaskalawala.com/travellingtopuertoviejo",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/travellingtopuertoviejo/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/travellingtopuertoviejo/"
+    },
+    {
+      "route": "/puertoviejobyplane",
+      "url": "https://www.reservaskalawala.com/puertoviejobyplane",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/puertoviejobyplane/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/puertoviejobyplane/"
+    },
+    {
+      "route": "/TenHoursInPuerto",
+      "url": "https://www.reservaskalawala.com/TenHoursInPuerto",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/TenHoursInPuerto/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/TenHoursInPuerto/"
+    },
+    {
+      "route": "/bushours",
+      "url": "https://www.reservaskalawala.com/bushours",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/bushours/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/bushours/"
+    },
+    {
+      "route": "/cahuitaparkwhattodo",
+      "url": "https://www.reservaskalawala.com/cahuitaparkwhattodo",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/cahuitaparkwhattodo/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/cahuitaparkwhattodo/"
+    },
+    {
+      "route": "/indigenousTravelPV",
+      "url": "https://www.reservaskalawala.com/indigenousTravelPV",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/indigenousTravelPV/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/indigenousTravelPV/"
+    },
+    {
+      "route": "/bestTimeToVisitPuerto",
+      "url": "https://www.reservaskalawala.com/bestTimeToVisitPuerto",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/bestTimeToVisitPuerto/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/bestTimeToVisitPuerto/"
+    },
+    {
+      "route": "/puertoHiddenGems",
+      "url": "https://www.reservaskalawala.com/puertoHiddenGems",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/puertoHiddenGems/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/puertoHiddenGems/"
+    },
+    {
+      "route": "/twodaysinpuertoviejoES",
+      "url": "https://www.reservaskalawala.com/twodaysinpuertoviejoES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/twodaysinpuertoviejoES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/twodaysinpuertoviejoES/"
+    },
+    {
+      "route": "/gettingtogandocaES",
+      "url": "https://www.reservaskalawala.com/gettingtogandocaES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/gettingtogandocaES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/gettingtogandocaES/"
+    },
+    {
+      "route": "/travellingtopuertoviejoES",
+      "url": "https://www.reservaskalawala.com/travellingtopuertoviejoES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/travellingtopuertoviejoES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/travellingtopuertoviejoES/"
+    },
+    {
+      "route": "/puertoviejobyplaneES",
+      "url": "https://www.reservaskalawala.com/puertoviejobyplaneES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/puertoviejobyplaneES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/puertoviejobyplaneES/"
+    },
+    {
+      "route": "/TenHoursInPuertoES",
+      "url": "https://www.reservaskalawala.com/TenHoursInPuertoES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/TenHoursInPuertoES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/TenHoursInPuertoES/"
+    },
+    {
+      "route": "/bushoursES",
+      "url": "https://www.reservaskalawala.com/bushoursES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/bushoursES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/bushoursES/"
+    },
+    {
+      "route": "/cahuitaparkwhattodoES",
+      "url": "https://www.reservaskalawala.com/cahuitaparkwhattodoES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/cahuitaparkwhattodoES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/cahuitaparkwhattodoES/"
+    },
+    {
+      "route": "/indigenousTravelPVES",
+      "url": "https://www.reservaskalawala.com/indigenousTravelPVES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/indigenousTravelPVES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/indigenousTravelPVES/"
+    },
+    {
+      "route": "/bestTimeToVisitPuertoES",
+      "url": "https://www.reservaskalawala.com/bestTimeToVisitPuertoES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/bestTimeToVisitPuertoES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/bestTimeToVisitPuertoES/"
+    },
+    {
+      "route": "/puertoHiddenGemsES",
+      "url": "https://www.reservaskalawala.com/puertoHiddenGemsES",
+      "status": 200,
+      "hops": 1,
+      "chain": [
+        {
+          "status": 301,
+          "to": "https://www.reservaskalawala.com/puertoHiddenGemsES/"
+        }
+      ],
+      "final": "https://www.reservaskalawala.com/puertoHiddenGemsES/"
+    }
+  ]
+}

--- a/scripts/check-urls.mjs
+++ b/scripts/check-urls.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * URL inventory checker for the i18n rollout (docs/i18n-rollout-plan.md).
+ *
+ * Two modes:
+ *
+ *   capture   Walk every route in package.json -> reactSnap.include against a
+ *             live origin and record final status + redirect hop count into
+ *             docs/seo-baseline/url-status-<date>.json.
+ *
+ *   verify    Re-walk a saved baseline and fail if any URL stopped resolving,
+ *             or (once Phase 5 lands the 301 map) takes more than one hop.
+ *             Chained redirects leak link equity and Google reports them, so
+ *             hop count is asserted, not just the final status.
+ *
+ * Phase 0 uses capture. Phase 5 and Phase 10 use verify.
+ *
+ *   node scripts/check-urls.mjs capture
+ *   node scripts/check-urls.mjs verify docs/seo-baseline/url-status-2026-08-06.json
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const ORIGIN = process.env.ORIGIN || 'https://www.reservaskalawala.com';
+const CONCURRENCY = 4; // polite against a shared cPanel host
+
+/** Follow redirects by hand so we can count hops rather than just see the end. */
+async function trace(url) {
+  const chain = [];
+  let current = url;
+
+  for (let i = 0; i < 10; i++) {
+    let res;
+    try {
+      res = await fetch(current, { redirect: 'manual' });
+    } catch (err) {
+      return { url, status: 0, hops: chain.length, chain, error: String(err.cause?.code || err.message) };
+    }
+
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get('location');
+      if (!location) return { url, status: res.status, hops: chain.length, chain, error: 'redirect without location' };
+      current = new URL(location, current).toString();
+      chain.push({ status: res.status, to: current });
+      continue;
+    }
+    return { url, status: res.status, hops: chain.length, chain, final: current };
+  }
+  return { url, status: 0, hops: chain.length, chain, error: 'too many redirects' };
+}
+
+async function pool(items, worker) {
+  const results = new Array(items.length);
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(CONCURRENCY, items.length) }, async () => {
+      while (next < items.length) {
+        const i = next++;
+        results[i] = await worker(items[i]);
+      }
+    }),
+  );
+  return results;
+}
+
+function routes() {
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+  const list = pkg.reactSnap?.include || [];
+  if (!list.length) {
+    console.error('[check-urls] reactSnap.include is empty.');
+    process.exit(1);
+  }
+  return list;
+}
+
+async function capture() {
+  const list = routes();
+  console.log(`[check-urls] capturing ${list.length} routes against ${ORIGIN}`);
+
+  const results = await pool(list, async (route) => {
+    const r = await trace(ORIGIN + (route === '/' ? '/' : route));
+    console.log(`  ${String(r.status).padEnd(3)} ${r.hops ? `(${r.hops} hop) ` : ''}${route}${r.error ? ` -- ${r.error}` : ''}`);
+    return { route, ...r };
+  });
+
+  const stamp = new Date().toISOString().slice(0, 10);
+  const outDir = path.join(ROOT, 'docs', 'seo-baseline');
+  fs.mkdirSync(outDir, { recursive: true });
+  const out = path.join(outDir, `url-status-${stamp}.json`);
+  fs.writeFileSync(out, JSON.stringify({ origin: ORIGIN, capturedAt: new Date().toISOString(), results }, null, 2));
+
+  const ok = results.filter((r) => r.status === 200).length;
+  const redirected = results.filter((r) => r.hops > 0).length;
+  const broken = results.filter((r) => r.status !== 200);
+
+  console.log(`\n[check-urls] ${ok}/${results.length} returned 200, ${redirected} redirected`);
+  if (broken.length) {
+    console.log('[check-urls] NOT 200:');
+    for (const b of broken) console.log(`  ${b.status} ${b.route} ${b.error || ''}`);
+  }
+  console.log(`[check-urls] wrote ${path.relative(ROOT, out)}`);
+}
+
+async function verify(baselinePath) {
+  if (!baselinePath || !fs.existsSync(baselinePath)) {
+    console.error('[check-urls] verify needs a baseline file: node scripts/check-urls.mjs verify <file>');
+    process.exit(1);
+  }
+  const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
+  console.log(`[check-urls] verifying ${baseline.results.length} baseline URLs against ${ORIGIN}`);
+
+  const failures = [];
+  await pool(baseline.results, async (entry) => {
+    const r = await trace(entry.url.replace(baseline.origin, ORIGIN));
+    if (r.status !== 200) {
+      failures.push(`${r.status} ${entry.route} (was ${entry.status})`);
+    } else if (r.hops > 1) {
+      // A single 301 to the new locale-prefixed URL is expected post-Phase 5.
+      // More than one means a redirect chain.
+      failures.push(`${r.hops} hops ${entry.route} -> ${r.final}`);
+    }
+  });
+
+  if (failures.length) {
+    console.error(`\n[check-urls] ${failures.length} FAILED:`);
+    for (const f of failures) console.error(`  ${f}`);
+    process.exit(1);
+  }
+  console.log('\n[check-urls] all baseline URLs resolve in at most one hop.');
+}
+
+const [mode, arg] = process.argv.slice(2);
+if (mode === 'capture') await capture();
+else if (mode === 'verify') await verify(arg);
+else {
+  console.error('usage: node scripts/check-urls.mjs capture | verify <baseline.json>');
+  process.exit(1);
+}

--- a/scripts/codemod-locale.mjs
+++ b/scripts/codemod-locale.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * ONE-SHOT codemod for i18n Phase 1: `isSpanish: boolean` -> `locale: Locale`.
+ *
+ * Delete this file once Phase 1 is merged. It is committed only so the diff it
+ * produced is reproducible and reviewable.
+ *
+ * Handles the mechanical prop rename across the ~60 files where `isSpanish` is
+ * purely a prop threaded down from a page component. Files that *derive*
+ * `isSpanish` locally are listed in SKIP and were migrated by hand — a blind
+ * rename there would have turned a local boolean into a shadowed locale string.
+ *
+ * TypeScript is the safety net: anything this misses is a compile error, not a
+ * silent runtime bug. Run `npx tsc --noEmit` immediately after.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SRC = path.join(ROOT, 'src');
+
+/** Files where `isSpanish` is a local derivation or an unrelated identifier. */
+const SKIP = new Set(
+  [
+    'components/CookieConsentBanner/CookieConsentBanner.tsx',
+    'components/HelpMeChoose/HelpMeChoose.component.tsx',
+    'components/OurHomes/Components/HomeCard.component.tsx',
+    'components/OurHomes/Components/NamCard.component.tsx',
+    'components/OurHomes/Components/VillaCard.component.tsx',
+    'components/OurOtherHomes/Components/OtherHomesCard.component.tsx',
+    'components/OurOtherHomes/Components/OtherHomesCard.componentRib.tsx',
+    'components/PortalGuard/PortalGuard.component.tsx',
+    'components/FlagComponent/Flag.component.tsx',
+    'hooks/useLanguageDetection.ts',
+    'pages/Booking.page.tsx',
+    'pages/Listing/components/ImagesModal/ImagesModal.component.tsx',
+    'pages/NotFound.page.tsx',
+    'pages/Portal.page.tsx',
+    'pages/PortalDetail.page.tsx',
+    'Router/Router.tsx',
+  ].map((p) => p.split('/').join(path.sep)),
+);
+
+function walk(dir, out = []) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) walk(full, out);
+    else if (/\.tsx?$/.test(e.name)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Order matters: the type declaration and JSX attribute forms are rewritten
+ * before the bare-identifier pass, so `isSpanish={true}` never reaches the
+ * generic rename and become `locale={true}`.
+ */
+const RULES = [
+  // interface / type members and function params
+  [/\bisSpanish\s*:\s*boolean\b/g, 'locale: Locale'],
+  [/\bisSpanish\?\s*:\s*boolean\b/g, 'locale?: Locale'],
+
+  // JSX attributes with literal booleans
+  [/\bisSpanish=\{true\}/g, "locale=\"es\""],
+  [/\bisSpanish=\{false\}/g, "locale=\"en\""],
+  // JSX attribute forwarding a variable
+  [/\bisSpanish=\{isSpanish\}/g, 'locale={locale}'],
+  [/\bisSpanish=\{([^}]+)\}/g, 'locale={$1}'],
+
+  // object literal shorthand / explicit
+  [/\bisSpanish:\s*true\b/g, "locale: 'es'"],
+  [/\bisSpanish:\s*false\b/g, "locale: 'en'"],
+
+  // comparisons and guards
+  [/!\s*isSpanish\b/g, "locale !== 'es'"],
+  [/\bisSpanish\s*\?/g, "locale === 'es' ?"],
+  [/\bisSpanish\s*&&/g, "locale === 'es' &&"],
+  [/\bisSpanish\s*\|\|/g, "locale === 'es' ||"],
+
+  // remaining bare identifiers: destructuring, prop shorthand, plain reads
+  [/\bisSpanish\b/g, 'locale'],
+];
+
+let changed = 0;
+let skipped = 0;
+
+for (const file of walk(SRC)) {
+  const rel = path.relative(SRC, file);
+  const before = fs.readFileSync(file, 'utf8');
+  if (!/\bisSpanish\b/.test(before)) continue;
+
+  if (SKIP.has(rel)) {
+    skipped++;
+    console.log(`  skip (manual)  ${rel}`);
+    continue;
+  }
+
+  let after = before;
+  for (const [re, to] of RULES) after = after.replace(re, to);
+
+  // Add the Locale type import only where the type is actually referenced.
+  if (/\bLocale\b/.test(after) && !/from ['"].*i18n['"]/.test(after)) {
+    const depth = rel.split(path.sep).length - 1;
+    const prefix = depth === 0 ? './' : '../'.repeat(depth);
+    const importLine = `import type { Locale } from '${prefix}i18n';\n`;
+    const lastImport = after.lastIndexOf('\nimport ');
+    if (lastImport === -1) {
+      after = importLine + after;
+    } else {
+      const eol = after.indexOf('\n', lastImport + 1);
+      after = after.slice(0, eol + 1) + importLine + after.slice(eol + 1);
+    }
+  }
+
+  if (after !== before) {
+    fs.writeFileSync(file, after);
+    changed++;
+    console.log(`  rewrote        ${rel}`);
+  }
+}
+
+console.log(`\n[codemod] rewrote ${changed} files, skipped ${skipped} for manual migration`);
+console.log('[codemod] now run: npx tsc --noEmit');

--- a/src/Router/Router.tsx
+++ b/src/Router/Router.tsx
@@ -5,6 +5,7 @@ import * as PostHog from '../services/PostHog.service';
 import MessageTipContainer from '../components/MessageTip/MessageTipContainer.component';
 import { useRandomPopup } from '../hooks/useRandomPopup';
 import PortalGuard from '../components/PortalGuard/PortalGuard.component';
+import { useLocale } from '../i18n';
 
 /*
  * Every routed page is code-split.
@@ -104,16 +105,13 @@ const PostHogPageView = () => {
 
 // Component to handle random popup logic inside Router context
 const RandomPopupHandler = () => {
-  const location = useLocation();
-  
-  // Determine if current page is Spanish based on route
-  const isSpanishPage = location.pathname.endsWith('ES') || 
-                       location.pathname.includes('ES/') ||
-                       location.pathname === '/HomeES';
-  
-  // Use the random popup hook once at the app level
-  useRandomPopup({ isSpanishPage });
-  
+  // Was a fourth hand-rolled copy of the Spanish-route check; now the shared
+  // detector. useRandomPopup still takes a boolean — it moves to a locale with
+  // the message catalogs in Phase 2.
+  const locale = useLocale();
+
+  useRandomPopup({ isSpanishPage: locale === 'es' });
+
   return null; // This component doesn't render anything
 };
 

--- a/src/components/BookingCtaBanner/BookingCtaBanner.component.tsx
+++ b/src/components/BookingCtaBanner/BookingCtaBanner.component.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import './BookingCtaBanner.style.scss';
+import type { Locale } from '../../i18n';
 
 interface IBookingCtaBanner {
-  isSpanish: boolean;
+  locale: Locale;
 }
 
 /**
@@ -13,9 +14,9 @@ interface IBookingCtaBanner {
  * be dropped in after a section a visitor has just finished reading (Our
  * Homes, the reviews) so the ask is never more than one section away.
  */
-const BookingCtaBanner: React.FC<IBookingCtaBanner> = ({ isSpanish }) => {
+const BookingCtaBanner: React.FC<IBookingCtaBanner> = ({ locale }) => {
   const navigate = useNavigate();
-  const bookPath = isSpanish ? '/bookES' : '/book';
+  const bookPath = locale === 'es' ? '/bookES' : '/book';
 
   const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
@@ -30,7 +31,7 @@ const BookingCtaBanner: React.FC<IBookingCtaBanner> = ({ isSpanish }) => {
     <section className="booking-cta-banner">
       <div className="container">
         <a href={bookPath} className="booking-cta-banner__btn" onClick={handleClick}>
-          {isSpanish ? 'Ver disponibilidad' : 'Check availability'}
+          {locale === 'es' ? 'Ver disponibilidad' : 'Check availability'}
         </a>
       </div>
     </section>

--- a/src/components/BookingSearchWidget/BookingSearchWidget.component.tsx
+++ b/src/components/BookingSearchWidget/BookingSearchWidget.component.tsx
@@ -7,10 +7,11 @@ import CalendarWithPriceDots from '../CalendarWithPriceDots';
 import { MAX_PORTFOLIO_GUESTS } from '../../utils/constants';
 import { getCostaRicaToday, nightsBetween } from '../../utils/dates';
 import './BookingSearchWidget.style.scss';
+import type { Locale } from '../../i18n';
 
 interface BookingSearchWidgetProps {
   /** Whether the current page is Spanish */
-  isSpanish: boolean;
+  locale: Locale;
   /** Optional: pre-select a number of guests (e.g. from property guestNumber) */
   defaultGuests?: number;
   /** Variant: 'sidebar' for listing pages, 'hero' for homepages */
@@ -61,13 +62,13 @@ const strings = {
 };
 
 const BookingSearchWidget: React.FC<BookingSearchWidgetProps> = ({
-  isSpanish,
+  locale,
   defaultGuests = 2,
   variant = 'sidebar',
   apartmentSlug,
 }) => {
   const navigate = useNavigate();
-  const lang = isSpanish ? 'es' : 'en';
+  const lang = locale === 'es' ? 'es' : 'en';
   const s = strings[lang];
   const today = useMemo(() => getCostaRicaToday(), []);
 
@@ -153,7 +154,7 @@ const BookingSearchWidget: React.FC<BookingSearchWidgetProps> = ({
 
     setIsSubmitting(true);
 
-    const bookPath = isSpanish ? '/bookES' : '/book';
+    const bookPath = locale === 'es' ? '/bookES' : '/book';
     const params = new URLSearchParams({
       arrivalDate,
       departureDate,

--- a/src/components/BookingSearchWidget/BookingSearchWidget.test.tsx
+++ b/src/components/BookingSearchWidget/BookingSearchWidget.test.tsx
@@ -19,7 +19,7 @@ jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn()
 function renderWidget() {
   return render(
     <MemoryRouter>
-      <BookingSearchWidget isSpanish={false} />
+      <BookingSearchWidget locale="en" />
     </MemoryRouter>
   );
 }

--- a/src/components/CookieConsentBanner/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner/CookieConsentBanner.tsx
@@ -8,6 +8,7 @@ import React, { useState, useEffect } from 'react';
 import { CookieConsentService, ConsentPreferences } from '../../services/CookieConsent.service';
 import { isPrerender } from '../../utils/isPrerender';
 import './CookieConsentBanner.scss';
+import type { Locale } from '../../i18n';
 
 interface CookieConsentBannerProps {
   onConsentChange?: (canTrack: boolean) => void;
@@ -40,35 +41,39 @@ export const CookieConsentBanner: React.FC<CookieConsentBannerProps> = ({ onCons
   const currentPath = window.location.pathname;
   const currentSearch = window.location.search;
 
-  const isSpanish = currentPath.toUpperCase().endsWith('ES') ||
+  // Kept verbatim rather than delegating to detectLocaleFromPath: this one also
+  // honours /es, /spanish and ?lang=es, which the shared detector deliberately
+  // does not. Phase 4 folds these in once the locale is a real route segment.
+  const spanish = currentPath.toUpperCase().endsWith('ES') ||
                    currentPath.includes('/es') ||
                    currentPath.includes('/spanish') ||
                    currentSearch.includes('lang=es');
+  const locale: Locale = spanish ? 'es' : 'en';
 
   // Text content based on language
   const text = {
-    title: isSpanish ? '🍪 Cookies' : '🍪 Cookies',
-    description: isSpanish 
+    title: (locale === 'es') ? '🍪 Cookies' : '🍪 Cookies',
+    description: (locale === 'es') 
       ? 'Usamos cookies para mejorar tu experiencia y analizar el tráfico.'
       : 'We use cookies to improve your experience and analyze traffic.',
-    acceptAll: isSpanish ? 'Aceptar' : 'Accept',
-    rejectAll: isSpanish ? 'Rechazar' : 'Reject',
-    customize: isSpanish ? 'Opciones' : 'Options',
-    essential: isSpanish ? 'Esenciales' : 'Essential',
-    analytics: isSpanish ? 'Análisis' : 'Analytics',
-    marketing: isSpanish ? 'Marketing' : 'Marketing',
-    required: isSpanish ? '(Req.)' : '(Req.)',
-    essentialDesc: isSpanish 
+    acceptAll: (locale === 'es') ? 'Aceptar' : 'Accept',
+    rejectAll: (locale === 'es') ? 'Rechazar' : 'Reject',
+    customize: (locale === 'es') ? 'Opciones' : 'Options',
+    essential: (locale === 'es') ? 'Esenciales' : 'Essential',
+    analytics: (locale === 'es') ? 'Análisis' : 'Analytics',
+    marketing: (locale === 'es') ? 'Marketing' : 'Marketing',
+    required: (locale === 'es') ? '(Req.)' : '(Req.)',
+    essentialDesc: (locale === 'es') 
       ? 'Necesarias para el funcionamiento del sitio.'
       : 'Required for the site to function.',
-    analyticsDesc: isSpanish
+    analyticsDesc: (locale === 'es')
       ? 'Nos ayudan a entender el uso del sitio.'
       : 'Help us understand site usage.',
-    marketingDesc: isSpanish
+    marketingDesc: (locale === 'es')
       ? 'Para mostrar anuncios relevantes.'
       : 'To show relevant ads.',
-    savePreferences: isSpanish ? 'Guardar' : 'Save',
-    cancel: isSpanish ? 'Cancelar' : 'Cancel'
+    savePreferences: (locale === 'es') ? 'Guardar' : 'Save',
+    cancel: (locale === 'es') ? 'Cancelar' : 'Cancel'
   };
 
   useEffect(() => {

--- a/src/components/FeatureHighlights/FeatureHighlights.component.tsx
+++ b/src/components/FeatureHighlights/FeatureHighlights.component.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import { PROPERTY_MARKETING_CONFIG } from '../../utils/constants';
 import './FeatureHighlights.style.scss';
+import type { Locale } from '../../i18n';
 
 interface FeatureHighlightsProps {
   propertyKey: string;
   propertyName: string;
-  isSpanish: boolean;
+  locale: Locale;
 }
 
 const FeatureHighlights: React.FC<FeatureHighlightsProps> = ({ 
   propertyKey, 
   propertyName,
-  isSpanish 
+  locale 
 }) => {
   const config = PROPERTY_MARKETING_CONFIG[propertyKey];
   
@@ -20,12 +21,10 @@ const FeatureHighlights: React.FC<FeatureHighlightsProps> = ({
     return null;
   }
 
-  const features = isSpanish 
-    ? config.featureHighlights.es 
+  const features = locale === 'es' ? config.featureHighlights.es 
     : config.featureHighlights.en;
 
-  const sectionTitle = isSpanish 
-    ? `¿Por qué los huéspedes eligen ${propertyName}?`
+  const sectionTitle = locale === 'es' ? `¿Por qué los huéspedes eligen ${propertyName}?`
     : `Why guests choose ${propertyName}`;
 
   return (

--- a/src/components/FlagComponent/Flag.component.tsx
+++ b/src/components/FlagComponent/Flag.component.tsx
@@ -1,18 +1,25 @@
 // Toggles between the current English and Spanish route while preserving query state.
+//
+// Phase 7 replaces this binary toggle with a six-language combo box. Until then
+// it only offers the two locales that have content (RELEASED_LOCALES), but it no
+// longer carries its own copy of the "is this Spanish?" rule — that lives in
+// src/i18n/detectLocale.ts, so Phase 4's switch to /:locale/ routes needs no
+// change here.
 
 import { ES, US } from "country-flag-icons/react/3x2";
 import { useLocation, useNavigate } from "react-router-dom";
+import { LOCALE_META, useLocale } from "../../i18n";
 
 export const LanguageSwitcher = () => {
     const navigate = useNavigate();
     const location = useLocation();
-    const currentUrl = location.pathname;
-    const englishLangUsed = !isSpanishPath(currentUrl);
-    const nextLanguageLabel = englishLangUsed ? "Espa\u00f1ol" : "English";
+    const locale = useLocale();
+    const nextLocale = locale === "es" ? "en" : "es";
+    const nextLanguageLabel = LOCALE_META[nextLocale].nativeName;
 
     const handleLanguageChange = () => {
         navigate({
-            pathname: getAlternateLanguagePath(currentUrl),
+            pathname: getAlternateLanguagePath(location.pathname),
             search: location.search,
             hash: location.hash,
         });
@@ -20,15 +27,18 @@ export const LanguageSwitcher = () => {
 
     return (
         <button type="button" aria-label={`Switch language to ${nextLanguageLabel}`} onClick={handleLanguageChange}>
-            {englishLangUsed ? <ES title={nextLanguageLabel} /> : <US title={nextLanguageLabel} />}
+            {locale === "en" ? <ES title={nextLanguageLabel} /> : <US title={nextLanguageLabel} />}
         </button>
     );
 };
 
-function isSpanishPath(pathname: string): boolean {
-    return pathname.endsWith("ES") || pathname.includes("ES/") || pathname === "/HomeES";
-}
-
+/**
+ * Maps a route to its counterpart in the other language.
+ *
+ * Still suffix arithmetic because the routes themselves are still suffixed.
+ * Phase 4 replaces this with a lookup in routes.config.ts, which is what makes
+ * the same switcher work for six languages instead of two.
+ */
 function getAlternateLanguagePath(pathname: string): string {
     if (pathname === "/HomeES") {
         return "/";
@@ -38,7 +48,7 @@ function getAlternateLanguagePath(pathname: string): string {
         return "/HomeES";
     }
 
-    if (isSpanishPath(pathname)) {
+    if (pathname.endsWith("ES") || pathname.includes("ES/")) {
         return pathname.endsWith("ES") ? pathname.slice(0, -2) : pathname.replace("ES/", "/");
     }
 

--- a/src/components/Footer/Footer.component.tsx
+++ b/src/components/Footer/Footer.component.tsx
@@ -2,21 +2,22 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { PROPERTY_DISPLAY_NAMES, BLOG_ARTICLES } from '../../utils/constants';
 import './Footer.style.scss';
+import type { Locale } from '../../i18n';
 
 interface IFooter {
-  isSpanish: boolean;
+  locale: Locale;
 }
 
-const Footer: React.FC<IFooter> = ({ isSpanish }) => {
-  const suffix = isSpanish ? 'ES' : '';
-  const bookPath = isSpanish ? '/bookES' : '/book';
+const Footer: React.FC<IFooter> = ({ locale }) => {
+  const suffix = locale === 'es' ? 'ES' : '';
+  const bookPath = locale === 'es' ? '/bookES' : '/book';
 
   return (
     <footer className="site-footer">
       <div className="container">
         <div className="footer-grid">
           <div className="footer-col">
-            <h4>{isSpanish ? 'Nuestras Casas' : 'Our Homes'}</h4>
+            <h4>{locale === 'es' ? 'Nuestras Casas' : 'Our Homes'}</h4>
             <ul>
               {Object.entries(PROPERTY_DISPLAY_NAMES).map(([code, name]) => (
                 <li key={code}>
@@ -27,12 +28,12 @@ const Footer: React.FC<IFooter> = ({ isSpanish }) => {
           </div>
 
           <div className="footer-col">
-            <h4>{isSpanish ? 'Guías de Viaje' : 'Travel Guides'}</h4>
+            <h4>{locale === 'es' ? 'Guías de Viaje' : 'Travel Guides'}</h4>
             <ul>
               {BLOG_ARTICLES.map((article) => (
                 <li key={article.key}>
-                  <Link to={isSpanish ? article.pathEs : article.pathEn}>
-                    {isSpanish ? article.titleEs : article.titleEn}
+                  <Link to={locale === 'es' ? article.pathEs : article.pathEn}>
+                    {locale === 'es' ? article.titleEs : article.titleEn}
                   </Link>
                 </li>
               ))}
@@ -40,14 +41,14 @@ const Footer: React.FC<IFooter> = ({ isSpanish }) => {
           </div>
 
           <div className="footer-col">
-            <h4>{isSpanish ? 'Contacto' : 'Contact'}</h4>
+            <h4>{locale === 'es' ? 'Contacto' : 'Contact'}</h4>
             <ul className="footer-contact">
               <li>
                 <a href="tel:+50684632276">+506 8463-2276</a>
               </li>
               <li>
                 <a href="https://wa.me/50684632276" target="_blank" rel="noopener noreferrer">
-                  {isSpanish ? 'Chatear por WhatsApp' : 'Chat on WhatsApp'}
+                  {locale === 'es' ? 'Chatear por WhatsApp' : 'Chat on WhatsApp'}
                 </a>
               </li>
               <li>
@@ -58,9 +59,9 @@ const Footer: React.FC<IFooter> = ({ isSpanish }) => {
           </div>
 
           <div className="footer-col footer-cta-col">
-            <h4>{isSpanish ? '¿Listo para reservar?' : 'Ready to book?'}</h4>
+            <h4>{locale === 'es' ? '¿Listo para reservar?' : 'Ready to book?'}</h4>
             <Link to={bookPath} className="footer-cta-btn">
-              {isSpanish ? 'Ver disponibilidad' : 'Check availability'}
+              {locale === 'es' ? 'Ver disponibilidad' : 'Check availability'}
             </Link>
           </div>
         </div>

--- a/src/components/GuestReviews/GuestReviews.component.tsx
+++ b/src/components/GuestReviews/GuestReviews.component.tsx
@@ -1,15 +1,16 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { GUEST_REVIEWS, Review } from './reviewsData';
 import './GuestReviews.style.scss';
+import type { Locale } from '../../i18n';
 
 interface GuestReviewsProps {
   propertyKey: string;
-  isSpanish: boolean;
+  locale: Locale;
 }
 
 const STARS = '★★★★★';
 
-const GuestReviews: React.FC<GuestReviewsProps> = ({ propertyKey, isSpanish }) => {
+const GuestReviews: React.FC<GuestReviewsProps> = ({ propertyKey, locale }) => {
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const cardsRef = useRef<HTMLDivElement>(null);
@@ -57,8 +58,8 @@ const GuestReviews: React.FC<GuestReviewsProps> = ({ propertyKey, isSpanish }) =
   const reviews = GUEST_REVIEWS[propertyKey];
   if (!reviews || reviews.length === 0) return null;
 
-  const heading = isSpanish ? 'Lo que dicen nuestros huéspedes' : 'What our guests are saying';
-  const closeLabel = isSpanish ? 'Cerrar reseñas' : 'Close reviews';
+  const heading = locale === 'es' ? 'Lo que dicen nuestros huéspedes' : 'What our guests are saying';
+  const closeLabel = locale === 'es' ? 'Cerrar reseñas' : 'Close reviews';
 
   const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target === e.currentTarget) closePanel();
@@ -72,8 +73,8 @@ const GuestReviews: React.FC<GuestReviewsProps> = ({ propertyKey, isSpanish }) =
   };
 
   const renderReviewMeta = (review: Review) => {
-    const text = isSpanish ? review.text.es : review.text.en;
-    const stayLabel = isSpanish ? translateStayType(review.stayType) : review.stayType;
+    const text = locale === 'es' ? review.text.es : review.text.en;
+    const stayLabel = locale === 'es' ? translateStayType(review.stayType) : review.stayType;
     return { text, stayLabel };
   };
 

--- a/src/components/HelpMeChoose/HelpMeChoose.component.tsx
+++ b/src/components/HelpMeChoose/HelpMeChoose.component.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { cdnSrcSet } from '../../utils/imageCdn';
 import { useNavigate } from 'react-router-dom';
 import './HelpMeChoose.style.scss';
+import type { Locale } from '../../i18n';
 
 interface HelpMeChooseOption {
     emoji: string;
@@ -44,7 +45,7 @@ const HelpMeChoose: React.FC<IHelpMeChoose> = ({ title, titleHighlight, options 
                     {options.map((option) => {
                         // Spanish house codes contain "ES" — same convention HomeCard
                         // uses to label its own CTA without a language prop.
-                        const isSpanish = option.houseLangCode.includes('ES');
+                        const cardLocale: Locale = option.houseLangCode.includes('ES') ? 'es' : 'en';
                         return (
                             <a
                                 key={option.houseLangCode}
@@ -59,7 +60,7 @@ const HelpMeChoose: React.FC<IHelpMeChoose> = ({ title, titleHighlight, options 
                                     <span className="card-emoji">{option.emoji}</span>
                                     <span className="card-label">{option.label}</span>
                                     <span className="card-house-name">{option.houseName}</span>
-                                    <span className="card-cta">{isSpanish ? 'Ver casa →' : 'View home →'}</span>
+                                    <span className="card-cta">{cardLocale === 'es' ? 'Ver casa →' : 'View home →'}</span>
                                 </div>
                             </a>
                         );

--- a/src/components/HomeReviews/HomeReviews.component.tsx
+++ b/src/components/HomeReviews/HomeReviews.component.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { GUEST_REVIEWS, Review } from '../GuestReviews/reviewsData';
 import './HomeReviews.style.scss';
+import type { Locale } from '../../i18n';
 
 interface HomeReviewsProps {
-  isSpanish: boolean;
+  locale: Locale;
 }
 
 interface FlatReview extends Review {
@@ -63,16 +64,16 @@ function translateStayType(stayType: string): string {
 const SCROLL_SPEED_DESKTOP = 0.02; // px per ms
 const SCROLL_SPEED_MOBILE  = 0.01; // px per ms
 
-const HomeReviews: React.FC<HomeReviewsProps> = ({ isSpanish }) => {
+const HomeReviews: React.FC<HomeReviewsProps> = ({ locale }) => {
   const [activeReview, setActiveReview] = useState<FlatReview | null>(null);
   const trackRef = useRef<HTMLDivElement>(null);
   const pausedRef = useRef(false);
   const rafRef = useRef<number>();
   const lastTimeRef = useRef<number | null>(null);
 
-  const headingMain = isSpanish ? 'Lo que dicen nuestros' : 'What our guests are';
-  const headingHighlight = isSpanish ? 'huéspedes' : 'saying';
-  const closeLabel = isSpanish ? 'Cerrar reseña' : 'Close review';
+  const headingMain = locale === 'es' ? 'Lo que dicen nuestros' : 'What our guests are';
+  const headingHighlight = locale === 'es' ? 'huéspedes' : 'saying';
+  const closeLabel = locale === 'es' ? 'Cerrar reseña' : 'Close review';
 
   // Auto-scroll via rAF
   useEffect(() => {
@@ -152,9 +153,9 @@ const HomeReviews: React.FC<HomeReviewsProps> = ({ isSpanish }) => {
         onTouchEnd={() => { pausedRef.current = false; }}
       >
         {DOUBLED.map((review, index) => {
-          const text = isSpanish ? review.text.es : review.text.en;
-          const propertyLabel = isSpanish ? review.propertyLabelES : review.propertyLabel;
-          const stayLabel = isSpanish ? translateStayType(review.stayType) : review.stayType;
+          const text = locale === 'es' ? review.text.es : review.text.en;
+          const propertyLabel = locale === 'es' ? review.propertyLabelES : review.propertyLabel;
+          const stayLabel = locale === 'es' ? translateStayType(review.stayType) : review.stayType;
 
           return (
             <div
@@ -183,9 +184,9 @@ const HomeReviews: React.FC<HomeReviewsProps> = ({ isSpanish }) => {
       </div>
 
       {activeReview && (() => {
-        const text = isSpanish ? activeReview.text.es : activeReview.text.en;
-        const propertyLabel = isSpanish ? activeReview.propertyLabelES : activeReview.propertyLabel;
-        const stayLabel = isSpanish ? translateStayType(activeReview.stayType) : activeReview.stayType;
+        const text = locale === 'es' ? activeReview.text.es : activeReview.text.en;
+        const propertyLabel = locale === 'es' ? activeReview.propertyLabelES : activeReview.propertyLabel;
+        const stayLabel = locale === 'es' ? translateStayType(activeReview.stayType) : activeReview.stayType;
         return (
           <div
             className="home-reviews__overlay"

--- a/src/components/InstantConfirmationBadge/InstantConfirmationBadge.component.tsx
+++ b/src/components/InstantConfirmationBadge/InstantConfirmationBadge.component.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import './InstantConfirmationBadge.style.scss';
+import type { Locale } from '../../i18n';
 
 interface InstantConfirmationBadgeProps {
-  isSpanish: boolean;
+  locale: Locale;
 }
 
-const InstantConfirmationBadge: React.FC<InstantConfirmationBadgeProps> = ({ isSpanish }) => {
+const InstantConfirmationBadge: React.FC<InstantConfirmationBadgeProps> = ({ locale }) => {
   return (
     <div className="instant-confirmation-badge">
       <span className="checkmark">✔</span>
       <span className="text">
-        {isSpanish ? 'Confirmación inmediata' : 'Instant confirmation'}
+        {locale === 'es' ? 'Confirmación inmediata' : 'Instant confirmation'}
       </span>
     </div>
   );

--- a/src/components/ListingMarketingSection/ListingMarketingSection.component.tsx
+++ b/src/components/ListingMarketingSection/ListingMarketingSection.component.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import { PROPERTY_MARKETING_CONFIG } from '../../utils/constants';
 import './ListingMarketingSection.style.scss';
+import type { Locale } from '../../i18n';
 
 interface ListingMarketingSectionProps {
   propertyKey: string;
-  isSpanish: boolean;
+  locale: Locale;
 }
 
 const ListingMarketingSection: React.FC<ListingMarketingSectionProps> = ({ 
   propertyKey, 
-  isSpanish 
+  locale 
 }) => {
   const config = PROPERTY_MARKETING_CONFIG[propertyKey];
   
@@ -18,7 +19,7 @@ const ListingMarketingSection: React.FC<ListingMarketingSectionProps> = ({
     return null;
   }
 
-  const descriptiveTitle = isSpanish ? config.descriptiveTitle.es : config.descriptiveTitle.en;
+  const descriptiveTitle = locale === 'es' ? config.descriptiveTitle.es : config.descriptiveTitle.en;
 
   return (
     <div className="listing-marketing-section">

--- a/src/components/OurHomes/Components/HomeCard.component.tsx
+++ b/src/components/OurHomes/Components/HomeCard.component.tsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSnowflake, faUtensils, faWifi, faUser, faParking } from '@fortawesome/free-solid-svg-icons';
 import { useNavigate } from "react-router-dom";
 import './HomeCard.style.scss'
+import type { Locale } from '../../../i18n';
 
 interface IHomeCard {
     name: string;
@@ -18,7 +19,7 @@ const HomeCard: FC<IHomeCard> = ({ guestNumber, parking, name, image, houseLangC
 
     // Spanish house codes contain "ES" (see OurHomes.componentES filter), so the
     // card can label its own CTA without threading a language prop from parents.
-    const isSpanish = houseLangCode.includes('ES');
+    const cardLocale: Locale = houseLangCode.includes('ES') ? 'es' : 'en';
     const navigate = useNavigate();
     const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
         // A real href already handles ctrl/cmd-click, middle-click and "open in
@@ -54,7 +55,7 @@ const HomeCard: FC<IHomeCard> = ({ guestNumber, parking, name, image, houseLangC
                         <FontAwesomeIcon icon={faWifi} />
                         <FontAwesomeIcon icon={faParking} />
                     </div>
-                    <span className="card-cta">{isSpanish ? 'Ver casa →' : 'View home →'}</span>
+                    <span className="card-cta">{cardLocale === 'es' ? 'Ver casa →' : 'View home →'}</span>
                 </div>
             </div>
 

--- a/src/components/OurHomes/Components/NamCard.component.tsx
+++ b/src/components/OurHomes/Components/NamCard.component.tsx
@@ -5,6 +5,7 @@ import { faSnowflake, faUtensils, faWifi, faUser, faParking, faSwimmingPool } fr
 import { useNavigate } from "react-router-dom";
 
 import './HomeCard.style.scss'
+import type { Locale } from '../../../i18n';
 
 interface IHomeCard {
     name: string;
@@ -18,7 +19,7 @@ const NamCard: FC<IHomeCard> = ({ guestNumber, name, image, houseLangCode }) => 
 
     // Spanish house codes contain "ES", so the card can label its own CTA
     // without threading a language prop from parents.
-    const isSpanish = houseLangCode.includes('ES');
+    const cardLocale: Locale = houseLangCode.includes('ES') ? 'es' : 'en';
     const navigate = useNavigate();
     const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
         // A real href already handles ctrl/cmd-click, middle-click and "open in
@@ -53,7 +54,7 @@ const NamCard: FC<IHomeCard> = ({ guestNumber, name, image, houseLangCode }) => 
                         <FontAwesomeIcon icon={faUtensils} />
                         <FontAwesomeIcon icon={faWifi} />
                     </div>
-                    <span className="card-cta">{isSpanish ? 'Ver casa →' : 'View home →'}</span>
+                    <span className="card-cta">{cardLocale === 'es' ? 'Ver casa →' : 'View home →'}</span>
                 </div>
             </div>
 

--- a/src/components/OurHomes/Components/VillaCard.component.tsx
+++ b/src/components/OurHomes/Components/VillaCard.component.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import { cdnImage, cdnSrcSet } from '../../../utils/imageCdn';
 
 import './HomeCard.style.scss'
+import type { Locale } from '../../../i18n';
 
 interface IHomeCard {
     name: string;
@@ -18,7 +19,7 @@ const VillaCard: FC<IHomeCard> = ({ guestNumber, name, image, houseLangCode }) =
 
     // Spanish house codes contain "ES", so the card can label its own CTA
     // without threading a language prop from parents.
-    const isSpanish = houseLangCode.includes('ES');
+    const cardLocale: Locale = houseLangCode.includes('ES') ? 'es' : 'en';
     const navigate = useNavigate();
     const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
         // A real href already handles ctrl/cmd-click, middle-click and "open in
@@ -69,7 +70,7 @@ const VillaCard: FC<IHomeCard> = ({ guestNumber, name, image, houseLangCode }) =
                         <FontAwesomeIcon icon={faWifi} />
                         <FontAwesomeIcon icon={faParking} />
                     </div>
-                    <span className="card-cta">{isSpanish ? 'Ver casa →' : 'View home →'}</span>
+                    <span className="card-cta">{cardLocale === 'es' ? 'Ver casa →' : 'View home →'}</span>
                 </div>
             </div>
 

--- a/src/components/OurOtherHomes/Components/OtherHomesCard.component.tsx
+++ b/src/components/OurOtherHomes/Components/OtherHomesCard.component.tsx
@@ -5,6 +5,7 @@ import { faSnowflake, faUtensils, faWifi, faUser, faParking } from '@fortawesome
 import { useNavigate } from 'react-router-dom';
 
 import './OtherHomesCard.style.scss';
+import { detectLocaleFromPath, type Locale } from '../../../i18n';
 
 interface IOtherHomesCard {
     name: string;
@@ -16,7 +17,7 @@ interface IOtherHomesCard {
 const OtherHomesCard: FC<IOtherHomesCard> = ({ guestNumber, name, image, redirectPath }) => {
     // Spanish routes end in "ES" (e.g. /PlumeriaES), so the card labels its own
     // CTA without a language prop.
-    const isSpanish = !!redirectPath?.endsWith('ES');
+    const cardLocale: Locale = detectLocaleFromPath(redirectPath ?? '');
     const navigate = useNavigate();
 
     const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
@@ -51,7 +52,7 @@ const OtherHomesCard: FC<IOtherHomesCard> = ({ guestNumber, name, image, redirec
                     <FontAwesomeIcon icon={faWifi} />
                     <FontAwesomeIcon icon={faParking} />
                 </div>
-                <span className="card-cta">{isSpanish ? 'Ver casa →' : 'View home →'}</span>
+                <span className="card-cta">{cardLocale === 'es' ? 'Ver casa →' : 'View home →'}</span>
             </div>
         </a>
     );

--- a/src/components/OurOtherHomes/Components/OtherHomesCard.componentRib.tsx
+++ b/src/components/OurOtherHomes/Components/OtherHomesCard.componentRib.tsx
@@ -5,6 +5,7 @@ import { faSnowflake, faUtensils, faWifi, faUser, faSwimmingPool, faParking } fr
 import { useNavigate } from 'react-router-dom';
 
 import './OtherHomesCard.style.scss';
+import { detectLocaleFromPath, type Locale } from '../../../i18n';
 
 interface IOtherHomesCard {
     name: string;
@@ -16,7 +17,7 @@ interface IOtherHomesCard {
 const OtherHomesCardRib: FC<IOtherHomesCard> = ({ guestNumber, name, image, redirectPath }) => {
     // Spanish routes end in "ES" (e.g. /VillaMarES), so the card labels its own
     // CTA without a language prop.
-    const isSpanish = !!redirectPath?.endsWith('ES');
+    const cardLocale: Locale = detectLocaleFromPath(redirectPath ?? '');
     const navigate = useNavigate();
 
     const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
@@ -52,7 +53,7 @@ const OtherHomesCardRib: FC<IOtherHomesCard> = ({ guestNumber, name, image, redi
                     <FontAwesomeIcon icon={faWifi} />
                     <FontAwesomeIcon icon={faParking} />
                 </div>
-                <span className="card-cta">{isSpanish ? 'Ver casa →' : 'View home →'}</span>
+                <span className="card-cta">{cardLocale === 'es' ? 'Ver casa →' : 'View home →'}</span>
             </div>
         </a>
     );

--- a/src/components/PriceConfirmationSection/PriceConfirmationSection.component.tsx
+++ b/src/components/PriceConfirmationSection/PriceConfirmationSection.component.tsx
@@ -5,18 +5,19 @@ import { getCostaRicaToday } from '../../utils/dates';
 import { formatBookingMoney } from '../../utils/money';
 import InstantConfirmationBadge from '../InstantConfirmationBadge/InstantConfirmationBadge.component';
 import './PriceConfirmationSection.style.scss';
+import type { Locale } from '../../i18n';
 
 interface PriceConfirmationSectionProps {
   propertyKey: string;
-  isSpanish: boolean;
+  locale: Locale;
 }
 
 const PriceConfirmationSection: React.FC<PriceConfirmationSectionProps> = ({
   propertyKey,
-  isSpanish
+  locale
 }) => {
   const config = PROPERTY_MARKETING_CONFIG[propertyKey];
-  const language = isSpanish ? 'es' : 'en';
+  const language = locale === 'es' ? 'es' : 'en';
   const currentMonth = React.useMemo(() => getCostaRicaToday().slice(0, 7), []);
   // Shares the cache with the search widget's calendar, so this costs no extra
   // request — and the headline price can never contradict the dots below it.
@@ -36,12 +37,10 @@ const PriceConfirmationSection: React.FC<PriceConfirmationSectionProps> = ({
       ? formatBookingMoney(liveLowestCents, currency, language, { hideZeroCents: true })
       : `$${config.price.usd}`;
 
-  const tooltipText = isSpanish
-    ? 'Precio más bajo disponible este mes. Las tarifas varían según la temporada y las fechas elegidas.'
+  const tooltipText = locale === 'es' ? 'Precio más bajo disponible este mes. Las tarifas varían según la temporada y las fechas elegidas.'
     : 'Lowest available rate this month. Rates vary by season and by the dates you choose.';
 
-  const priceText = isSpanish
-    ? (
+  const priceText = locale === 'es' ? (
       <>
         Desde {priceLabel} por noche{' '}
         <span className="average-indicator">
@@ -66,10 +65,10 @@ const PriceConfirmationSection: React.FC<PriceConfirmationSectionProps> = ({
         {priceText}
       </div>
       <div className="confirmation-badge">
-        <InstantConfirmationBadge isSpanish={isSpanish} />
+        <InstantConfirmationBadge locale={locale} />
       </div>
       <p className='price-display' style={{ marginTop: '15px', marginBottom: 0 }}>
-        {isSpanish ? (
+        {locale === 'es' ? (
           <><>
             Elige la <strong>tarifa no reembolsable</strong>
           </>

--- a/src/components/PropertyFacts/PropertyFacts.component.tsx
+++ b/src/components/PropertyFacts/PropertyFacts.component.tsx
@@ -3,10 +3,11 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBath, faBed, faUserGroup, IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { CapacityFact, getCapacityFacts } from '../../utils/propertyCapacity';
 import './PropertyFacts.style.scss';
+import type { Locale } from '../../i18n';
 
 interface PropertyFactsProps {
   propertyKey: string;
-  isSpanish: boolean;
+  locale: Locale;
 }
 
 const iconList: Record<CapacityFact['icon'], IconDefinition> = {
@@ -17,9 +18,9 @@ const iconList: Record<CapacityFact['icon'], IconDefinition> = {
 
 const PropertyFacts: React.FC<PropertyFactsProps> = ({
   propertyKey,
-  isSpanish
+  locale
 }) => {
-  const facts = getCapacityFacts(propertyKey, isSpanish);
+  const facts = getCapacityFacts(propertyKey, locale);
 
   // Gracefully handle missing configuration
   if (!facts.length) {
@@ -29,7 +30,7 @@ const PropertyFacts: React.FC<PropertyFactsProps> = ({
   return (
     <ul
       className="property-facts"
-      aria-label={isSpanish ? 'Capacidad de la casa' : 'Property capacity'}
+      aria-label={locale === 'es' ? 'Capacidad de la casa' : 'Property capacity'}
     >
       {facts.map(({ key, icon, label }) => (
         <li className="property-facts__item" key={key}>

--- a/src/components/PropertyFacts/__tests__/PropertyFacts.test.tsx
+++ b/src/components/PropertyFacts/__tests__/PropertyFacts.test.tsx
@@ -4,7 +4,7 @@ import { PROPERTY_CAPACITY } from '../../../utils/constants';
 
 describe('PropertyFacts', () => {
   test('renders bedrooms, bathrooms and max occupancy in English', () => {
-    render(<PropertyFacts propertyKey="Geco" isSpanish={false} />);
+    render(<PropertyFacts propertyKey="Geco" locale="en" />);
 
     expect(screen.getByText('2 bedrooms')).toBeInTheDocument();
     expect(screen.getByText('1 bathroom')).toBeInTheDocument();
@@ -12,7 +12,7 @@ describe('PropertyFacts', () => {
   });
 
   test('renders the same facts in Spanish', () => {
-    render(<PropertyFacts propertyKey="Geco" isSpanish={true} />);
+    render(<PropertyFacts propertyKey="Geco" locale="es" />);
 
     expect(screen.getByText('2 habitaciones')).toBeInTheDocument();
     expect(screen.getByText('1 baño')).toBeInTheDocument();
@@ -20,33 +20,33 @@ describe('PropertyFacts', () => {
   });
 
   test('uses singular wording for one-bedroom properties', () => {
-    const { unmount } = render(<PropertyFacts propertyKey="VillaMar" isSpanish={false} />);
+    const { unmount } = render(<PropertyFacts propertyKey="VillaMar" locale="en" />);
     expect(screen.getByText('1 bedroom')).toBeInTheDocument();
     unmount();
 
-    render(<PropertyFacts propertyKey="VillaMar" isSpanish={true} />);
+    render(<PropertyFacts propertyKey="VillaMar" locale="es" />);
     expect(screen.getByText('1 habitación')).toBeInTheDocument();
   });
 
   test('renders plural bathrooms for the two-bathroom properties', () => {
-    const { unmount } = render(<PropertyFacts propertyKey="Delfin" isSpanish={false} />);
+    const { unmount } = render(<PropertyFacts propertyKey="Delfin" locale="en" />);
     expect(screen.getByText('2 bathrooms')).toBeInTheDocument();
     expect(screen.getByText('Up to 6 guests')).toBeInTheDocument();
     unmount();
 
-    render(<PropertyFacts propertyKey="Giulia" isSpanish={true} />);
+    render(<PropertyFacts propertyKey="Giulia" locale="es" />);
     expect(screen.getByText('2 baños')).toBeInTheDocument();
     expect(screen.getByText('Hasta 4 huéspedes')).toBeInTheDocument();
   });
 
   test('renders nothing when the property has no capacity configured', () => {
-    const { container } = render(<PropertyFacts propertyKey="NotAProperty" isSpanish={false} />);
+    const { container } = render(<PropertyFacts propertyKey="NotAProperty" locale="en" />);
     expect(container).toBeEmptyDOMElement();
   });
 
   test('every configured property renders all three facts', () => {
     Object.keys(PROPERTY_CAPACITY).forEach((propertyKey) => {
-      const { unmount } = render(<PropertyFacts propertyKey={propertyKey} isSpanish={false} />);
+      const { unmount } = render(<PropertyFacts propertyKey={propertyKey} locale="en" />);
       expect(screen.getByLabelText('Property capacity').children).toHaveLength(3);
       unmount();
     });

--- a/src/components/SocialStatement/SocialStatement.component.tsx
+++ b/src/components/SocialStatement/SocialStatement.component.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import { PROPERTY_MARKETING_CONFIG } from '../../utils/constants';
 import './SocialStatement.style.scss';
+import type { Locale } from '../../i18n';
 
 interface SocialStatementProps {
   propertyKey: string;
-  isSpanish: boolean;
+  locale: Locale;
 }
 
 const SocialStatement: React.FC<SocialStatementProps> = ({ 
   propertyKey, 
-  isSpanish 
+  locale 
 }) => {
   const config = PROPERTY_MARKETING_CONFIG[propertyKey];
   
@@ -18,8 +19,7 @@ const SocialStatement: React.FC<SocialStatementProps> = ({
     return null;
   }
 
-  const socialStatement = isSpanish 
-    ? config.socialStatement.es 
+  const socialStatement = locale === 'es' ? config.socialStatement.es 
     : config.socialStatement.en;
 
   return (

--- a/src/components/WelcomeSlider/WelcomeSlider.component.tsx
+++ b/src/components/WelcomeSlider/WelcomeSlider.component.tsx
@@ -52,7 +52,7 @@ const WelcomeSlider = () => {
         <br />
 
         <div className="hero-booking">
-          <BookingSearchWidget isSpanish={false} variant="hero" />
+          <BookingSearchWidget locale="en" variant="hero" />
           <p className="hero-trust">✓ Instant confirmation · ✓ Secure booking · ✓ No platform fees</p>
         </div>
       </div>

--- a/src/components/WelcomeSlider/WelcomeSlider.componentES.tsx
+++ b/src/components/WelcomeSlider/WelcomeSlider.componentES.tsx
@@ -29,7 +29,7 @@ const WelcomeSliderES = () => {
         <br />
 
         <div className="hero-booking">
-          <BookingSearchWidget isSpanish={true} variant="hero" />
+          <BookingSearchWidget locale="es" variant="hero" />
           <p className="hero-trust">✓ Confirmación instantánea · ✓ Reserva segura · ✓ Sin comisiones</p>
         </div>
       </div>

--- a/src/components/__tests__/listingPageIntegration.test.tsx
+++ b/src/components/__tests__/listingPageIntegration.test.tsx
@@ -50,7 +50,7 @@ describe('Listing Page Integration Tests', () => {
 
   describe('Component Rendering Integration', () => {
     test('ListingMarketingSection renders descriptive title only', () => {
-      render(<ListingMarketingSection propertyKey="Rana" isSpanish={false} />);
+      render(<ListingMarketingSection propertyKey="Rana" locale="en" />);
       
       // Should contain descriptive title only (price and confirmation moved to separate component)
       expect(screen.getByText('Family home, pet friendly with air conditioning')).toBeInTheDocument();
@@ -61,7 +61,7 @@ describe('Listing Page Integration Tests', () => {
     });
 
     test('PriceConfirmationSection renders price and confirmation badge', () => {
-      render(<PriceConfirmationSection propertyKey="Rana" isSpanish={false} />);
+      render(<PriceConfirmationSection propertyKey="Rana" locale="en" />);
       
       // Falls back to the configured price when live rates are unavailable.
       expect(screen.getByText(/From \$160 per night/)).toBeInTheDocument();
@@ -72,7 +72,7 @@ describe('Listing Page Integration Tests', () => {
     });
 
     test('ListingMarketingSection renders Spanish descriptive title only', () => {
-      render(<ListingMarketingSection propertyKey="Rana" isSpanish={true} />);
+      render(<ListingMarketingSection propertyKey="Rana" locale="es" />);
       
       // Should contain Spanish descriptive title only
       expect(screen.getByText('Casa familiar, pet friendly con aire acondicionado')).toBeInTheDocument();
@@ -83,7 +83,7 @@ describe('Listing Page Integration Tests', () => {
     });
 
     test('PriceConfirmationSection renders Spanish price and confirmation badge', () => {
-      render(<PriceConfirmationSection propertyKey="Rana" isSpanish={true} />);
+      render(<PriceConfirmationSection propertyKey="Rana" locale="es" />);
       
       // Spanish quotes USD too — the booking engine charges in USD, so a colón
       // figure here would contradict the calendar and the checkout total.
@@ -95,13 +95,13 @@ describe('Listing Page Integration Tests', () => {
     });
 
     test('SocialStatement renders property-specific content', () => {
-      render(<SocialStatement propertyKey="VillaMar" isSpanish={false} />);
+      render(<SocialStatement propertyKey="VillaMar" locale="en" />);
       
       expect(screen.getByText('Chosen for its private pool perfect for romantic getaways')).toBeInTheDocument();
     });
 
     test('FeatureHighlights renders with emoji icons', () => {
-      render(<FeatureHighlights propertyKey="Tucano" propertyName="Casa Tucano" isSpanish={false} />);
+      render(<FeatureHighlights propertyKey="Tucano" propertyName="Casa Tucano" locale="en" />);
       
       expect(screen.getByText('Why guests choose Casa Tucano')).toBeInTheDocument();
       
@@ -112,7 +112,7 @@ describe('Listing Page Integration Tests', () => {
     });
 
     test('InstantConfirmationBadge renders with correct styling', () => {
-      render(<InstantConfirmationBadge isSpanish={false} />);
+      render(<InstantConfirmationBadge locale="en" />);
       
       const badge = screen.getByText('✔');
       expect(badge).toBeInTheDocument();
@@ -125,13 +125,13 @@ describe('Listing Page Integration Tests', () => {
       // Mock mobile viewport
       mockMatchMedia(true); // Simulate mobile media query match
       
-      render(<ListingMarketingSection propertyKey="Delfin" isSpanish={false} />);
+      render(<ListingMarketingSection propertyKey="Delfin" locale="en" />);
       
       // Components should still render descriptive title on mobile
       expect(screen.getByText('Spacious house perfect for large families')).toBeInTheDocument();
       
       // Price and confirmation should be tested separately in PriceConfirmationSection
-      render(<PriceConfirmationSection propertyKey="Delfin" isSpanish={false} />);
+      render(<PriceConfirmationSection propertyKey="Delfin" locale="en" />);
       expect(screen.getByText(/From \$199 per night/)).toBeInTheDocument();
       expect(screen.getByText('✔')).toBeInTheDocument();
       expect(screen.getByText('Instant confirmation')).toBeInTheDocument();
@@ -141,7 +141,7 @@ describe('Listing Page Integration Tests', () => {
       // Mock desktop viewport
       mockMatchMedia(false); // Simulate desktop media query (no match for mobile)
       
-      render(<FeatureHighlights propertyKey="VillaCoral" propertyName="Villa Coral" isSpanish={true} />);
+      render(<FeatureHighlights propertyKey="VillaCoral" propertyName="Villa Coral" locale="es" />);
       
       // Components should render all content on desktop
       expect(screen.getByText('¿Por qué los huéspedes eligen Villa Coral?')).toBeInTheDocument();
@@ -151,10 +151,10 @@ describe('Listing Page Integration Tests', () => {
     test('Layout maintains proper structure across different screen sizes', () => {
       render(
         <div>
-          <ListingMarketingSection propertyKey="Areka" isSpanish={false} />
-          <PriceConfirmationSection propertyKey="Areka" isSpanish={false} />
-          <SocialStatement propertyKey="Areka" isSpanish={false} />
-          <FeatureHighlights propertyKey="Areka" propertyName="Casa Areka" isSpanish={false} />
+          <ListingMarketingSection propertyKey="Areka" locale="en" />
+          <PriceConfirmationSection propertyKey="Areka" locale="en" />
+          <SocialStatement propertyKey="Areka" locale="en" />
+          <FeatureHighlights propertyKey="Areka" propertyName="Casa Areka" locale="en" />
         </div>
       );
       
@@ -178,7 +178,7 @@ describe('Listing Page Integration Tests', () => {
   describe('Error Handling Integration', () => {
     test('Components handle missing configuration gracefully', () => {
       // Test with non-existent property key
-      render(<ListingMarketingSection propertyKey="NonExistentProperty" isSpanish={false} />);
+      render(<ListingMarketingSection propertyKey="NonExistentProperty" locale="en" />);
       
       // Component should not crash and should render nothing
       expect(screen.queryByText(/per night/)).not.toBeInTheDocument();
@@ -186,21 +186,21 @@ describe('Listing Page Integration Tests', () => {
 
     test('PriceConfirmationSection handles missing configuration gracefully', () => {
       // Test with non-existent property key
-      render(<PriceConfirmationSection propertyKey="NonExistentProperty" isSpanish={false} />);
+      render(<PriceConfirmationSection propertyKey="NonExistentProperty" locale="en" />);
       
       // Component should not crash and should render nothing
       expect(screen.queryByText(/per night/)).not.toBeInTheDocument();
     });
 
     test('Components handle invalid property keys gracefully', () => {
-      render(<SocialStatement propertyKey="" isSpanish={false} />);
+      render(<SocialStatement propertyKey="" locale="en" />);
       
       // Component should not crash
       expect(document.body).toBeInTheDocument();
     });
 
     test('FeatureHighlights handles missing property name gracefully', () => {
-      render(<FeatureHighlights propertyKey="Giulia" propertyName="" isSpanish={false} />);
+      render(<FeatureHighlights propertyKey="Giulia" propertyName="" locale="en" />);
       
       // Should still render the section, even with empty property name
       expect(screen.getByText(/Why guests choose/)).toBeInTheDocument();
@@ -208,14 +208,14 @@ describe('Listing Page Integration Tests', () => {
   });
 
   describe('Language Consistency Integration', () => {
-    test('All components use consistent language when isSpanish=true', () => {
+    test('All components use consistent language when locale=true', () => {
       render(
         <div>
-          <ListingMarketingSection propertyKey="Plumeria" isSpanish={true} />
-          <PriceConfirmationSection propertyKey="Plumeria" isSpanish={true} />
-          <SocialStatement propertyKey="Plumeria" isSpanish={true} />
-          <FeatureHighlights propertyKey="Plumeria" propertyName="Casa Plumeria" isSpanish={true} />
-          <InstantConfirmationBadge isSpanish={true} />
+          <ListingMarketingSection propertyKey="Plumeria" locale="es" />
+          <PriceConfirmationSection propertyKey="Plumeria" locale="es" />
+          <SocialStatement propertyKey="Plumeria" locale="es" />
+          <FeatureHighlights propertyKey="Plumeria" propertyName="Casa Plumeria" locale="es" />
+          <InstantConfirmationBadge locale="es" />
         </div>
       );
       
@@ -228,14 +228,14 @@ describe('Listing Page Integration Tests', () => {
       expect(screen.getAllByText('Confirmación inmediata')[0]).toBeInTheDocument();
     });
 
-    test('All components use consistent language when isSpanish=false', () => {
+    test('All components use consistent language when locale=false', () => {
       render(
         <div>
-          <ListingMarketingSection propertyKey="Giulia" isSpanish={false} />
-          <PriceConfirmationSection propertyKey="Giulia" isSpanish={false} />
-          <SocialStatement propertyKey="Giulia" isSpanish={false} />
-          <FeatureHighlights propertyKey="Giulia" propertyName="Casa Giulia" isSpanish={false} />
-          <InstantConfirmationBadge isSpanish={false} />
+          <ListingMarketingSection propertyKey="Giulia" locale="en" />
+          <PriceConfirmationSection propertyKey="Giulia" locale="en" />
+          <SocialStatement propertyKey="Giulia" locale="en" />
+          <FeatureHighlights propertyKey="Giulia" propertyName="Casa Giulia" locale="en" />
+          <InstantConfirmationBadge locale="en" />
         </div>
       );
       

--- a/src/hooks/useLanguageDetection.ts
+++ b/src/hooks/useLanguageDetection.ts
@@ -1,16 +1,15 @@
-import { useLocation } from 'react-router-dom';
+import { useLocale } from '../i18n';
 
 /**
- * Hook to detect if the current page is in Spanish based on the URL
- * @returns boolean indicating if the current page is Spanish
+ * @deprecated Use `useLocale()` from `src/i18n` instead.
+ *
+ * Kept as a thin shim so Phase 1 stays a mechanical change: its four remaining
+ * callers (Portal.page, PortalDetail.page, PortalGuard, Booking.page) branch on
+ * a boolean in a lot of places, and rewriting all of that belongs with the
+ * message-catalog work in Phase 2 rather than here.
+ *
+ * The detection logic itself is gone — this now delegates to the single source
+ * of truth, so it cannot drift from the rest of the app. Delete the shim once
+ * those four callers move to `useLocale()`.
  */
-export const useLanguageDetection = (): boolean => {
-  const location = useLocation();
-  
-  // Determine if current page is Spanish based on route
-  const isSpanishPage = location.pathname.endsWith('ES') || 
-                       location.pathname.includes('ES/') ||
-                       location.pathname === '/HomeES';
-  
-  return isSpanishPage;
-};
+export const useLanguageDetection = (): boolean => useLocale() === 'es';

--- a/src/i18n/detectLocale.ts
+++ b/src/i18n/detectLocale.ts
@@ -1,0 +1,28 @@
+import { DEFAULT_LOCALE, Locale } from './locales';
+
+/**
+ * Single source of truth for "what language is this URL?".
+ *
+ * Before Phase 1 this logic existed in nine hand-rolled copies — `isSpanishPath`
+ * in the flag switcher, `useLanguageDetection`, and seven inline
+ * `pathname.endsWith('ES')` checks scattered through components. They had
+ * already drifted: some checked `endsWith('ES')`, some also `includes('ES/')`,
+ * one special-cased `/HomeES`, one lowercased first. Six languages would have
+ * multiplied that drift, so they all now call here.
+ *
+ * PHASE 1 (now): derives the locale from the legacy `…ES` route suffix.
+ * PHASE 4: routes become `/es/plumeria` and this reads the `:locale` segment
+ *          instead. That is a change to this file alone — every caller keeps
+ *          working, which is the whole point of centralising it now.
+ */
+export function detectLocaleFromPath(pathname: string): Locale {
+  // Case-sensitive on purpose. Every Spanish route ends in a literal uppercase
+  // "ES" (/HomeES, /PlumeriaES, /bookES). One of the old copies lowercased the
+  // path first, which would also match a route ending in "es" — none exist
+  // today, but /puertoHiddenGems and /bushours sit one rename away from it.
+  //
+  // The `ES/` clause catches nested Spanish routes whose suffix is not at the
+  // end: /bookES/return, /bookES/confirmed, /portalES/:reservationPublicId.
+  const spanish = pathname.endsWith('ES') || pathname.includes('ES/');
+  return spanish ? 'es' : DEFAULT_LOCALE;
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,4 @@
+export { LOCALES, DEFAULT_LOCALE, RELEASED_LOCALES, LOCALE_META, isLocale } from './locales';
+export type { Locale } from './locales';
+export { detectLocaleFromPath } from './detectLocale';
+export { useLocale } from './useLocale';

--- a/src/i18n/locales.ts
+++ b/src/i18n/locales.ts
@@ -1,0 +1,39 @@
+/**
+ * The set of languages the site is being built for.
+ *
+ * See docs/i18n-rollout-plan.md. All six are declared here from Phase 1 so the
+ * type work happens once — code written against `Locale` today keeps compiling
+ * when DE/FR/IT/PT content arrives in Phase 8. Until then those four resolve to
+ * English at every lookup site, which is the intended interim behaviour.
+ *
+ * `RELEASED_LOCALES` is the separate, narrower question of what a visitor is
+ * allowed to pick. Do not offer a language in the switcher until its content
+ * exists, or the switcher navigates to pages that do not.
+ */
+
+export const LOCALES = ['en', 'es', 'de', 'fr', 'it', 'pt'] as const;
+
+export type Locale = (typeof LOCALES)[number];
+
+export const DEFAULT_LOCALE: Locale = 'en';
+
+/** Locales with real content, i.e. what the language switcher may offer. */
+export const RELEASED_LOCALES: readonly Locale[] = ['en', 'es'];
+
+/**
+ * Native names, deliberately — a German speaker scanning for their language
+ * looks for "Deutsch", not "German". `flag` is an ISO 3166-1 alpha-2 code for
+ * the `country-flag-icons` components the switcher uses.
+ */
+export const LOCALE_META: Record<Locale, { nativeName: string; flag: string }> = {
+  en: { nativeName: 'English', flag: 'US' },
+  es: { nativeName: 'Español', flag: 'ES' },
+  de: { nativeName: 'Deutsch', flag: 'DE' },
+  fr: { nativeName: 'Français', flag: 'FR' },
+  it: { nativeName: 'Italiano', flag: 'IT' },
+  pt: { nativeName: 'Português', flag: 'PT' },
+};
+
+export function isLocale(value: string): value is Locale {
+  return (LOCALES as readonly string[]).includes(value);
+}

--- a/src/i18n/useLocale.ts
+++ b/src/i18n/useLocale.ts
@@ -1,0 +1,16 @@
+import { useLocation } from 'react-router-dom';
+import { detectLocaleFromPath } from './detectLocale';
+import { Locale } from './locales';
+
+/**
+ * The locale of the page currently being viewed.
+ *
+ * Use this in any component that sits inside the router and needs to know the
+ * language. Components that receive a `locale` prop from a parent page should
+ * keep using the prop — Phase 3 collapses the duplicated EN/ES page components,
+ * and after that the prop threading goes away in favour of this hook.
+ */
+export function useLocale(): Locale {
+  const location = useLocation();
+  return detectLocaleFromPath(location.pathname);
+}

--- a/src/pages/Blog/BlogIndex.page.tsx
+++ b/src/pages/Blog/BlogIndex.page.tsx
@@ -50,7 +50,7 @@ const BlogIndex = () => {
           </ul>
         </Col>
       </Row>
-      <Footer isSpanish={false} />
+      <Footer locale="en" />
     </div>
   );
 };

--- a/src/pages/Blog/BlogIndex.page_ES.tsx
+++ b/src/pages/Blog/BlogIndex.page_ES.tsx
@@ -45,7 +45,7 @@ const BlogIndexES = () => {
           </ul>
         </Col>
       </Row>
-      <Footer isSpanish={true} />
+      <Footer locale="es" />
     </div>
   );
 };

--- a/src/pages/Home/Home.page.nam.tsx
+++ b/src/pages/Home/Home.page.nam.tsx
@@ -60,15 +60,15 @@ const HomeNam = () => {
       <WelcomeSliderNam />
       <FixedNavigation isBlog={false} />
       <HelpMeChoose title="Find your" titleHighlight="Ideal Stay" options={helpMeChooseOptions} />
-      <BookingSearchWidget isSpanish={false} variant="hero" />
-      <HomeReviews isSpanish={false} />
+      <BookingSearchWidget locale="en" variant="hero" />
+      <HomeReviews locale="en" />
       <OurHomesNam NamDataList={NamDataList} />
       <OurOtherHomesNam />
       <DiscoverNam />
       <PortfolioNam />
       {/* <Testimonial /> */}
       <ContactUs />
-      <Footer isSpanish={false} />
+      <Footer locale="en" />
 
     </div>
   )

--- a/src/pages/Home/Home.page.rib.tsx
+++ b/src/pages/Home/Home.page.rib.tsx
@@ -28,7 +28,7 @@ const HomeRib = () => {
       </Helmet>
       <WelcomeSliderRib />
       <FixedNavigationRib isBlog={false} />
-      <BookingSearchWidget isSpanish={false} variant="hero" />
+      <BookingSearchWidget locale="en" variant="hero" />
       <OurHomesRIB houseDataList={ribHouseDataEngList} />
       <OurOtherHomesRIB />
       <DiscoverRIB />
@@ -36,7 +36,7 @@ const HomeRib = () => {
       <PortfolioRIB />
       {/* <Testimonial /> */}
       <ContactUs />
-      <Footer isSpanish={false} />
+      <Footer locale="en" />
     </div>
   )
 }

--- a/src/pages/Home/Home.page.tsx
+++ b/src/pages/Home/Home.page.tsx
@@ -61,16 +61,16 @@ const Home = () => {
       <WelcomeSlider />
       <FixedNavigation isBlog={false} />
       <HelpMeChoose title="Find your" titleHighlight="Ideal Stay" options={helpMeChooseOptions} />
-      <HomeReviews isSpanish={false} />
+      <HomeReviews locale="en" />
       <OurHomes houseDataList={houseDataEngList} />
       <OurOtherHomes />
-      <BookingCtaBanner isSpanish={false} />
+      <BookingCtaBanner locale="en" />
       <Discover />
       {/* <CallToAction /> */}
       <Portfolio />
       {/* <Testimonial /> */}
       <ContactUs />
-      <Footer isSpanish={false} />
+      <Footer locale="en" />
 
     </div>
   )

--- a/src/pages/Home/Home.pageES.nam.tsx
+++ b/src/pages/Home/Home.pageES.nam.tsx
@@ -61,15 +61,15 @@ const HomeNamES = () => {
       <WelcomeSliderNamES />
       <FixedNavigationES isBlog={false}/>
       <HelpMeChoose title="Elige tu" titleHighlight="Estadía Ideal" options={helpMeChooseOptionsES} />
-      <BookingSearchWidget isSpanish={true} variant="hero" />
-      <HomeReviews isSpanish={true} />
+      <BookingSearchWidget locale="es" variant="hero" />
+      <HomeReviews locale="es" />
       <OurHomes houseDataList={NamDataListES}/>
       <OurOtherHomesNamES />
       <DiscoverNamES />
       <PortfolioNam />
       {/* <Testimonial /> */}
       <ContactUs />
-      <Footer isSpanish={true} />
+      <Footer locale="es" />
 
     </div>
   )

--- a/src/pages/Home/Home.pageES.rib.tsx
+++ b/src/pages/Home/Home.pageES.rib.tsx
@@ -25,14 +25,14 @@ const HomeRibES = () => {
       </Helmet>
       <WelcomeSliderRibES />
       <FixedNavigationES isBlog={false}/>
-      <BookingSearchWidget isSpanish={true} variant="hero" />
+      <BookingSearchWidget locale="es" variant="hero" />
       <OurHomesRIBES houseDataList={VillasDataListES}/>
       <OurOtherHomesRIBES/>
       <DiscoverRIBES />
       <CallToActionES />
       <PortfolioRIBES />
       <ContactUs />
-      <Footer isSpanish={true} />
+      <Footer locale="es" />
     </div>
   )
 }

--- a/src/pages/Home/Home.pageES.tsx
+++ b/src/pages/Home/Home.pageES.tsx
@@ -59,15 +59,15 @@ const HomeES = () => {
       <WelcomeSliderES />
       <FixedNavigationES isBlog={false}/>
       <HelpMeChoose title="Elige tu" titleHighlight="Estadía Ideal" options={helpMeChooseOptionsES} />
-      <HomeReviews isSpanish={true} />
+      <HomeReviews locale="es" />
       <OurHomesES houseDataList={houseDataList}/>
       <OurOtherHomesES/>
-      <BookingCtaBanner isSpanish={true} />
+      <BookingCtaBanner locale="es" />
       <DiscoverES />
       <PortfolioES />
       {/* <Testimonial /> */}
       <ContactUsES />
-      <Footer isSpanish={true} />
+      <Footer locale="es" />
 
     </div>
   )

--- a/src/pages/Listing/components/Amenities/Amenities.component.tsx
+++ b/src/pages/Listing/components/Amenities/Amenities.component.tsx
@@ -3,17 +3,18 @@ import { AmenityType } from "../../../../utils/types";
 import AmenityIcon from "../../../../components/AmenityIcon/AmenityIcon.component";
 import { getCapacityFacts } from "../../../../utils/propertyCapacity";
 import './Amenities.style.scss'
+import type { Locale } from '../../../../i18n';
 
 interface IAmenities {
     amenities: AmenityType[]
     // Optional: when given, the grid leads with the property's bedroom, bathroom
     // and occupancy counts before the amenities themselves.
     propertyKey?: string
-    isSpanish?: boolean
+    locale?: Locale
 }
 
-const Amenities: FC<IAmenities> = ({ amenities, propertyKey, isSpanish = false }) => {
-    const capacityFacts = propertyKey ? getCapacityFacts(propertyKey, isSpanish) : [];
+const Amenities: FC<IAmenities> = ({ amenities, propertyKey, locale = 'en' }) => {
+    const capacityFacts = propertyKey ? getCapacityFacts(propertyKey, locale) : [];
 
     return (
         <div className="amenitiesCont d-flex justify-content-center">

--- a/src/pages/Listing/components/Amenities/__tests__/Amenities.test.tsx
+++ b/src/pages/Listing/components/Amenities/__tests__/Amenities.test.tsx
@@ -9,7 +9,7 @@ const amenities: AmenityType[] = [
 
 describe('Amenities', () => {
   test('leads with bedroom, bathroom and occupancy counts when given a property key', () => {
-    render(<Amenities amenities={amenities} propertyKey="Geco" isSpanish={false} />);
+    render(<Amenities amenities={amenities} propertyKey="Geco" locale="en" />);
 
     expect(screen.getByText('2 bedrooms')).toBeInTheDocument();
     expect(screen.getByText('1 bathroom')).toBeInTheDocument();
@@ -27,7 +27,7 @@ describe('Amenities', () => {
   });
 
   test('renders the counts in Spanish', () => {
-    render(<Amenities amenities={amenities} propertyKey="Delfin" isSpanish={true} />);
+    render(<Amenities amenities={amenities} propertyKey="Delfin" locale="es" />);
 
     expect(screen.getByText('2 habitaciones')).toBeInTheDocument();
     expect(screen.getByText('2 baños')).toBeInTheDocument();

--- a/src/pages/Listing/components/ImagesModal/ImagesModal.component.tsx
+++ b/src/pages/Listing/components/ImagesModal/ImagesModal.component.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import './ImagesModal.style.scss';
 import { getHouseImages } from "../../../../utils/houseImages";
 import ZoomableImage from "./ZoomableImage.component";
+import type { Locale } from '../../../../i18n';
 
 
 interface IIMagesModal {
@@ -9,11 +10,12 @@ interface IIMagesModal {
   houseName: string;
 }
 
-const isSpanish = (houseName: string) => houseName.endsWith('ES');
+/** House codes carry their own language: "GecoES" is the Spanish listing. */
+const localeOfHouse = (houseName: string): Locale => (houseName.endsWith('ES') ? 'es' : 'en');
 
 const ImagesModal = ({ closeModal, houseName }: IIMagesModal) => {
   const images = getHouseImages(houseName);
-  const spanish = isSpanish(houseName);
+  const spanish = localeOfHouse(houseName) === 'es';
   const [viewerIndex, setViewerIndex] = useState<number | null>(null);
   const isViewerOpen = viewerIndex !== null;
 

--- a/src/pages/Listing/staticPages/ListingAreka.page.tsx
+++ b/src/pages/Listing/staticPages/ListingAreka.page.tsx
@@ -78,17 +78,17 @@ const ListingAreka = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="Areka" isSpanish={false} />
+                        <ListingMarketingSection propertyKey="Areka" locale="en" />
                     </div>
                     <ImagesContainer showModal={handleShow} houseName={listing!} />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="Areka" isSpanish={false} />
+                    <SocialStatement propertyKey="Areka" locale="en" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Areka" isSpanish={false} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Areka" locale="en" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="Areka" propertyName="House Areka" isSpanish={false} />
+                    <FeatureHighlights propertyKey="Areka" propertyName="House Areka" locale="en" />
 
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
@@ -122,12 +122,12 @@ const ListingAreka = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="AREKA" isSpanish={false} />
+                    <GuestReviews propertyKey="AREKA" locale="en" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="Areka" isSpanish={false} />
-                    <BookingSearchWidget isSpanish={false} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Areka" />
+                    <PriceConfirmationSection propertyKey="Areka" locale="en" />
+                    <BookingSearchWidget locale="en" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Areka" />
                 </Col>
             </Row>
 
@@ -135,7 +135,7 @@ const ListingAreka = () => {
                 <OtherListings listings={NamSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
-            <Footer isSpanish={false} />
+            <Footer locale="en" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages/ListingDelfin.page.tsx
+++ b/src/pages/Listing/staticPages/ListingDelfin.page.tsx
@@ -78,18 +78,18 @@ const ListingDelfin = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="Delfin" isSpanish={false} />
+                        <ListingMarketingSection propertyKey="Delfin" locale="en" />
 
                     </div>
                     <ImagesContainer showModal={handleShow} houseName={listing!} />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="Delfin" isSpanish={false} />
+                    <SocialStatement propertyKey="Delfin" locale="en" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Delfin" isSpanish={false} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Delfin" locale="en" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="Delfin" propertyName="House Delfin" isSpanish={false} />
+                    <FeatureHighlights propertyKey="Delfin" propertyName="House Delfin" locale="en" />
 
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
@@ -122,12 +122,12 @@ const ListingDelfin = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="DELFINES" isSpanish={false} />
+                    <GuestReviews propertyKey="DELFINES" locale="en" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="Delfin" isSpanish={false} />
-                    <BookingSearchWidget isSpanish={false} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Delfin" />
+                    <PriceConfirmationSection propertyKey="Delfin" locale="en" />
+                    <BookingSearchWidget locale="en" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Delfin" />
                 </Col>
             </Row>
 
@@ -135,7 +135,7 @@ const ListingDelfin = () => {
                 <OtherListings listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
-            <Footer isSpanish={false} />
+            <Footer locale="en" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages/ListingGeco.page.tsx
+++ b/src/pages/Listing/staticPages/ListingGeco.page.tsx
@@ -79,18 +79,18 @@ const ListingGeco = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="Geco" isSpanish={false} />
+                        <ListingMarketingSection propertyKey="Geco" locale="en" />
 
                     </div>
                     <ImagesContainer showModal={handleShow} houseName={listing!} />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="Geco" isSpanish={false} />
+                    <SocialStatement propertyKey="Geco" locale="en" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Geco" isSpanish={false} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Geco" locale="en" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="Geco" propertyName="House Geco" isSpanish={false} />
+                    <FeatureHighlights propertyKey="Geco" propertyName="House Geco" locale="en" />
 
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
@@ -135,12 +135,12 @@ const ListingGeco = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="GECO" isSpanish={false} />
+                    <GuestReviews propertyKey="GECO" locale="en" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="Geco" isSpanish={false} />
-                    <BookingSearchWidget isSpanish={false} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Geco" />
+                    <PriceConfirmationSection propertyKey="Geco" locale="en" />
+                    <BookingSearchWidget locale="en" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Geco" />
                 </Col>
             </Row>
 
@@ -148,7 +148,7 @@ const ListingGeco = () => {
                 <OtherListings listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
-            <Footer isSpanish={false} />
+            <Footer locale="en" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages/ListingGiulia.page.tsx
+++ b/src/pages/Listing/staticPages/ListingGiulia.page.tsx
@@ -76,17 +76,17 @@ const ListingGiulia = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="Giulia" isSpanish={false} />
+                        <ListingMarketingSection propertyKey="Giulia" locale="en" />
                     </div>
                     <ImagesContainer showModal={handleShow} houseName={listing!} />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="Giulia" isSpanish={false} />
+                    <SocialStatement propertyKey="Giulia" locale="en" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Giulia" isSpanish={false} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Giulia" locale="en" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="Giulia" propertyName="House Giulia" isSpanish={false} />
+                    <FeatureHighlights propertyKey="Giulia" propertyName="House Giulia" locale="en" />
 
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
@@ -120,12 +120,12 @@ const ListingGiulia = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="GIULIA" isSpanish={false} />
+                    <GuestReviews propertyKey="GIULIA" locale="en" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="Giulia" isSpanish={false} />
-                    <BookingSearchWidget isSpanish={false} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Giulia" />
+                    <PriceConfirmationSection propertyKey="Giulia" locale="en" />
+                    <BookingSearchWidget locale="en" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Giulia" />
                 </Col>
             </Row>
 
@@ -133,7 +133,7 @@ const ListingGiulia = () => {
                 <OtherListings listings={NamSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
-            <Footer isSpanish={false} />
+            <Footer locale="en" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages/ListingPappagallo.page.tsx
+++ b/src/pages/Listing/staticPages/ListingPappagallo.page.tsx
@@ -77,17 +77,17 @@ const ListingPappagallo = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="Pappagallo" isSpanish={false} />
+                        <ListingMarketingSection propertyKey="Pappagallo" locale="en" />
                     </div>
                     <ImagesContainer showModal={handleShow} houseName={listing!} />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="Pappagallo" isSpanish={false} />
+                    <SocialStatement propertyKey="Pappagallo" locale="en" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Pappagallo" isSpanish={false} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Pappagallo" locale="en" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="Pappagallo" propertyName="House Pappagallo" isSpanish={false} />
+                    <FeatureHighlights propertyKey="Pappagallo" propertyName="House Pappagallo" locale="en" />
 
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
@@ -127,12 +127,12 @@ const ListingPappagallo = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="PAPPAGALLO" isSpanish={false} />
+                    <GuestReviews propertyKey="PAPPAGALLO" locale="en" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="Pappagallo" isSpanish={false} />
-                    <BookingSearchWidget isSpanish={false} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Pappagallo" />
+                    <PriceConfirmationSection propertyKey="Pappagallo" locale="en" />
+                    <BookingSearchWidget locale="en" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Pappagallo" />
                 </Col>
             </Row>
 
@@ -140,7 +140,7 @@ const ListingPappagallo = () => {
                 <OtherListings listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
-            <Footer isSpanish={false} />
+            <Footer locale="en" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages/ListingPlumeria.page.tsx
+++ b/src/pages/Listing/staticPages/ListingPlumeria.page.tsx
@@ -76,17 +76,17 @@ const ListingPlumeria = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="Plumeria" isSpanish={false} />
+                        <ListingMarketingSection propertyKey="Plumeria" locale="en" />
                     </div>
                     <ImagesContainer showModal={handleShow} houseName={listing!} />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="Plumeria" isSpanish={false} />
+                    <SocialStatement propertyKey="Plumeria" locale="en" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Plumeria" isSpanish={false} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Plumeria" locale="en" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="Plumeria" propertyName="House Plumeria" isSpanish={false} />
+                    <FeatureHighlights propertyKey="Plumeria" propertyName="House Plumeria" locale="en" />
 
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
@@ -115,12 +115,12 @@ const ListingPlumeria = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="PLUMERIA" isSpanish={false} />
+                    <GuestReviews propertyKey="PLUMERIA" locale="en" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="Plumeria" isSpanish={false} />
-                    <BookingSearchWidget isSpanish={false} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Plumeria" />
+                    <PriceConfirmationSection propertyKey="Plumeria" locale="en" />
+                    <BookingSearchWidget locale="en" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Plumeria" />
                 </Col>
             </Row>
 
@@ -128,7 +128,7 @@ const ListingPlumeria = () => {
                 <OtherListings listings={NamSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
-            <Footer isSpanish={false} />
+            <Footer locale="en" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages/ListingRana.page.tsx
+++ b/src/pages/Listing/staticPages/ListingRana.page.tsx
@@ -78,17 +78,17 @@ const ListingRana = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="Rana" isSpanish={false} />
+                        <ListingMarketingSection propertyKey="Rana" locale="en" />
                     </div>
                     <ImagesContainer showModal={handleShow} houseName={listing!} />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="Rana" isSpanish={false} />
+                    <SocialStatement propertyKey="Rana" locale="en" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Rana" isSpanish={false} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Rana" locale="en" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="Rana" propertyName="House Rana" isSpanish={false} />
+                    <FeatureHighlights propertyKey="Rana" propertyName="House Rana" locale="en" />
 
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
@@ -133,12 +133,12 @@ const ListingRana = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="RANA" isSpanish={false} />
+                    <GuestReviews propertyKey="RANA" locale="en" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="Rana" isSpanish={false} />
-                    <BookingSearchWidget isSpanish={false} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Rana" />
+                    <PriceConfirmationSection propertyKey="Rana" locale="en" />
+                    <BookingSearchWidget locale="en" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Rana" />
                 </Col>
             </Row>
 
@@ -146,7 +146,7 @@ const ListingRana = () => {
                 <OtherListings listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
-            <Footer isSpanish={false} />
+            <Footer locale="en" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages/ListingTucano.page.tsx
+++ b/src/pages/Listing/staticPages/ListingTucano.page.tsx
@@ -77,17 +77,17 @@ const ListingTucano = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="Tucano" isSpanish={false} />
+                        <ListingMarketingSection propertyKey="Tucano" locale="en" />
                     </div>
                     <ImagesContainer showModal={handleShow} houseName={listing!} />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="Tucano" isSpanish={false} />
+                    <SocialStatement propertyKey="Tucano" locale="en" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Tucano" isSpanish={false} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Tucano" locale="en" />
                     </div>
                    
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="Tucano" propertyName="House Tucano" isSpanish={false} />
+                    <FeatureHighlights propertyKey="Tucano" propertyName="House Tucano" locale="en" />
                    
                     <div className="description">
                     <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
@@ -120,19 +120,19 @@ const ListingTucano = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="TUCANO" isSpanish={false} />
+                    <GuestReviews propertyKey="TUCANO" locale="en" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="Tucano" isSpanish={false} />
-                    <BookingSearchWidget isSpanish={false} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Tucano" />
+                    <PriceConfirmationSection propertyKey="Tucano" locale="en" />
+                    <BookingSearchWidget locale="en" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Tucano" />
                 </Col>
             </Row>
             <div className="other-listings-bottom">
                 <OtherListings listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
-            <Footer isSpanish={false} />
+            <Footer locale="en" />
             
         </div>
     )

--- a/src/pages/Listing/staticPages/ListingVillaCoral.page.tsx
+++ b/src/pages/Listing/staticPages/ListingVillaCoral.page.tsx
@@ -80,17 +80,17 @@ const ListingVillaCoral = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="VillaCoral" isSpanish={false} />
+                        <ListingMarketingSection propertyKey="VillaCoral" locale="en" />
                     </div>
                     <ImagesContainer showModal={handleShow} houseName={listing!} />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="VillaCoral" isSpanish={false} />
+                    <SocialStatement propertyKey="VillaCoral" locale="en" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="VillaCoral" isSpanish={false} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="VillaCoral" locale="en" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="VillaCoral" propertyName="Villa Coral" isSpanish={false} />
+                    <FeatureHighlights propertyKey="VillaCoral" propertyName="Villa Coral" locale="en" />
 
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
@@ -130,12 +130,12 @@ const ListingVillaCoral = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="VILLA CORAL" isSpanish={false} />
+                    <GuestReviews propertyKey="VILLA CORAL" locale="en" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="VillaCoral" isSpanish={false} />
-                    <BookingSearchWidget isSpanish={false} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="VillaCoral" />
+                    <PriceConfirmationSection propertyKey="VillaCoral" locale="en" />
+                    <BookingSearchWidget locale="en" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="VillaCoral" />
                 </Col>
             </Row>
 
@@ -143,7 +143,7 @@ const ListingVillaCoral = () => {
                 <OtherListings listings={VillaSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
-            <Footer isSpanish={false} />
+            <Footer locale="en" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages/ListingVillaMar.page.tsx
+++ b/src/pages/Listing/staticPages/ListingVillaMar.page.tsx
@@ -80,17 +80,17 @@ const ListingVillaMar = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="VillaMar" isSpanish={false} />
+                        <ListingMarketingSection propertyKey="VillaMar" locale="en" />
                     </div>
                     <ImagesContainer showModal={handleShow} houseName={listing!} />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="VillaMar" isSpanish={false} />
+                    <SocialStatement propertyKey="VillaMar" locale="en" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="VillaMar" isSpanish={false} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="VillaMar" locale="en" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="VillaMar" propertyName="Villa Mar" isSpanish={false} />
+                    <FeatureHighlights propertyKey="VillaMar" propertyName="Villa Mar" locale="en" />
 
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
@@ -129,12 +129,12 @@ const ListingVillaMar = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="VILLA MAR" isSpanish={false} />
+                    <GuestReviews propertyKey="VILLA MAR" locale="en" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="VillaMar" isSpanish={false} />
-                    <BookingSearchWidget isSpanish={false} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="VillaMar" />
+                    <PriceConfirmationSection propertyKey="VillaMar" locale="en" />
+                    <BookingSearchWidget locale="en" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="VillaMar" />
                 </Col>
             </Row>
 
@@ -142,7 +142,7 @@ const ListingVillaMar = () => {
                 <OtherListings listings={VillaSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
-            <Footer isSpanish={false} />
+            <Footer locale="en" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages/__tests__/ListingDelfin.test.tsx
+++ b/src/pages/Listing/staticPages/__tests__/ListingDelfin.test.tsx
@@ -10,14 +10,15 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import ListingDelfin from '../ListingDelfin.page';
 import { houseDataList } from '../../../../utils/constants';
+import type { Locale } from '../../../../i18n';
 
 // Mock the booking search widget that replaced the Smoobu iframe
 jest.mock('../../../../components/BookingSearchWidget/BookingSearchWidget.component', () => {
-  return function MockBookingSearchWidget({ isSpanish, defaultGuests, variant }: { isSpanish: boolean; defaultGuests?: number; variant?: string }) {
+  return function MockBookingSearchWidget({ locale, defaultGuests, variant }: { locale: Locale; defaultGuests?: number; variant?: string }) {
     return (
       <div
         data-testid="booking-search-widget"
-        data-is-spanish={String(isSpanish)}
+        data-is-spanish={String(locale)}
         data-default-guests={defaultGuests}
         data-variant={variant}
       >

--- a/src/pages/Listing/staticPages_ES/ListingAreka.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingAreka.page_ES.tsx
@@ -78,17 +78,17 @@ const ListingArekaES = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="Areka" isSpanish={true} />
+                        <ListingMarketingSection propertyKey="Areka" locale="es" />
                     </div>
                     <ImagesContainer showModal={handleShow} houseName="Areka" />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="Areka" isSpanish={true} />
+                    <SocialStatement propertyKey="Areka" locale="es" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Areka" isSpanish={true} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Areka" locale="es" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="Areka" propertyName="Casa Areka" isSpanish={true} />
+                    <FeatureHighlights propertyKey="Areka" propertyName="Casa Areka" locale="es" />
 
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
@@ -121,12 +121,12 @@ const ListingArekaES = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="AREKA" isSpanish={true} />
+                    <GuestReviews propertyKey="AREKA" locale="es" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="Areka" isSpanish={true} />
-                    <BookingSearchWidget isSpanish={true} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Areka" />
+                    <PriceConfirmationSection propertyKey="Areka" locale="es" />
+                    <BookingSearchWidget locale="es" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Areka" />
                 </Col>
             </Row>
 
@@ -134,7 +134,7 @@ const ListingArekaES = () => {
                 <OtherListingsES listings={NamSnippetES} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName="Areka" />}
-            <Footer isSpanish={true} />
+            <Footer locale="es" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/ListingDelfin.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingDelfin.page_ES.tsx
@@ -78,18 +78,18 @@ const ListingDelfin = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="Delfin" isSpanish={true} />
+                        <ListingMarketingSection propertyKey="Delfin" locale="es" />
 
                     </div>
                     <ImagesContainer showModal={handleShow} houseName={listing!} />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="Delfin" isSpanish={true} />
+                    <SocialStatement propertyKey="Delfin" locale="es" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Delfin" isSpanish={true} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Delfin" locale="es" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="Delfin" propertyName="Casa Delfín" isSpanish={true} />
+                    <FeatureHighlights propertyKey="Delfin" propertyName="Casa Delfín" locale="es" />
 
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
@@ -130,12 +130,12 @@ const ListingDelfin = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="DELFINES" isSpanish={true} />
+                    <GuestReviews propertyKey="DELFINES" locale="es" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="Delfin" isSpanish={true} />
-                    <BookingSearchWidget isSpanish={true} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Delfin" />
+                    <PriceConfirmationSection propertyKey="Delfin" locale="es" />
+                    <BookingSearchWidget locale="es" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Delfin" />
                 </Col>
             </Row>
 
@@ -143,7 +143,7 @@ const ListingDelfin = () => {
                 <OtherListingsES listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
-            <Footer isSpanish={true} />
+            <Footer locale="es" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/ListingGeco.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingGeco.page_ES.tsx
@@ -77,17 +77,17 @@ const ListingGecoES = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="Geco" isSpanish={true} />
+                        <ListingMarketingSection propertyKey="Geco" locale="es" />
                     </div>
                     <ImagesContainer showModal={handleShow} houseName={listing!} />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="Geco" isSpanish={true} />
+                    <SocialStatement propertyKey="Geco" locale="es" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Geco" isSpanish={true} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Geco" locale="es" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="Geco" propertyName="Casa Geco" isSpanish={true} />
+                    <FeatureHighlights propertyKey="Geco" propertyName="Casa Geco" locale="es" />
 
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
@@ -132,12 +132,12 @@ const ListingGecoES = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="GECO" isSpanish={true} />
+                    <GuestReviews propertyKey="GECO" locale="es" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="Geco" isSpanish={true} />
-                    <BookingSearchWidget isSpanish={true} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Geco" />
+                    <PriceConfirmationSection propertyKey="Geco" locale="es" />
+                    <BookingSearchWidget locale="es" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Geco" />
                 </Col>
             </Row>
 
@@ -145,7 +145,7 @@ const ListingGecoES = () => {
                 <OtherListingsES listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
-            <Footer isSpanish={true} />
+            <Footer locale="es" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/ListingGiulia.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingGiulia.page_ES.tsx
@@ -78,17 +78,17 @@ const ListingGiuliaES = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="Giulia" isSpanish={true} />
+                        <ListingMarketingSection propertyKey="Giulia" locale="es" />
                     </div>
                     <ImagesContainer showModal={handleShow} houseName="Giulia" />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="Giulia" isSpanish={true} />
+                    <SocialStatement propertyKey="Giulia" locale="es" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Giulia" isSpanish={true} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Giulia" locale="es" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="Giulia" propertyName="Casa Giulia" isSpanish={true} />
+                    <FeatureHighlights propertyKey="Giulia" propertyName="Casa Giulia" locale="es" />
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
                             <p><strong>Entrada:</strong> 3:00 PM</p>
@@ -116,12 +116,12 @@ const ListingGiuliaES = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="GIULIA" isSpanish={true} />
+                    <GuestReviews propertyKey="GIULIA" locale="es" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="Giulia" isSpanish={true} />
-                    <BookingSearchWidget isSpanish={true} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Giulia" />
+                    <PriceConfirmationSection propertyKey="Giulia" locale="es" />
+                    <BookingSearchWidget locale="es" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Giulia" />
                 </Col>
             </Row>
 
@@ -129,7 +129,7 @@ const ListingGiuliaES = () => {
                 <OtherListingsES listings={NamSnippetES} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName="Giulia" />}
-            <Footer isSpanish={true} />
+            <Footer locale="es" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/ListingPappagallo.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingPappagallo.page_ES.tsx
@@ -79,17 +79,17 @@ const ListingPappagalloES = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="Pappagallo" isSpanish={true} />
+                        <ListingMarketingSection propertyKey="Pappagallo" locale="es" />
                     </div>
                     <ImagesContainer showModal={handleShow} houseName={listing!} />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="Pappagallo" isSpanish={true} />
+                    <SocialStatement propertyKey="Pappagallo" locale="es" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Pappagallo" isSpanish={true} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Pappagallo" locale="es" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="Pappagallo" propertyName="Casa Pappagallo" isSpanish={true} />
+                    <FeatureHighlights propertyKey="Pappagallo" propertyName="Casa Pappagallo" locale="es" />
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
                             <p><strong>Entrada:</strong> 2:00 PM</p>
@@ -129,12 +129,12 @@ const ListingPappagalloES = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="PAPPAGALLO" isSpanish={true} />
+                    <GuestReviews propertyKey="PAPPAGALLO" locale="es" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="Pappagallo" isSpanish={true} />
-                    <BookingSearchWidget isSpanish={true} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Pappagallo" />
+                    <PriceConfirmationSection propertyKey="Pappagallo" locale="es" />
+                    <BookingSearchWidget locale="es" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Pappagallo" />
                 </Col>
             </Row>
 
@@ -142,7 +142,7 @@ const ListingPappagalloES = () => {
                 <OtherListingsES listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
-            <Footer isSpanish={true} />
+            <Footer locale="es" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/ListingPlumeria.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingPlumeria.page_ES.tsx
@@ -78,17 +78,17 @@ const ListingPlumeriaES = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="Plumeria" isSpanish={true} />
+                        <ListingMarketingSection propertyKey="Plumeria" locale="es" />
                     </div>
                     <ImagesContainer showModal={handleShow} houseName="Plumeria" />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="Plumeria" isSpanish={true} />
+                    <SocialStatement propertyKey="Plumeria" locale="es" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Plumeria" isSpanish={true} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Plumeria" locale="es" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="Plumeria" propertyName="Casa Plumeria" isSpanish={true} />
+                    <FeatureHighlights propertyKey="Plumeria" propertyName="Casa Plumeria" locale="es" />
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
                             <p><strong>Entrada:</strong> 3:00 PM</p>
@@ -120,12 +120,12 @@ const ListingPlumeriaES = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="PLUMERIA" isSpanish={true} />
+                    <GuestReviews propertyKey="PLUMERIA" locale="es" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="Plumeria" isSpanish={true} />
-                    <BookingSearchWidget isSpanish={true} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Plumeria" />
+                    <PriceConfirmationSection propertyKey="Plumeria" locale="es" />
+                    <BookingSearchWidget locale="es" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Plumeria" />
                 </Col>
             </Row>
 
@@ -133,7 +133,7 @@ const ListingPlumeriaES = () => {
                 <OtherListingsES listings={NamSnippetES} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName="Plumeria" />}
-            <Footer isSpanish={true} />
+            <Footer locale="es" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/ListingRana.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingRana.page_ES.tsx
@@ -78,18 +78,18 @@ const ListingRana = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="Rana" isSpanish={true} />
+                        <ListingMarketingSection propertyKey="Rana" locale="es" />
 
                     </div>
                     <ImagesContainer showModal={handleShow} houseName={listing!} />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="Rana" isSpanish={true} />
+                    <SocialStatement propertyKey="Rana" locale="es" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Rana" isSpanish={true} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Rana" locale="es" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="Rana" propertyName="Casa Rana" isSpanish={true} />
+                    <FeatureHighlights propertyKey="Rana" propertyName="Casa Rana" locale="es" />
 
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
@@ -134,12 +134,12 @@ const ListingRana = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="RANA" isSpanish={true} />
+                    <GuestReviews propertyKey="RANA" locale="es" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="Rana" isSpanish={true} />
-                    <BookingSearchWidget isSpanish={true} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Rana" />
+                    <PriceConfirmationSection propertyKey="Rana" locale="es" />
+                    <BookingSearchWidget locale="es" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Rana" />
                 </Col>
             </Row>
 
@@ -147,7 +147,7 @@ const ListingRana = () => {
                 <OtherListingsES listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
-            <Footer isSpanish={true} />
+            <Footer locale="es" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/ListingTucano.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingTucano.page_ES.tsx
@@ -78,17 +78,17 @@ const ListingTucanoES = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="Tucano" isSpanish={true} />
+                        <ListingMarketingSection propertyKey="Tucano" locale="es" />
                     </div>
                     <ImagesContainer showModal={handleShow} houseName={listing!} />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="Tucano" isSpanish={true} />
+                    <SocialStatement propertyKey="Tucano" locale="es" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Tucano" isSpanish={true} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="Tucano" locale="es" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="Tucano" propertyName="Casa Tucano" isSpanish={true} />
+                    <FeatureHighlights propertyKey="Tucano" propertyName="Casa Tucano" locale="es" />
 
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
@@ -121,12 +121,12 @@ const ListingTucanoES = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="TUCANO" isSpanish={true} />
+                    <GuestReviews propertyKey="TUCANO" locale="es" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="Tucano" isSpanish={true} />
-                    <BookingSearchWidget isSpanish={true} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Tucano" />
+                    <PriceConfirmationSection propertyKey="Tucano" locale="es" />
+                    <BookingSearchWidget locale="es" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="Tucano" />
                 </Col>
             </Row>
 
@@ -134,7 +134,7 @@ const ListingTucanoES = () => {
                 <OtherListingsES listings={homesSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
-            <Footer isSpanish={true} />
+            <Footer locale="es" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/ListingVillaCoral.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingVillaCoral.page_ES.tsx
@@ -78,17 +78,17 @@ const ListingVillaCoralES = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="VillaCoral" isSpanish={true} />
+                        <ListingMarketingSection propertyKey="VillaCoral" locale="es" />
                     </div>
                     <ImagesContainer showModal={handleShow} houseName={listing!} />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="VillaCoral" isSpanish={true} />
+                    <SocialStatement propertyKey="VillaCoral" locale="es" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="VillaCoral" isSpanish={true} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="VillaCoral" locale="es" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="VillaCoral" propertyName="Villa Coral" isSpanish={true} />
+                    <FeatureHighlights propertyKey="VillaCoral" propertyName="Villa Coral" locale="es" />
 
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
@@ -128,12 +128,12 @@ const ListingVillaCoralES = () => {
                         </p>
                     </div>
 
-                    <GuestReviews propertyKey="VILLA CORAL" isSpanish={true} />
+                    <GuestReviews propertyKey="VILLA CORAL" locale="es" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="VillaCoral" isSpanish={true} />
-                    <BookingSearchWidget isSpanish={true} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="VillaCoral" />
+                    <PriceConfirmationSection propertyKey="VillaCoral" locale="es" />
+                    <BookingSearchWidget locale="es" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="VillaCoral" />
                 </Col>
             </Row>
 
@@ -141,7 +141,7 @@ const ListingVillaCoralES = () => {
                 <OtherListingsES listings={VillaCoralSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
-            <Footer isSpanish={true} />
+            <Footer locale="es" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/ListingVillaMar.page_ES.tsx
+++ b/src/pages/Listing/staticPages_ES/ListingVillaMar.page_ES.tsx
@@ -78,17 +78,17 @@ const ListingVillaMarES = () => {
                             </a>
                         </p>
                         {/* Add marketing section after title */}
-                        <ListingMarketingSection propertyKey="VillaMar" isSpanish={true} />
+                        <ListingMarketingSection propertyKey="VillaMar" locale="es" />
                     </div>
                     <ImagesContainer showModal={handleShow} houseName={listing!} />
                     {/* Add social statement after images */}
-                    <SocialStatement propertyKey="VillaMar" isSpanish={true} />
+                    <SocialStatement propertyKey="VillaMar" locale="es" />
                     <div className="amenaties">
-                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="VillaMar" isSpanish={true} />
+                        <Amenities amenities={houseData?.amenities as AmenityType[]} propertyKey="VillaMar" locale="es" />
                     </div>
 
                     {/* Add feature highlights before description */}
-                    <FeatureHighlights propertyKey="VillaMar" propertyName="Villa Mar" isSpanish={true} />
+                    <FeatureHighlights propertyKey="VillaMar" propertyName="Villa Mar" locale="es" />
 
                     <div className="description">
                         <div className="check-times" style={{ marginBottom: '20px', padding: '15px', borderRadius: '8px' }}>
@@ -128,12 +128,12 @@ const ListingVillaMarES = () => {
 
                     </div>
 
-                    <GuestReviews propertyKey="VILLA MAR" isSpanish={true} />
+                    <GuestReviews propertyKey="VILLA MAR" locale="es" />
 
                 </Col>
                 <Col id="smoobuComp" className="book col" lg={2} md={{ span: 12 }} sm={{ span: 12 }} xs={{ span: 12 }}>
-                    <PriceConfirmationSection propertyKey="VillaMar" isSpanish={true} />
-                    <BookingSearchWidget isSpanish={true} defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="VillaMar" />
+                    <PriceConfirmationSection propertyKey="VillaMar" locale="es" />
+                    <BookingSearchWidget locale="es" defaultGuests={houseData!.guestNumber} variant="sidebar" apartmentSlug="VillaMar" />
                 </Col>
             </Row>
 
@@ -141,7 +141,7 @@ const ListingVillaMarES = () => {
                 <OtherListingsES listings={VillaMarSnippet} currentListing={listing || ''} />
             </div>
             {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
-            <Footer isSpanish={true} />
+            <Footer locale="es" />
 
         </div>
     )

--- a/src/pages/Listing/staticPages_ES/__tests__/ListingDelfinES.test.tsx
+++ b/src/pages/Listing/staticPages_ES/__tests__/ListingDelfinES.test.tsx
@@ -10,14 +10,15 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import ListingDelfin from '../ListingDelfin.page_ES';
 import { houseDataList } from '../../../../utils/constants';
+import type { Locale } from '../../../../i18n';
 
 // Mock the booking search widget that replaced the Smoobu iframe
 jest.mock('../../../../components/BookingSearchWidget/BookingSearchWidget.component', () => {
-  return function MockBookingSearchWidget({ isSpanish, defaultGuests, variant }: { isSpanish: boolean; defaultGuests?: number; variant?: string }) {
+  return function MockBookingSearchWidget({ locale, defaultGuests, variant }: { locale: Locale; defaultGuests?: number; variant?: string }) {
     return (
       <div
         data-testid="booking-search-widget"
-        data-is-spanish={String(isSpanish)}
+        data-is-spanish={String(locale)}
         data-default-guests={defaultGuests}
         data-variant={variant}
       >

--- a/src/pages/NotFound.page.tsx
+++ b/src/pages/NotFound.page.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import { Link, useLocation } from 'react-router-dom';
+import { detectLocaleFromPath } from '../i18n';
 
 /**
  * Catch-all 404.
@@ -15,9 +16,9 @@ import { Link, useLocation } from 'react-router-dom';
  */
 const NotFound = () => {
   const { pathname } = useLocation();
-  const isSpanish = pathname.endsWith('ES');
+  const locale = detectLocaleFromPath(pathname);
 
-  const copy = isSpanish
+  const copy = (locale === 'es')
     ? {
         title: 'Página no encontrada | Reservas Kalawala',
         heading: 'No encontramos esta página',
@@ -36,7 +37,7 @@ const NotFound = () => {
   return (
     <main className="container" style={{ padding: '120px 16px', textAlign: 'center' }}>
       <Helmet>
-        <html lang={isSpanish ? 'es' : 'en'} />
+        <html lang={(locale === 'es') ? 'es' : 'en'} />
         <title>{copy.title}</title>
         <meta name="robots" content="noindex, follow" />
       </Helmet>

--- a/src/utils/propertyCapacity.ts
+++ b/src/utils/propertyCapacity.ts
@@ -1,3 +1,4 @@
+import type { Locale } from '../i18n';
 import { PROPERTY_CAPACITY } from './constants';
 
 /**
@@ -16,7 +17,7 @@ export type CapacityFact = {
 
 export const getCapacityFacts = (
   propertyKey: string,
-  isSpanish: boolean
+  locale: Locale
 ): CapacityFact[] => {
   const capacity = PROPERTY_CAPACITY[propertyKey];
 
@@ -30,22 +31,19 @@ export const getCapacityFacts = (
     {
       key: 'bedrooms',
       icon: 'bed',
-      label: isSpanish
-        ? `${bedrooms} ${bedrooms === 1 ? 'habitación' : 'habitaciones'}`
+      label: locale === 'es' ? `${bedrooms} ${bedrooms === 1 ? 'habitación' : 'habitaciones'}`
         : `${bedrooms} ${bedrooms === 1 ? 'bedroom' : 'bedrooms'}`
     },
     {
       key: 'bathrooms',
       icon: 'bath',
-      label: isSpanish
-        ? `${bathrooms} ${bathrooms === 1 ? 'baño' : 'baños'}`
+      label: locale === 'es' ? `${bathrooms} ${bathrooms === 1 ? 'baño' : 'baños'}`
         : `${bathrooms} ${bathrooms === 1 ? 'bathroom' : 'bathrooms'}`
     },
     {
       key: 'guests',
       icon: 'guests',
-      label: isSpanish
-        ? `Hasta ${maxGuests} ${maxGuests === 1 ? 'huésped' : 'huéspedes'}`
+      label: locale === 'es' ? `Hasta ${maxGuests} ${maxGuests === 1 ? 'huésped' : 'huéspedes'}`
         : `Up to ${maxGuests} ${maxGuests === 1 ? 'guest' : 'guests'}`
     }
   ];


### PR DESCRIPTION
Phase 1 of `docs/i18n-rollout-plan.md`. **Behaviour-preserving** — no user-visible change, same two languages, same routes.

> **Stacked on #39.** This branches off `chore/i18n-phase-0-baseline`, so merge #39 first and this diff reduces to Phase 1 alone.

## Why this is the gate on everything else

`isSpanish` was a **boolean used 360 times across 69 files**. A boolean cannot express six languages. There are now **zero `isSpanish` identifiers in `src/`**.

The useful property of this change: `Locale` is a union type, so a missed call site is a compile error rather than a silent runtime bug. That is what makes a 60-file rename safe to do in one go.

## What's added

`src/i18n/`:

- **`locales.ts`** — the `Locale` union (all six declared now, so the type work happens once), `DEFAULT_LOCALE`, `LOCALE_META` with native names and flag codes, and `RELEASED_LOCALES` — the separate, narrower question of *what a visitor may pick*, still `['en','es']`. Offering a language before its content exists would navigate people to pages that don't.
- **`detectLocale.ts`** — single source of truth for "what language is this URL?"
- **`useLocale.ts`** — the hook components use.

## The nine copies

Detection lived in nine hand-rolled copies, and they had **already drifted**: some checked `endsWith('ES')`, some also `includes('ES/')`, one special-cased `/HomeES`, one lowercased first. Six languages would have multiplied that. They all now call `detectLocaleFromPath`.

Phase 4 changes that *one function* to read a `:locale` route segment and every caller keeps working — which is the whole reason for centralising it now rather than later.

Two deliberate exceptions:

- **`CookieConsentBanner`** keeps its check verbatim. It also honours `/es`, `/spanish` and `?lang=es`, which the shared detector deliberately does not — delegating would have silently narrowed behaviour. Commented and marked for Phase 4.
- **`detectLocaleFromPath` is case-sensitive**, where one old copy lowercased first. Every Spanish route ends in a literal uppercase `ES`; matching case-insensitively would also match a route ending in "es". None exist today, but `/puertoHiddenGems` and `/bushours` sit one rename away from it.

## Scope change from the written plan

The plan had Phase 1 also converting the 49 inline ternaries to catalog lookups. **Moved to Phase 2**, and the plan is updated in this PR to say so.

Designing the catalog API is not a mechanical change, and mixing it into a 60-file rename makes the diff unreviewable — which this phase's own note explicitly warns against. The ternaries are now `locale === 'es' ? a : b`: behaviour-identical, with DE/FR/IT/PT correctly falling through to English until Phase 2.

Two `@deprecated` shims are left standing on purpose: `useLanguageDetection()` (now delegating to `useLocale()`, so it can no longer drift) and `useRandomPopup`'s `isSpanishPage` boolean. Their callers branch on a boolean in many places; converting them belongs with Phase 2.

## Validation

**`npx tsc --noEmit` — clean.**

**Unit tests — unchanged from `main`.** 4 suites / 27 tests fail, and they fail *identically* on unmodified `main` (299 passed, 326 total, both before and after). I ran the baseline rather than assume. Pre-existing, not introduced here.

**Prerender diff — the real evidence.** Built production output before and after and compared all 50 prerendered pages with content hashes normalised:

- **All 50 have byte-identical `<body>`.**
- 46 are fully identical; 4 differ only in react-helmet `<head>` ordering, verified as **equal tag multisets**.

For a refactor whose entire claim is "nothing changes", that's a stronger signal than a screenshot.

**Not run:** the Playwright e2e suite. It is `continue-on-error` in CI and per the workflow comment has never passed; the prerender diff is a stronger check for this specific claim.

## Note

`scripts/codemod-locale.mjs` is the one-shot script that produced the mechanical part of the diff. Committed so the rename is reproducible and reviewable — safe to delete after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
