### PR TITLE
fix(seo,i18n): valid VacationRental structured data + close remaining translation gaps

### DIFF
--- a/docs/i18n-rollout-plan.md
+++ b/docs/i18n-rollout-plan.md
@@ -2061,3 +2061,75 @@ what the next session should pick up.
   existing checklist. Separately, still open: a scoping decision on the
   `PROPERTY_MARKETING_CONFIG`/`locale === 'es'` follow-up from the Phase 8
   session log entry, and the outstanding PostHog export from Phase 0.
+
+### 2026-08-10 — VacationRental structured data fixed; remaining site-wide translation gap closed
+
+- **Structured data.** GSC's Rich Results check had all 45 property pages'
+  `VacationRental` markup failing validation. Root cause: `occupancy` used
+  `maxValue` instead of the spec's required `value`, and there was no
+  `identifier` anywhere — the spec requires one at the top level and,
+  per Google's guidance, one independent of listing content and consistent
+  across languages. Fixed in `public/index.html`: added a top-level
+  `identifier` (`reservas-kalawala`), a per-property `identifier` on each
+  `containsPlace` entry (matching the existing `routes.config.ts` slugs —
+  geco, rana, tucano, etc. — so it's stable across all 8 locale URLs for
+  the same listing), `additionalType: 'https://schema.org/EntirePlace'`,
+  and switched every `occupancy.maxValue` to `occupancy.value`. Both the
+  `VacationRental` and `Organization` JSON-LD blocks still parse; re-check
+  in Search Console after this deploys.
+- **Full translation audit.** The Phase 8 gap noted above
+  (`PROPERTY_MARKETING_CONFIG` and a `locale === 'es'` boolean pattern
+  rendering English-only for the six newer locales) turned out to be one
+  instance of a wider, recurring pattern: several components and data
+  sources were still typed/keyed for the original `en`/`es` pair only and
+  silently fell back to English for `de`/`fr`/`it`/`pt`/`he`/`hi`. A
+  dedicated audit agent enumerated every remaining instance site-wide.
+  Fixed: `PROPERTY_MARKETING_CONFIG` (all 10 properties, all 8 locales),
+  amenity name strings on listing pages, the cookie consent banner, the
+  404 page, `WhyStayWithUs`, guest review property labels and "stay type"
+  tags, the `StayRecommendation` widgets' reasons text (blog and
+  homepage), the blog cross-link/footer article titles, and the
+  "our photos" section heading. Content was produced by six parallel
+  translation agents (one per new locale) plus direct authoring for
+  smaller items, then spliced into the message catalogs and
+  `constants.ts` via generated scripts, each verified with a typecheck
+  pass.
+- **Bonus fix, found by spot-checking built HTML rather than by typecheck
+  or tests:** two of the ten blog articles (`travellingToPuerto`,
+  `gettingToGandoca` in `src/i18n/content/blog.tsx`) were missing their
+  entire German content block — a genuine pre-existing Phase 8 gap, not
+  something this session's routing changes introduced. Because that
+  content type is `Partial<Record<Locale, T>>`, a missing locale block
+  doesn't error at compile time — it silently falls back to `.en!`. Full
+  German translations written for both articles, JSX structure preserved.
+  Lesson for future locale work: `Partial<Record<Locale, T>>` completeness
+  has to be checked by script or by eye, not by `tsc`.
+- **Routing bug fixed at the root, not per-symptom.** Several of the
+  above call sites were routing new-locale visitors to English URLs even
+  after their *content* was translated, via `pathForLegacyId` — a
+  pre-i18n-rollout helper that only ever mapped to `'es'` or the default
+  locale (`'en'`), written before the 8-locale rollout and never updated.
+  Migrated every call site (`HomeCard`, `HelpMeChoose`, `OtherBlogs`,
+  `StayRecommendation`'s `link` field, `Footer`, `BlogIndex`) to
+  `routeKeyForSlug` + `pathForKey(locale)`, the pattern already used
+  elsewhere post-rollout, instead of patching each site individually.
+- **Deliberately left untranslated, by design, not oversight:** the
+  booking/payment flow (`bookingLanguage(locale)` in `src/i18n/paths.ts`
+  intentionally narrows to a smaller language set — a German visitor
+  gets the English booking UI rather than a missing one; this session
+  did not widen that boundary), guest review *body* text (verbatim
+  guest-authored content), image captions/alt text, and blog bus-schedule
+  table *row data* (the table headers are translated; the row content is
+  transit-agency schedule data, not prose).
+- Validation: clean `tsc --noEmit`, full Jest suite unchanged (299 passed,
+  same 4 pre-existing jsdom `matchMedia` failures, none newly introduced),
+  two full production builds (177/177 pages) both green, and manual
+  spot-checks of the built HTML across `PROPERTY_MARKETING_CONFIG`,
+  amenities, footer links, `HomeCard`/`HelpMeChoose` routing,
+  `StayRecommendation`, and both newly-fixed German blog articles.
+- **Next session:** Phase 10 (GSC submission/monitoring) is still tracked
+  separately on PR #59, open but not yet merged as of this entry — not
+  lost, just pending review. Re-run the Rich Results check once this
+  structured-data fix is live. The `PROPERTY_MARKETING_CONFIG`/
+  `locale === 'es'` follow-up referenced above is now resolved by this
+  session's work and can be considered closed.

--- a/public/index.html
+++ b/public/index.html
@@ -158,6 +158,7 @@
   "@context": "https://schema.org",
   "@type": "VacationRental",
   "name": "Reservas Kalawala",
+  "identifier": "reservas-kalawala",
   "description": "Family-run vacation rental company offering fully equipped houses and villas in Puerto Viejo de Talamanca, Costa Rica. 10 properties sleeping 2-8 guests with private kitchens, bathrooms, A/C, and free WiFi. Book direct for the best rates.",
   "url": "https://www.reservaskalawala.com",
   "image": "https://www.reservaskalawala.com/logo.png",
@@ -227,10 +228,12 @@
       "@type": "Accommodation",
       "name": "Casa Geco",
       "url": "https://www.reservaskalawala.com/Geco",
+      "identifier": "geco",
+      "additionalType": "https://schema.org/EntirePlace",
       "description": "2-bedroom house in the heart of Puerto Viejo, sleeps 5, private fenced parking, pet friendly, fully equipped kitchen, 2 A/C units, 100Mbps WiFi.",
       "occupancy": {
         "@type": "QuantitativeValue",
-        "maxValue": 5
+        "value": 5
       },
       "numberOfBedrooms": 2,
       "numberOfBathroomsTotal": 1,
@@ -246,10 +249,12 @@
       "@type": "Accommodation",
       "name": "Casa Rana",
       "url": "https://www.reservaskalawala.com/Rana",
+      "identifier": "rana",
+      "additionalType": "https://schema.org/EntirePlace",
       "description": "2-bedroom house in the heart of Puerto Viejo, sleeps 5, private fenced parking, pet friendly with fenced garden, fully equipped kitchen, 2 A/C units.",
       "occupancy": {
         "@type": "QuantitativeValue",
-        "maxValue": 5
+        "value": 5
       },
       "numberOfBedrooms": 2,
       "numberOfBathroomsTotal": 1,
@@ -265,10 +270,12 @@
       "@type": "Accommodation",
       "name": "Casa Tucano",
       "url": "https://www.reservaskalawala.com/Tucano",
+      "identifier": "tucano",
+      "additionalType": "https://schema.org/EntirePlace",
       "description": "2-bedroom wooden apartment above Italian bakery, sleeps 5, terrace, pet friendly, fully equipped kitchen, 2 A/C units.",
       "occupancy": {
         "@type": "QuantitativeValue",
-        "maxValue": 5
+        "value": 5
       },
       "numberOfBedrooms": 2,
       "numberOfBathroomsTotal": 1,
@@ -284,10 +291,12 @@
       "@type": "Accommodation",
       "name": "Casa Pappagallo",
       "url": "https://www.reservaskalawala.com/Pappagallo",
+      "identifier": "pappagallo",
+      "additionalType": "https://schema.org/EntirePlace",
       "description": "2-bedroom wooden apartment above Italian bakery, sleeps 5, terrace, pet friendly, remodeled 2021, fully equipped kitchen, 2 A/C units.",
       "occupancy": {
         "@type": "QuantitativeValue",
-        "maxValue": 5
+        "value": 5
       },
       "numberOfBedrooms": 2,
       "numberOfBathroomsTotal": 1,
@@ -303,10 +312,12 @@
       "@type": "Accommodation",
       "name": "Casa Delfines",
       "url": "https://www.reservaskalawala.com/Delfin",
+      "identifier": "delfin",
+      "additionalType": "https://schema.org/EntirePlace",
       "description": "2-bedroom house, sleeps 6, 2 bathrooms, private parking, fully equipped kitchen, 2 A/C units.",
       "occupancy": {
         "@type": "QuantitativeValue",
-        "maxValue": 6
+        "value": 6
       },
       "numberOfBedrooms": 2,
       "numberOfBathroomsTotal": 2,
@@ -322,10 +333,12 @@
       "@type": "Accommodation",
       "name": "Casa Areka",
       "url": "https://www.reservaskalawala.com/Areka",
+      "identifier": "areka",
+      "additionalType": "https://schema.org/EntirePlace",
       "description": "Fully equipped bungalow with A/C, 200m from Playa Chiquita beach, a few minutes from Puerto Viejo and Manzanillo.",
       "occupancy": {
         "@type": "QuantitativeValue",
-        "maxValue": 2
+        "value": 2
       },
       "numberOfBedrooms": 1,
       "numberOfBathroomsTotal": 1,
@@ -340,10 +353,12 @@
       "@type": "Accommodation",
       "name": "Casa Giulia",
       "url": "https://www.reservaskalawala.com/Giulia",
+      "identifier": "giulia",
+      "additionalType": "https://schema.org/EntirePlace",
       "description": "Fully equipped bungalow with A/C, 200m from Playa Chiquita beach. Perfect for families up to 4 people.",
       "occupancy": {
         "@type": "QuantitativeValue",
-        "maxValue": 4
+        "value": 4
       },
       "numberOfBedrooms": 2,
       "numberOfBathroomsTotal": 2,
@@ -358,10 +373,12 @@
       "@type": "Accommodation",
       "name": "Casa Plumeria",
       "url": "https://www.reservaskalawala.com/Plumeria",
+      "identifier": "plumeria",
+      "additionalType": "https://schema.org/EntirePlace",
       "description": "Fully equipped bungalow with A/C, 200m from Playa Chiquita beach, a few minutes from Puerto Viejo and Manzanillo.",
       "occupancy": {
         "@type": "QuantitativeValue",
-        "maxValue": 2
+        "value": 2
       },
       "numberOfBedrooms": 1,
       "numberOfBathroomsTotal": 1,
@@ -376,10 +393,12 @@
       "@type": "Accommodation",
       "name": "Villa Mar",
       "url": "https://www.reservaskalawala.com/VillaMar",
+      "identifier": "villamar",
+      "additionalType": "https://schema.org/EntirePlace",
       "description": "Villa with private pool, king-size bed, dedicated workspace with ethernet, fully equipped kitchen.",
       "occupancy": {
         "@type": "QuantitativeValue",
-        "maxValue": 2
+        "value": 2
       },
       "numberOfBedrooms": 1,
       "numberOfBathroomsTotal": 1,
@@ -406,10 +425,12 @@
       "@type": "Accommodation",
       "name": "Villa Coral",
       "url": "https://www.reservaskalawala.com/VillaCoral",
+      "identifier": "villacoral",
+      "additionalType": "https://schema.org/EntirePlace",
       "description": "Villa with private pool, king-size bed, dedicated workspace with ethernet, fully equipped kitchen.",
       "occupancy": {
         "@type": "QuantitativeValue",
-        "maxValue": 2
+        "value": 2
       },
       "numberOfBedrooms": 1,
       "numberOfBathroomsTotal": 1,

--- a/src/components/CookieConsentBanner/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner/CookieConsentBanner.tsx
@@ -8,7 +8,7 @@ import React, { useState, useEffect } from 'react';
 import { CookieConsentService, ConsentPreferences } from '../../services/CookieConsent.service';
 import { isPrerender } from '../../utils/isPrerender';
 import './CookieConsentBanner.scss';
-import { detectLocaleFromPath, type Locale } from '../../i18n';
+import { detectLocaleFromPath, getMessages, type Locale } from '../../i18n';
 
 interface CookieConsentBannerProps {
   onConsentChange?: (canTrack: boolean) => void;
@@ -48,30 +48,7 @@ export const CookieConsentBanner: React.FC<CookieConsentBannerProps> = ({ onCons
   const locale: Locale = detectLocaleFromPath(currentPath);
 
   // Text content based on language
-  const text = {
-    title: (locale === 'es') ? '🍪 Cookies' : '🍪 Cookies',
-    description: (locale === 'es') 
-      ? 'Usamos cookies para mejorar tu experiencia y analizar el tráfico.'
-      : 'We use cookies to improve your experience and analyze traffic.',
-    acceptAll: (locale === 'es') ? 'Aceptar' : 'Accept',
-    rejectAll: (locale === 'es') ? 'Rechazar' : 'Reject',
-    customize: (locale === 'es') ? 'Opciones' : 'Options',
-    essential: (locale === 'es') ? 'Esenciales' : 'Essential',
-    analytics: (locale === 'es') ? 'Análisis' : 'Analytics',
-    marketing: (locale === 'es') ? 'Marketing' : 'Marketing',
-    required: (locale === 'es') ? '(Req.)' : '(Req.)',
-    essentialDesc: (locale === 'es') 
-      ? 'Necesarias para el funcionamiento del sitio.'
-      : 'Required for the site to function.',
-    analyticsDesc: (locale === 'es')
-      ? 'Nos ayudan a entender el uso del sitio.'
-      : 'Help us understand site usage.',
-    marketingDesc: (locale === 'es')
-      ? 'Para mostrar anuncios relevantes.'
-      : 'To show relevant ads.',
-    savePreferences: (locale === 'es') ? 'Guardar' : 'Save',
-    cancel: (locale === 'es') ? 'Cancelar' : 'Cancel'
-  };
+  const text = getMessages(locale).cookieBanner;
 
   useEffect(() => {
     // react-snap saves the DOM after effects have run, so revealing the banner

--- a/src/components/Footer/Footer.component.tsx
+++ b/src/components/Footer/Footer.component.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { PROPERTY_DISPLAY_NAMES, BLOG_ARTICLES } from '../../utils/constants';
 import './Footer.style.scss';
 import { bookingPath, getMessages, type Locale } from '../../i18n';
+import { blogArticleHeading } from '../../i18n/blogArticleHeadings';
 import { pathForKey, routeKeyForSlug } from '../../routes.config';
 
 interface IFooter {
@@ -34,13 +35,13 @@ const Footer: React.FC<IFooter> = ({ locale }) => {
           <div className="footer-col">
             <h4>{m.footer.travelGuides}</h4>
             <ul>
-              {/* Locale-keyed DATA, not chrome: BLOG_ARTICLES stores flat
-                  titleEn/titleEs/pathEn/pathEs fields. pathEn/pathEs are
-                  computed from routes.config.ts (PHASE 4). */}
+              {/* Locale-keyed DATA, not chrome: title reuses the Phase-8-translated
+                  blog.tsx heading for this article; path comes straight from
+                  routes.config.ts. Both resolve per-locale, not just en/es. */}
               {BLOG_ARTICLES.map((article) => (
                 <li key={article.key}>
-                  <Link to={locale === 'es' ? article.pathEs : article.pathEn}>
-                    {locale === 'es' ? article.titleEs : article.titleEn}
+                  <Link to={pathForKey(article.routeKey, locale)}>
+                    {blogArticleHeading(article.routeKey, locale)}
                   </Link>
                 </li>
               ))}

--- a/src/components/GuestReviews/GuestReviews.component.tsx
+++ b/src/components/GuestReviews/GuestReviews.component.tsx
@@ -59,8 +59,9 @@ const GuestReviews: React.FC<GuestReviewsProps> = ({ propertyKey, locale }) => {
   const reviews = GUEST_REVIEWS[propertyKey];
   if (!reviews || reviews.length === 0) return null;
 
-  const heading = getMessages(locale).reviews.heading;
-  const closeLabel = getMessages(locale).reviews.closeReviews;
+  const m = getMessages(locale);
+  const heading = m.reviews.heading;
+  const closeLabel = m.reviews.closeReviews;
 
   const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target === e.currentTarget) closePanel();
@@ -75,7 +76,7 @@ const GuestReviews: React.FC<GuestReviewsProps> = ({ propertyKey, locale }) => {
 
   const renderReviewMeta = (review: Review) => {
     const text = pickLocalized(review.text, locale);
-    const stayLabel = locale === 'es' ? translateStayType(review.stayType) : review.stayType;
+    const stayLabel = m.reviewTags[review.stayType as keyof typeof m.reviewTags] ?? review.stayType;
     return { text, stayLabel };
   };
 
@@ -157,16 +158,5 @@ const GuestReviews: React.FC<GuestReviewsProps> = ({ propertyKey, locale }) => {
     </div>
   );
 };
-
-function translateStayType(stayType: string): string {
-  const map: Record<string, string> = {
-    'Stayed a few nights': 'Estadía de algunas noches',
-    'Stayed one night': 'Estadía de una noche',
-    'Stayed with kids': 'Estadía con niños',
-    'Stayed with a pet': 'Estadía con mascota',
-    'Stayed about a week': 'Estadía de aproximadamente una semana',
-  };
-  return map[stayType] ?? stayType;
-}
 
 export default GuestReviews;

--- a/src/components/HelpMeChoose/HelpMeChoose.component.tsx
+++ b/src/components/HelpMeChoose/HelpMeChoose.component.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { cdnSrcSet } from '../../utils/imageCdn';
 import { useNavigate } from 'react-router-dom';
 import './HelpMeChoose.style.scss';
-import type { Locale } from '../../i18n';
-import { pathForLegacyId } from '../../routes.config';
+import { getMessages, type Locale } from '../../i18n';
+import { pathForKey, routeKeyForSlug } from '../../routes.config';
 
 interface HelpMeChooseOption {
     emoji: string;
@@ -17,12 +17,13 @@ interface IHelpMeChoose {
     title: string;
     titleHighlight?: string;
     options: HelpMeChooseOption[];
+    locale: Locale;
 }
 
-const HelpMeChoose: React.FC<IHelpMeChoose> = ({ title, titleHighlight, options }) => {
+const HelpMeChoose: React.FC<IHelpMeChoose> = ({ title, titleHighlight, options, locale }) => {
     const navigate = useNavigate();
 
-    const handleClick = (event: React.MouseEvent<HTMLAnchorElement>, houseLangCode: string) => {
+    const handleClick = (event: React.MouseEvent<HTMLAnchorElement>, href: string) => {
         // A real href already handles ctrl/cmd-click, middle-click and "open in
         // new tab" correctly — only take over plain left-clicks so those keep
         // working, and use the SPA transition (no full reload) for everything else.
@@ -30,7 +31,7 @@ const HelpMeChoose: React.FC<IHelpMeChoose> = ({ title, titleHighlight, options 
             return;
         }
         event.preventDefault();
-        navigate(pathForLegacyId(houseLangCode));
+        navigate(href);
         setTimeout(() => {
             window.scrollTo(0, 0);
         }, 0);
@@ -44,15 +45,16 @@ const HelpMeChoose: React.FC<IHelpMeChoose> = ({ title, titleHighlight, options 
                 </div>
                 <div className="help-me-choose-cards">
                     {options.map((option) => {
-                        // Spanish house codes contain "ES" — same convention HomeCard
-                        // uses to label its own CTA without a language prop.
-                        const cardLocale: Locale = option.houseLangCode.includes('ES') ? 'es' : 'en';
+                        // houseLangCode's "ES" suffix only ever distinguished en/es —
+                        // same fix as HomeCard: route by the real locale instead.
+                        const routeKey = routeKeyForSlug(option.houseLangCode.replace(/ES$/, ''));
+                        const href = routeKey ? pathForKey(routeKey, locale) : '#';
                         return (
                             <a
                                 key={option.houseLangCode}
                                 className="help-me-choose-card"
-                                href={pathForLegacyId(option.houseLangCode)}
-                                onClick={(event) => handleClick(event, option.houseLangCode)}
+                                href={href}
+                                onClick={(event) => handleClick(event, href)}
                             >
                                 <div className="card-image-wrapper">
                                     <img src={option.image} alt={option.houseName} width={1000} height={667} loading="lazy" decoding="async" srcSet={cdnSrcSet(option.image)} sizes="(max-width: 575px) 86vw, (max-width: 991px) 320px, 250px" />
@@ -61,7 +63,7 @@ const HelpMeChoose: React.FC<IHelpMeChoose> = ({ title, titleHighlight, options 
                                     <span className="card-emoji">{option.emoji}</span>
                                     <span className="card-label">{option.label}</span>
                                     <span className="card-house-name">{option.houseName}</span>
-                                    <span className="card-cta">{cardLocale === 'es' ? 'Ver casa →' : 'View home →'}</span>
+                                    <span className="card-cta">{getMessages(locale).property.viewHomeCta}</span>
                                 </div>
                             </a>
                         );

--- a/src/components/HomeReviews/HomeReviews.component.tsx
+++ b/src/components/HomeReviews/HomeReviews.component.tsx
@@ -3,29 +3,33 @@ import { GUEST_REVIEWS, Review } from '../GuestReviews/reviewsData';
 import './HomeReviews.style.scss';
 import type { Locale } from '../../i18n';
 import { getMessages, pickLocalized } from '../../i18n';
+import { listingContent, type ListingKey } from '../../i18n/content/listings';
 
 interface HomeReviewsProps {
   locale: Locale;
 }
 
 interface FlatReview extends Review {
-  propertyLabel: string;
-  propertyLabelES: string;
+  // The listings.ts key for this property, resolved to a translated display
+  // name (featureName, e.g. "Haus Geco") at render time via listingContent —
+  // reuses the names Phase 8 already translated into all 8 locales instead
+  // of maintaining a second, separate translation of the same property names.
+  propertyKey: ListingKey;
 }
 
 const STARS = '★★★★★';
 
-const PROPERTY_LABELS: Record<string, { en: string; es: string }> = {
-  GECO: { en: 'House Geco', es: 'Casa Geco' },
-  TUCANO: { en: 'House Tucano', es: 'Casa Tucano' },
-  RANA: { en: 'House Rana', es: 'Casa Rana' },
-  AREKA: { en: 'House Areka', es: 'Casa Areka' },
-  PAPPAGALLO: { en: 'House Pappagallo', es: 'Casa Pappagallo' },
-  'VILLA CORAL': { en: 'Villa Coral', es: 'Villa Coral' },
-  PLUMERIA: { en: 'House Plumeria', es: 'Casa Plumeria' },
-  GIULIA: { en: 'Casa Giulia', es: 'Casa Giulia' },
-  'VILLA MAR': { en: 'Villa Mar', es: 'Villa Mar' },
-  DELFINES: { en: 'Casa Delfines', es: 'Casa Delfines' },
+const PROPERTY_KEY_MAP: Record<string, ListingKey> = {
+  GECO: 'Geco',
+  TUCANO: 'Tucano',
+  RANA: 'Rana',
+  AREKA: 'Areka',
+  PAPPAGALLO: 'Pappagallo',
+  'VILLA CORAL': 'VillaCoral',
+  PLUMERIA: 'Plumeria',
+  GIULIA: 'Giulia',
+  'VILLA MAR': 'VillaMar',
+  DELFINES: 'Delfin',
 };
 
 // Round-robin interleave so consecutive cards are always from different properties
@@ -33,8 +37,7 @@ function buildInterleavedReviews(): FlatReview[] {
   const byProperty = Object.entries(GUEST_REVIEWS).map(([key, reviews]) =>
     reviews.map((r) => ({
       ...r,
-      propertyLabel: PROPERTY_LABELS[key]?.en ?? key,
-      propertyLabelES: PROPERTY_LABELS[key]?.es ?? key,
+      propertyKey: PROPERTY_KEY_MAP[key] ?? 'Geco',
     }))
   );
   const result: FlatReview[] = [];
@@ -50,17 +53,6 @@ function buildInterleavedReviews(): FlatReview[] {
 const INTERLEAVED = buildInterleavedReviews();
 // Duplicate for seamless infinite loop
 const DOUBLED = [...INTERLEAVED, ...INTERLEAVED];
-
-function translateStayType(stayType: string): string {
-  const map: Record<string, string> = {
-    'Stayed a few nights': 'Estadía de algunas noches',
-    'Stayed one night': 'Estadía de una noche',
-    'Stayed with kids': 'Estadía con niños',
-    'Stayed with a pet': 'Estadía con mascota',
-    'Stayed about a week': 'Estadía de aproximadamente una semana',
-  };
-  return map[stayType] ?? stayType;
-}
 
 const SCROLL_SPEED_DESKTOP = 0.02; // px per ms
 const SCROLL_SPEED_MOBILE  = 0.01; // px per ms
@@ -156,8 +148,8 @@ const HomeReviews: React.FC<HomeReviewsProps> = ({ locale }) => {
       >
         {DOUBLED.map((review, index) => {
           const text = pickLocalized(review.text, locale);
-          const propertyLabel = locale === 'es' ? review.propertyLabelES : review.propertyLabel;
-          const stayLabel = locale === 'es' ? translateStayType(review.stayType) : review.stayType;
+          const propertyLabel = listingContent(review.propertyKey, locale).featureName;
+          const stayLabel = m.reviewTags[review.stayType as keyof typeof m.reviewTags] ?? review.stayType;
 
           return (
             <div
@@ -187,8 +179,8 @@ const HomeReviews: React.FC<HomeReviewsProps> = ({ locale }) => {
 
       {activeReview && (() => {
         const text = pickLocalized(activeReview.text, locale);
-        const propertyLabel = locale === 'es' ? activeReview.propertyLabelES : activeReview.propertyLabel;
-        const stayLabel = locale === 'es' ? translateStayType(activeReview.stayType) : activeReview.stayType;
+        const propertyLabel = listingContent(activeReview.propertyKey, locale).featureName;
+        const stayLabel = m.reviewTags[activeReview.stayType as keyof typeof m.reviewTags] ?? activeReview.stayType;
         return (
           <div
             className="home-reviews__overlay"

--- a/src/components/OurHomes/Components/HomeCard.component.tsx
+++ b/src/components/OurHomes/Components/HomeCard.component.tsx
@@ -4,8 +4,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSnowflake, faUtensils, faWifi, faUser, faParking } from '@fortawesome/free-solid-svg-icons';
 import { useNavigate } from "react-router-dom";
 import './HomeCard.style.scss'
-import type { Locale } from '../../../i18n';
-import { pathForLegacyId } from '../../../routes.config';
+import { getMessages, type Locale } from '../../../i18n';
+import { pathForKey, routeKeyForSlug } from '../../../routes.config';
 
 interface IHomeCard {
     name: string;
@@ -15,15 +15,18 @@ interface IHomeCard {
     hasFencedParking: boolean;
     image: string
     houseLangCode:string;
+    locale: Locale;
 }
 
 
-const HomeCard: FC<IHomeCard> = ({ guestNumber, hasFencedParking, name, image, houseLangCode }) => {
-
-    // Spanish house codes contain "ES" (see OurHomes.component filter), so the
-    // card can label its own CTA without threading a language prop from parents.
-    const cardLocale: Locale = houseLangCode.includes('ES') ? 'es' : 'en';
+const HomeCard: FC<IHomeCard> = ({ guestNumber, hasFencedParking, name, image, houseLangCode, locale }) => {
     const navigate = useNavigate();
+    // houseLangCode is an "ES"-suffixed or unsuffixed slug (see OurHomes'
+    // caller) — the suffix only ever distinguishes en/es and was never wired
+    // for the other six locales, so both the card and its href go through
+    // routeKeyForSlug + pathForKey(locale) instead, driven by the real locale.
+    const routeKey = routeKeyForSlug(houseLangCode.replace(/ES$/, ''));
+    const href = routeKey ? pathForKey(routeKey, locale) : '#';
     const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
         // A real href already handles ctrl/cmd-click, middle-click and "open in
         // new tab" correctly — only take over plain left-clicks so those keep
@@ -32,13 +35,13 @@ const HomeCard: FC<IHomeCard> = ({ guestNumber, hasFencedParking, name, image, h
             return;
         }
         event.preventDefault();
-        navigate(pathForLegacyId(houseLangCode));
+        navigate(href);
         setTimeout(() => {
             window.scrollTo(0, 0);
         }, 0);
     };
     return (
-        <a className="home-card-item" data-wow-duration="500ms" href={pathForLegacyId(houseLangCode)} onClick={handleClick}>
+        <a className="home-card-item" data-wow-duration="500ms" href={href} onClick={handleClick}>
             <div className="block">
                 <div className="icon-box d-block mx-auto">
                     <img src={image} alt={name} className="img-fluid rounded our-homes-img-m" width={1000} height={667} loading="lazy" decoding="async" srcSet={cdnSrcSet(image)} sizes="(max-width: 767px) 90vw, (max-width: 1199px) 45vw, 350px" />
@@ -58,7 +61,7 @@ const HomeCard: FC<IHomeCard> = ({ guestNumber, hasFencedParking, name, image, h
                         <FontAwesomeIcon icon={faWifi} />
                         {hasFencedParking && <FontAwesomeIcon icon={faParking} />}
                     </div>
-                    <span className="card-cta">{cardLocale === 'es' ? 'Ver casa →' : 'View home →'}</span>
+                    <span className="card-cta">{getMessages(locale).property.viewHomeCta}</span>
                 </div>
             </div>
 

--- a/src/components/OurHomes/OurHomes.component.tsx
+++ b/src/components/OurHomes/OurHomes.component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import HomeCard from './Components/HomeCard.component';
 import './OurHomes.style.scss'
 import { HouseDataType } from '../../utils/types';
-import { useMessages } from '../../i18n';
+import { useMessages, useLocale } from '../../i18n';
 
 interface IOurHomes{
     style?: any;
@@ -11,6 +11,7 @@ interface IOurHomes{
 
 const OurHomes: React.FC<IOurHomes> = ({ style, houseDataList }) => {
     const m = useMessages();
+    const locale = useLocale();
     // Homes data is passed as props
     return (
         <section id="house-list" className="bg-one about section" style={style}>
@@ -29,6 +30,7 @@ const OurHomes: React.FC<IOurHomes> = ({ style, houseDataList }) => {
                                 name={name}
                                 image={image}
                                 houseLangCode={houseLangCode}
+                                locale={locale}
                             />
                         ))}
                     </div>

--- a/src/components/OurOtherHomes/Components/OtherHomesCard.component.tsx
+++ b/src/components/OurOtherHomes/Components/OtherHomesCard.component.tsx
@@ -5,7 +5,7 @@ import { faSnowflake, faUtensils, faWifi, faUser, faParking } from '@fortawesome
 import { useNavigate } from 'react-router-dom';
 
 import './OtherHomesCard.style.scss';
-import { detectLocaleFromPath, type Locale } from '../../../i18n';
+import { detectLocaleFromPath, getMessages, type Locale } from '../../../i18n';
 
 interface IOtherHomesCard {
     name: string;
@@ -55,7 +55,7 @@ const OtherHomesCard: FC<IOtherHomesCard> = ({ guestNumber, hasFencedParking, na
                     <FontAwesomeIcon icon={faWifi} />
                     {hasFencedParking && <FontAwesomeIcon icon={faParking} />}
                 </div>
-                <span className="card-cta">{cardLocale === 'es' ? 'Ver casa →' : 'View home →'}</span>
+                <span className="card-cta">{getMessages(cardLocale).property.viewHomeCta}</span>
             </div>
         </a>
     );

--- a/src/components/OurOtherHomes/Components/OtherHomesCard.componentRib.tsx
+++ b/src/components/OurOtherHomes/Components/OtherHomesCard.componentRib.tsx
@@ -5,7 +5,7 @@ import { faSnowflake, faUtensils, faWifi, faUser, faSwimmingPool, faParking } fr
 import { useNavigate } from 'react-router-dom';
 
 import './OtherHomesCard.style.scss';
-import { detectLocaleFromPath, type Locale } from '../../../i18n';
+import { detectLocaleFromPath, getMessages, type Locale } from '../../../i18n';
 
 interface IOtherHomesCard {
     name: string;
@@ -56,7 +56,7 @@ const OtherHomesCardRib: FC<IOtherHomesCard> = ({ guestNumber, hasFencedParking,
                     <FontAwesomeIcon icon={faWifi} />
                     {hasFencedParking && <FontAwesomeIcon icon={faParking} />}
                 </div>
-                <span className="card-cta">{cardLocale === 'es' ? 'Ver casa →' : 'View home →'}</span>
+                <span className="card-cta">{getMessages(cardLocale).property.viewHomeCta}</span>
             </div>
         </a>
     );

--- a/src/components/Portfolio/Portfolio.component.tsx
+++ b/src/components/Portfolio/Portfolio.component.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 import { Button } from 'react-bootstrap';
 import PortfolioImage from '../PortfolioImage/PortfolioImage.component';
+import { useMessages } from '../../i18n';
 
 const Portfolio = () => {
+  const m = useMessages();
   const [folderName, setFolderName] = useState<string>('Tucano');
 
   const [activeButton, setActiveButton] = useState<string>('Tucano');
@@ -18,7 +20,7 @@ const Portfolio = () => {
     <div id="portfolio" className="portfolio section">
       <div className="col-lg-12">
         <div className="title text-center">
-          <h2>Our <span className="color">Photos</span></h2>
+          <h2>{m.sections.ourLead} <span className="color">{m.sections.ourPhotosHeading}</span></h2>
           <div className="border2"></div>
         </div>
       </div>

--- a/src/components/StayRecommendation/StayRecommendation.component.tsx
+++ b/src/components/StayRecommendation/StayRecommendation.component.tsx
@@ -10,20 +10,9 @@ interface PropertyRecommendation {
 interface StayRecommendationProps {
   title: string;
   properties: PropertyRecommendation[];
-  language?: 'en' | 'es';
 }
 
-const StayRecommendation: React.FC<StayRecommendationProps> = ({ title, properties, language = 'es' }) => {
-  const translations = {
-    en: {
-      defaultTitle: "Where to stay if you only have 2 days in Puerto Viejo?"
-    },
-    es: {
-      defaultTitle: "¿Dónde hospedarte si solo tienes 2 días en Puerto Viejo?"
-    }
-  };
-
-  const currentTranslations = translations[language];
+const StayRecommendation: React.FC<StayRecommendationProps> = ({ title, properties }) => {
   return (
     <div className="stay-recommendation">
       <div className="stay-recommendation__container">

--- a/src/components/StayRecommendation/__tests__/StayRecommendation.test.tsx
+++ b/src/components/StayRecommendation/__tests__/StayRecommendation.test.tsx
@@ -7,29 +7,29 @@
 
 import { render, screen } from '@testing-library/react';
 import StayRecommendation from '../StayRecommendation.component';
-import { PUERTO_VIEJO_BLOG_RECOMMENDATIONS } from '../../../utils/constants';
+import { puertoViejoBlogRecommendations } from '../../../utils/constants';
 
 describe('StayRecommendation Component', () => {
   const mockProps = {
-    title: '¿Dónde hospedarte si solo tienes 2 días en Puerto Viejo?',
-    properties: PUERTO_VIEJO_BLOG_RECOMMENDATIONS
+    title: 'Where to stay if you only have 2 days in Puerto Viejo?',
+    properties: puertoViejoBlogRecommendations('en')
   };
 
   test('renders the component with title and properties', () => {
     render(<StayRecommendation {...mockProps} />);
-    
+
     // Check if title is rendered
     expect(screen.getByText(mockProps.title)).toBeInTheDocument();
-    
+
     // Check if all properties are rendered
     expect(screen.getByText('Casa Geco')).toBeInTheDocument();
-    expect(screen.getByText('Plumeria')).toBeInTheDocument();
+    expect(screen.getByText('Casa Plumeria')).toBeInTheDocument();
     expect(screen.getByText('Villa Coral')).toBeInTheDocument();
-    
+
     // Check if reasons are rendered
-    expect(screen.getByText('Ideal si quieres moverte caminando')).toBeInTheDocument();
-    expect(screen.getByText('Perfecta para descansar cerca de la playa')).toBeInTheDocument();
-    expect(screen.getByText('Si buscas una escapada corta con piscina privada')).toBeInTheDocument();
+    expect(screen.getByText('Ideal for getting around on foot')).toBeInTheDocument();
+    expect(screen.getByText('Perfect for relaxing near the beach')).toBeInTheDocument();
+    expect(screen.getByText('Great for a short getaway with a private pool')).toBeInTheDocument();
   });
 
   test('renders property links correctly', () => {

--- a/src/components/WhyStayWithUs/WhyStayWithUs.component.tsx
+++ b/src/components/WhyStayWithUs/WhyStayWithUs.component.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import './WhyStayWithUs.style.scss';
+import { getMessages, type Locale } from '../../i18n';
 
 interface WhyStayWithUsProps {
   title?: string;
   benefits?: string[];
   ctaText?: string;
   ctaLink: string;
-  language?: 'en' | 'es';
+  locale: Locale;
 }
 
 const WhyStayWithUs: React.FC<WhyStayWithUsProps> = ({
@@ -14,32 +15,9 @@ const WhyStayWithUs: React.FC<WhyStayWithUsProps> = ({
   benefits,
   ctaText,
   ctaLink,
-  language = 'es'
+  locale
 }) => {
-  const translations = {
-    en: {
-      title: "Why book with us?",
-      benefits: [
-        "Strategic locations",
-        "Fully equipped houses",
-        "Direct booking and local support",
-        "No platform commissions"
-      ],
-      ctaText: "View all our properties"
-    },
-    es: {
-      title: "¿Por qué reservar con nosotros?",
-      benefits: [
-        "Ubicaciones estratégicas",
-        "Casas totalmente equipadas",
-        "Reserva directa y soporte local",
-        "Sin comisiones de plataformas"
-      ],
-      ctaText: "Ver todas nuestras propiedades"
-    }
-  };
-
-  const currentTranslations = translations[language];
+  const currentTranslations = getMessages(locale).whyStayWithUs;
   const displayTitle = title || currentTranslations.title;
   const displayBenefits = benefits || currentTranslations.benefits;
   const displayCtaText = ctaText || currentTranslations.ctaText;

--- a/src/i18n/amenityLabels.ts
+++ b/src/i18n/amenityLabels.ts
@@ -1,0 +1,173 @@
+/**
+ * Amenity name strings (the little icon + text pairs on every listing page),
+ * keyed by the exact English string as it appears in src/utils/constants.ts's
+ * houseDataList amenities arrays — translated into the six locales that
+ * didn't exist when that data was authored.
+ *
+ * Deliberately a lookup table keyed by content, not a restructuring of
+ * houseDataList itself: houseDataList duplicates a full property record per
+ * suffixed locale (Geco/GecoES) rather than being Locale-keyed, and widening
+ * that to 8 locales would mean 6 more full duplicate entries per property.
+ *
+ * No `en`/`es` fields here on purpose. For those two locales
+ * `houseDataByLangCode` already resolves the amenity list with the right
+ * language's `name` baked in directly (that's the existing, live,
+ * already-correct behavior) — Amenities.component.tsx renders `name`
+ * as-is for en/es and only reaches into this table for the other six, where
+ * `name` is guaranteed to be the raw English string (the six new locales
+ * fall back to the unsuffixed, English houseDataList entry).
+ */
+export const AMENITY_LABELS: Record<string, Partial<Record<'de' | 'fr' | 'it' | 'pt' | 'he' | 'hi', string>>> = {
+  'Private Pool, Exclusive for guests of this villa': {
+    de: 'Privater Pool, exklusiv für Gäste dieser Villa',
+    fr: 'Piscine privée, exclusive aux hôtes de cette villa',
+    it: 'Piscina privata, esclusiva per gli ospiti di questa villa',
+    pt: 'Piscina privada, exclusiva para os hóspedes desta vivenda',
+    he: 'בריכה פרטית, בלעדית לאורחי הווילה',
+    hi: 'निजी स्विमिंग पूल, इस विला के मेहमानों के लिए विशेष',
+  },
+  'Private Equipped Bathroom': {
+    de: 'Privates ausgestattetes Badezimmer',
+    fr: 'Salle de bain privée équipée',
+    it: 'Bagno privato attrezzato',
+    pt: 'Casa de banho privativa equipada',
+    he: 'חדר אמבטיה פרטי ומאובזר',
+    hi: 'निजी सुसज्जित बाथरूम',
+  },
+  'Private Equipped Kitchen': {
+    de: 'Private ausgestattete Küche',
+    fr: 'Cuisine privée équipée',
+    it: 'Cucina privata attrezzata',
+    pt: 'Cozinha privativa equipada',
+    he: 'מטבח פרטי ומאובזר',
+    hi: 'निजी सुसज्जित रसोई',
+  },
+  '2 A/C Units': {
+    de: '2 Klimaanlagen',
+    fr: '2 unités de climatisation',
+    it: '2 unità di aria condizionata',
+    pt: '2 unidades de ar condicionado',
+    he: '2 יחידות מיזוג אוויר',
+    hi: '2 A/C यूनिट',
+  },
+  'Private unfenced Parking': {
+    de: 'Privater unumzäunter Parkplatz',
+    fr: 'Parking privé non clôturé',
+    it: 'Parcheggio privato non recintato',
+    pt: 'Estacionamento privado não vedado',
+    he: 'חניה פרטית לא גדורה',
+    hi: 'निजी खुली पार्किंग',
+  },
+  '100Mbps WiFi': {
+    de: '100-Mbit/s-WLAN',
+    fr: 'WiFi 100 Mbps',
+    it: 'WiFi da 100Mbps',
+    pt: 'Wi-Fi de 100 Mbps',
+    he: 'WiFi במהירות 100Mbps',
+    hi: '100Mbps वाई-फाई',
+  },
+  'A/C': {
+    de: 'Klimaanlage',
+    fr: 'Climatisation',
+    it: 'Aria condizionata',
+    pt: 'Ar condicionado',
+    he: 'מיזוג אוויר',
+    hi: 'A/C',
+  },
+  'Private Fenced Parking': {
+    de: 'Privater umzäunter Parkplatz',
+    fr: 'Parking privé clôturé',
+    it: 'Parcheggio privato recintato',
+    pt: 'Estacionamento privado vedado',
+    he: 'חניה פרטית גדורה',
+    hi: 'निजी घिरी हुई पार्किंग',
+  },
+  'Pet Friendly': {
+    de: 'Haustierfreundlich',
+    fr: 'Animaux acceptés',
+    it: 'Animali domestici ammessi',
+    pt: 'Aceita animais de estimação',
+    he: 'ידידותי לחיות מחמד',
+    hi: 'पालतू-अनुकूल',
+  },
+  'Private Outside Parking': {
+    de: 'Privater Außenparkplatz',
+    fr: 'Parking privé extérieur',
+    it: 'Parcheggio privato esterno',
+    pt: 'Estacionamento privado exterior',
+    he: 'חניה פרטית בחוץ',
+    hi: 'निजी बाहरी पार्किंग',
+  },
+  '2 Private Equipped Bathroom': {
+    de: '2 private ausgestattete Badezimmer',
+    fr: '2 salles de bain privées équipées',
+    it: '2 bagni privati attrezzati',
+    pt: '2 Casas de banho privativas equipadas',
+    he: '2 חדרי אמבטיה פרטיים ומאובזרים',
+    hi: '2 निजी सुसज्जित बाथरूम',
+  },
+  'Bedrooms with A/C': {
+    de: 'Schlafzimmer mit Klimaanlage',
+    fr: 'Chambres climatisées',
+    it: 'Camere con aria condizionata',
+    pt: 'Quartos com ar condicionado',
+    he: 'חדרי שינה עם מיזוג אוויר',
+    hi: 'A/C वाले बेडरूम',
+  },
+  'Outside Parking': {
+    de: 'Außenparkplatz',
+    fr: 'Parking extérieur',
+    it: 'Parcheggio esterno',
+    pt: 'Estacionamento exterior',
+    he: 'חניה בחוץ',
+    hi: 'बाहरी पार्किंग',
+  },
+  '2 Private Equipped Bathrooms': {
+    de: '2 private ausgestattete Badezimmer',
+    fr: '2 salles de bain privées équipées',
+    it: '2 bagni privati attrezzati',
+    pt: '2 Casas de banho privativas equipadas',
+    he: '2 חדרי אמבטיה פרטיים ומאובזרים',
+    hi: '2 निजी सुसज्जित बाथरूम',
+  },
+  'Private Fenced Parking for 2 Vehicles': {
+    de: 'Privater umzäunter Parkplatz für 2 Fahrzeuge',
+    fr: 'Parking privé clôturé pour 2 véhicules',
+    it: 'Parcheggio privato recintato per 2 veicoli',
+    pt: 'Estacionamento privado vedado para 2 veículos',
+    he: 'חניה פרטית גדורה ל-2 רכבים',
+    hi: 'निजी घिरी हुई पार्किंग, 2 वाहनों के लिए',
+  },
+  'Private Pool': {
+    de: 'Privater Pool',
+    fr: 'Piscine privée',
+    it: 'Piscina privata',
+    pt: 'Piscina privada',
+    he: 'בריכה פרטית',
+    hi: 'निजी स्विमिंग पूल',
+  },
+  'WiFi': {
+    de: 'WLAN',
+    fr: 'WiFi',
+    it: 'WiFi',
+    pt: 'Wi-Fi',
+    he: 'WiFi',
+    hi: 'वाई-फाई',
+  },
+  'Unfenced Parking': {
+    de: 'Unumzäunter Parkplatz',
+    fr: 'Parking non clôturé',
+    it: 'Parcheggio non recintato',
+    pt: 'Estacionamento não vedado',
+    he: 'חניה לא גדורה',
+    hi: 'खुली पार्किंग',
+  },
+  '2 A/C': {
+    de: '2 Klimaanlagen',
+    fr: '2 climatiseurs',
+    it: '2 climatizzatori',
+    pt: '2 Ar condicionado',
+    he: '2 מזגנים',
+    hi: '2 A/C',
+  },
+};

--- a/src/i18n/blogArticleHeadings.ts
+++ b/src/i18n/blogArticleHeadings.ts
@@ -1,0 +1,41 @@
+import type { Locale } from './locales';
+import type { RouteKey } from '../routes.config';
+import {
+  tenHoursInPuertoContent,
+  puertoViejoByPlaneContent,
+  twoDaysInPVContent,
+  gettingToGandocaContent,
+  travellingToPuertoContent,
+  cahuitaParkContent,
+  bestTimeToVisitContent,
+  indigenousTravelContent,
+  puertoHiddenGemsContent,
+  busHoursContent,
+} from './content/blog';
+
+/**
+ * Every blog article's translated `heading` (and `seoTitle`), keyed by its
+ * routes.config.ts RouteKey — the single place that reuses Phase 8's
+ * per-article translations for the cross-linking widgets (OtherBlogs,
+ * Footer's "Travel Guides" column, BlogIndex) instead of each maintaining
+ * its own separate, EN/ES-only title. Each of the 10 blog content modules
+ * has its own distinct TypeScript interface (see blog.tsx), but all of them
+ * share `seoTitle`/`heading` as their first two fields, so this only reaches
+ * for the two fields every shape has in common.
+ */
+const BLOG_HEADING_BY_ROUTE_KEY: Partial<Record<RouteKey, (locale: Locale) => string>> = {
+  blogTwodays: (l) => twoDaysInPVContent(l).heading,
+  blogGandoca: (l) => gettingToGandocaContent(l).heading,
+  blogSanjose: (l) => travellingToPuertoContent(l).heading,
+  blogByplane: (l) => puertoViejoByPlaneContent(l).heading,
+  blogTenhours: (l) => tenHoursInPuertoContent(l).heading,
+  blogBushours: (l) => busHoursContent(l).heading,
+  blogCahuitapark: (l) => cahuitaParkContent(l).heading,
+  blogIndigenous: (l) => indigenousTravelContent(l).heading,
+  blogBesttime: (l) => bestTimeToVisitContent(l).heading,
+  blogHiddengems: (l) => puertoHiddenGemsContent(l).heading,
+};
+
+export function blogArticleHeading(routeKey: RouteKey, locale: Locale): string {
+  return BLOG_HEADING_BY_ROUTE_KEY[routeKey]?.(locale) ?? routeKey;
+}

--- a/src/i18n/content/blog.tsx
+++ b/src/i18n/content/blog.tsx
@@ -567,6 +567,36 @@ export interface GettingToGandocaContent {
 }
 
 const gettingToGandoca: Partial<Record<Locale, GettingToGandocaContent>> = {
+  de: {
+    seoTitle: 'So erreichen Sie das Nationale Wildschutzgebiet Gandoca-Manzanillo von Puerto Viejo, Costa Rica',
+    seoDescription:
+      'Das Nationale Wildschutzgebiet Gandoca-Manzanillo in der Provinz Limón ist eines der bestgehüteten Geheimnisse der costa-ricanischen Südkaribik. Dieses beeindruckende Schutzgebiet bietet eine vielfältige Auswahl an Ökosystemen, von Mangroven und Korallenriffen bis hin zu unberührten Stränden.',
+    heading: 'So erreichen Sie das Nationale Wildschutzgebiet Gandoca-Manzanillo von Puerto Viejo, Costa Rica',
+    heroAlt: 'Nationales Wildschutzgebiet Gandoca-Manzanillo',
+    intro:
+      <>Das <a href="https://maps.app.goo.gl/orUHFbrZvpJH1fnb9" target="_blank" rel="noopener noreferrer">Nationale Wildschutzgebiet Gandoca-Manzanillo</a> in der Provinz Limón ist eines der bestgehüteten Geheimnisse der costa-ricanischen Südkaribik. Dieses beeindruckende Schutzgebiet bietet eine vielfältige Auswahl an Ökosystemen, von Mangroven und Korallenriffen bis hin zu unberührten Stränden. Wenn Sie sich in Puerto Viejo de Talamanca aufhalten und einen Ausflug in die Natur suchen, ist dies eine hervorragende Option. In diesem Leitfaden zeigen wir Ihnen, wie Sie von Puerto Viejo aus einfach dorthin gelangen, um dieses Naturparadies in vollen Zügen zu erkunden.</>,
+    transportOptionsHeading: 'Transportmöglichkeiten',
+    stayRecommendationTitle: 'Wo übernachten bei einem Besuch von Gandoca-Manzanillo?',
+    busHeading: '1. Bus von Puerto Viejo nach Manzanillo',
+    busIntro:
+      <>Die einfachste und günstigste Art, das <a href="https://maps.app.goo.gl/orUHFbrZvpJH1fnb9" target="_blank" rel="noopener noreferrer">Nationale Wildschutzgebiet Gandoca-Manzanillo</a> zu erreichen, ist der Bus vom Zentrum von Puerto Viejo nach Manzanillo. Die <a href="https://maps.app.goo.gl/orUHFbrZvpJH1fnb9" target="_blank" rel="noopener noreferrer">Bushaltestelle</a> befindet sich dort, wo Sie die Tickets kaufen, in der Nähe des Basketballplatzes oder bei der Eisdiele Deleite.</>,
+    busSchedulesLabel: 'Busfahrpläne:',
+    tableRouteHeader: 'Route',
+    tableDepartureHeader: 'Abfahrtszeiten',
+    scooterHeading: '2. Einen Roller oder 4x4 mieten',
+    scooterParagraph1:
+      <>Wenn Sie lieber in Ihrem eigenen Tempo erkunden möchten, ist die Miete eines Rollers oder 4x4 eine hervorragende Option. Wenn Sie in unseren Häusern im Zentrum von Puerto Viejo wohnen, können Sie Fahrzeuge direkt gegenüber bei <a href="https://maps.app.goo.gl/uao7BMUuwFLyRL6dA" target="_blank" rel="noopener noreferrer">Mistery Jungle</a> mieten, ab 30 $. Wenn Sie in unseren Villen in Playa Chiquita wohnen, können Sie sich das Fahrzeug direkt zu Ihrer Villa liefern lassen.</>,
+    scooterParagraph2:
+      'Diese Option ist ideal für alle, die ein individuelles Abenteuer suchen, da Sie überall anhalten können, wo Sie möchten, und das charmante Dorf Manzanillo erkunden können, ohne sich um Busfahrpläne kümmern zu müssen. Genießen Sie die Freiheit, auf Ihre eigene Art zu erkunden, und entdecken Sie alle Ecken, die dieses schöne Reiseziel zu bieten hat.',
+    carHeading: '3. Mit dem Auto von Puerto Viejo aus',
+    carParagraph:
+      'Wenn Sie sich entscheiden, mit dem Auto von Puerto Viejo aus zu fahren, folgen Sie einfach der Richtung Manzanillo über die 14 km lange Strecke. Bei der Ankunft finden Sie Parkplätze außerhalb des Schutzgebiets, wo Ihnen einige Einheimische gegen eine kleine Gebühr anbieten, auf Ihr Fahrzeug aufzupassen. Aus Sicherheitsgründen empfehlen wir, keine Wertsachen im Auto zu lassen.',
+    conclusionHeading: 'Fazit',
+    conclusionParagraph1:
+      'Das Nationale Wildschutzgebiet Gandoca-Manzanillo ist ein Muss für Natur- und Abenteuerliebhaber. Ob Sie mit dem Bus fahren, ein Fahrzeug mieten oder selbst fahren — dieses Naturparadies ist einfach und bequem zu erreichen.',
+    conclusionParagraph2:
+      'Wir laden Sie ein, Ihren Besuch in diesem wunderschönen Schutzgebiet zu planen und die Gelegenheit zu nutzen, in unseren gemütlichen Häusern in Puerto Viejo de Talamanca zu übernachten. Wir bieten eine komfortable und entspannende Umgebung — perfekt, um die Natur zu genießen und alles zu erkunden, was die Region zu bieten hat. Entdecken Sie den Charme des Nationalen Wildschutzgebiets Gandoca-Manzanillo und die Herzlichkeit unserer Villen!',
+  },
   en: {
     seoTitle: 'How to Get to Gandoca-Manzanillo National Wildlife Refuge from Puerto Viejo, Costa Rica',
     seoDescription:
@@ -795,6 +825,34 @@ export interface TravellingToPuertoContent {
 }
 
 const travellingToPuerto: Partial<Record<Locale, TravellingToPuertoContent>> = {
+  de: {
+    seoTitle: 'Wie man von San José nach Puerto Viejo kommt',
+    seoDescription:
+      'Wenn Sie eine Reise nach Puerto Viejo, Costa Rica, planen, fragen Sie sich vielleicht, wie Sie mit öffentlichen Verkehrsmitteln dorthin gelangen. Zum Glück gibt es mehrere Optionen, die Sie in diese wunderschöne Karibikstadt in Talamanca bringen.',
+    heading: 'Wie man von San José nach Puerto Viejo kommt',
+    paragraphsBeforeStay: [
+      'Wenn Sie eine Reise nach Puerto Viejo, Costa Rica, planen, fragen Sie sich vielleicht, wie Sie mit öffentlichen Verkehrsmitteln dorthin gelangen. Zum Glück gibt es mehrere Optionen, die Sie in diese wunderschöne Karibikstadt in Talamanca bringen.',
+      <>Eine der beliebtesten Möglichkeiten, nach Puerto Viejo zu gelangen, ist der Bus. Das wichtigste Busunternehmen auf der Strecke von San José nach Puerto Viejo ist <a href="https://www.mepecr.com/HorarioS_S.html" target="_blank" rel="noopener noreferrer">MEPE</a>. Die Busstation befindet sich im Zentrum von San José, genau an der 9. Avenue und 12. Straße, und ist daher leicht zu finden.</>,
+      <b><i>Der <a href="https://www.mepecr.com/HorarioS_S.html" target="_blank" rel="noopener noreferrer">Busfahrplan</a> nach Puerto Viejo lautet wie folgt: 6, 8 und 10 Uhr, 14 Uhr sowie der letzte Bus um 16 Uhr.</i></b>,
+      'Zwar können Sie keine Tickets im Voraus reservieren, aber es ist immer ratsam, früh an der Busstation zu sein, um sich einen Platz im Bus zu sichern. Beachten Sie, dass die Busse in der Hauptreisezeit, etwa an Feiertagen und Wochenenden, schnell voll werden können, planen Sie also entsprechend.',
+    ],
+    stayRecommendationTitle: 'Wo übernachten auf dem Weg nach Puerto Viejo?',
+    paragraphsBetween: [
+      'Der Bus hat viele Haltestellen und hält auch an den Busstationen in Limón und Cahuita, bevor er schließlich Puerto Viejo erreicht.',
+      'Wenn Sie bei den Transportkosten sparen möchten, ist der öffentliche Bus die günstigste Option. Diese Busse sind sauber, zuverlässig und bieten eine erschwingliche Möglichkeit, nach Puerto Viejo zu gelangen. Auch wenn sie nicht so luxuriös sind wie private Shuttleservices, bringen sie Sie sicher und pünktlich an Ihr Ziel.',
+      'Dank regelmäßiger Busfahrpläne von San José und anderen nahegelegenen Orten lässt sich Ihre Reise leicht planen, damit Sie alles genießen können, was Puerto Viejo zu bieten hat.',
+      <b><i>Eine weitere Möglichkeit, von San José nach Puerto Viejo zu gelangen, ist der Bus von <a href="https://maps.app.goo.gl/a5kV7YvzybHjVae28" target="_blank" rel="noopener noreferrer">Caribeños</a>, der direkt nach Limón fährt. Von dort können Sie in einen Bus nach Puerto Viejo umsteigen.</i></b>,
+      <>Der Busfahrplan von San José nach Limón startet an der <a href="https://maps.app.goo.gl/a5kV7YvzybHjVae28" target="_blank" rel="noopener noreferrer">Caribeños-Haltestelle</a> an der Calle Central, Cinco Esquinas. Die Busse fahren stündlich von 6 bis 19 Uhr, sodass sich Ihre Reise leicht planen lässt. In Limón angekommen, können Sie zur <a href="https://maps.app.goo.gl/WV4CmLqzco2Eft7y9" target="_blank" rel="noopener noreferrer">Mepe</a>-Bushaltestelle laufen, die sich in der Nähe des zentralen Marktes befindet, und einen der stündlich abfahrenden Busse nach Puerto Viejo nehmen.</>,
+      'Beachten Sie jedoch, dass die Fahrt von San José nach Limón je nach Verkehr und Straßenverhältnissen etwa 3 bis 4 Stunden dauern kann. Planen Sie daher unbedingt im Voraus, um nicht über Nacht in Limón festzusitzen. Außerdem fährt der letzte Bus von Limón nach Puerto Viejo um 20 Uhr ab, stellen Sie also sicher, dass Sie rechtzeitig in Limón ankommen, um den Anschluss zu schaffen.',
+      <>Eine weitere Möglichkeit, nach Puerto Viejo zu gelangen, ist ein <a href="mailto:reservas.kalawala@gmail.com?subject=Organise private transportation&body= " target="_blank" rel="noopener noreferrer">privater Transport</a>. Diese Option kann mit anderen Reisenden geteilt werden oder privat für Sie und Ihre Begleitung sein, was sie zu einer bequemen und komfortablen Art macht, an Ihr Ziel zu reisen.</>,
+      'Mit privatem Transport können Sie an einem beliebigen Ort abgeholt und direkt zu Ihrer Unterkunft in Puerto Viejo gebracht werden. Diese Option ist besonders hilfreich für alle mit viel Gepäck, mehr Privatsphäre oder besonderen Reisebedürfnissen.',
+      'Je nach Anzahl der Reisenden kann privater Transport im Vergleich zu einem geteilten Shuttle sogar kostengünstiger sein.',
+      'Außerdem bietet er die Flexibilität, den eigenen Zeitplan zu bestimmen und unterwegs anzuhalten, um einige der wunderschönen Ausblicke entlang der Strecke zu genießen.',
+      'Wenn Sie an privatem Transport nach Puerto Viejo interessiert sind, gibt es mehrere renommierte Unternehmen, die diesen Service anbieten. Es lohnt sich immer, die Optionen zu recherchieren und Preise zu vergleichen, um das beste Angebot zu finden.',
+      'Auch wir bieten diesen Service an und können Ihnen Routen und Preise nennen, damit Sie die beste Entscheidung für Ihre Reise treffen können.',
+      'Ob Sie nun die Bequemlichkeit öffentlicher Verkehrsmittel oder den Komfort eines privaten Transports bevorzugen — es gibt mehrere Wege nach Puerto Viejo. Unabhängig von Ihrer Wahl werden Sie die atemberaubende Landschaft und lebendige Kultur dieser wunderschönen Karibikstadt in Talamanca, Costa Rica, garantiert genießen.',
+    ],
+  },
   en: {
     seoTitle: 'How to get to Puerto Viejo from San Jose',
     seoDescription:

--- a/src/i18n/messages/de.ts
+++ b/src/i18n/messages/de.ts
@@ -61,6 +61,7 @@ export const de: Messages = {
     otherListingsHeading: 'Entdecken Sie unsere weiteren Unterkünfte!',
     readBlog: (title: string) => `Blogbeitrag lesen: ${title}`,
     weOfferEquipped: 'Wir bieten voll ausgestattete Häuser:',
+    ourPhotosHeading: 'Fotos',
   },
 
   contact: {
@@ -128,5 +129,57 @@ export const de: Messages = {
     bedrooms: (count: number) => `${count} Schlafzimmer`,
     bathrooms: (count: number) => `${count} Badezimmer`,
     upToGuests: (count: number) => `Bis zu ${count} ${count === 1 ? 'Gast' : 'Gästen'}`,
+    viewHomeCta: 'Haus ansehen →',
   },
+  cookieBanner: {
+    title: '🍪 Cookies',
+    description: 'Wir verwenden Cookies, um Ihr Erlebnis zu verbessern und den Traffic zu analysieren.',
+    acceptAll: 'Akzeptieren',
+    rejectAll: 'Ablehnen',
+    customize: 'Optionen',
+    essential: 'Notwendig',
+    analytics: 'Analyse',
+    marketing: 'Marketing',
+    required: '(Erf.)',
+    essentialDesc: 'Notwendig, damit die Website funktioniert.',
+    analyticsDesc: 'Hilft uns, die Nutzung der Website zu verstehen.',
+    marketingDesc: 'Um relevante Werbung zu zeigen.',
+    savePreferences: 'Speichern',
+    cancel: 'Abbrechen',
+  },
+
+  notFound: {
+    title: 'Seite nicht gefunden | Reservas Kalawala',
+    heading: 'Wir konnten diese Seite nicht finden',
+    body: 'Der Link ist möglicherweise fehlerhaft, oder die Seite wurde verschoben.',
+    cta: 'Zurück zur Startseite',
+  },
+
+  whyStayWithUs: {
+    title: 'Warum bei uns buchen?',
+    benefits: [
+      'Strategische Lagen',
+      'Voll ausgestattete Häuser',
+      'Direkte Buchung und lokaler Support',
+      'Keine Plattformgebühren',
+    ],
+    ctaText: 'Alle unsere Unterkünfte ansehen',
+  },
+
+  imagesModal: {
+    close: 'Schließen',
+    photos: 'Fotos',
+    previous: 'Zurück',
+    next: 'Weiter',
+    empty: 'Keine Bilder verfügbar',
+  },
+
+  reviewTags: {
+    'Stayed a few nights': 'Aufenthalt von ein paar Nächten',
+    'Stayed one night': 'Aufenthalt von einer Nacht',
+    'Stayed with kids': 'Aufenthalt mit Kindern',
+    'Stayed with a pet': 'Aufenthalt mit Haustier',
+    'Stayed about a week': 'Aufenthalt von etwa einer Woche',
+  },
+
 };

--- a/src/i18n/messages/en.ts
+++ b/src/i18n/messages/en.ts
@@ -77,6 +77,9 @@ export const en = {
     otherListingsHeading: 'Check out our other options!',
     readBlog: (title: string) => `Read blog: ${title}`,
     weOfferEquipped: 'We offer fully equipped homes:',
+    // Portfolio.component.tsx's "Our Photos" gallery heading — was literal
+    // JSX with no locale branching at all, not even for Spanish.
+    ourPhotosHeading: 'Photos',
   },
 
   contact: {
@@ -154,6 +157,65 @@ export const en = {
     bedrooms: (count: number) => `${count} ${count === 1 ? 'bedroom' : 'bedrooms'}`,
     bathrooms: (count: number) => `${count} ${count === 1 ? 'bathroom' : 'bathrooms'}`,
     upToGuests: (count: number) => `Up to ${count} ${count === 1 ? 'guest' : 'guests'}`,
+    // Shared by HomeCard, HelpMeChoose, and both OtherHomesCard variants — was
+    // four separate hardcoded `locale === 'es' ? 'Ver casa →' : 'View home →'`
+    // ternaries that silently fell back to English for every other locale.
+    viewHomeCta: 'View home →',
+  },
+
+  cookieBanner: {
+    title: '🍪 Cookies',
+    description: 'We use cookies to improve your experience and analyze traffic.',
+    acceptAll: 'Accept',
+    rejectAll: 'Reject',
+    customize: 'Options',
+    essential: 'Essential',
+    analytics: 'Analytics',
+    marketing: 'Marketing',
+    required: '(Req.)',
+    essentialDesc: 'Required for the site to function.',
+    analyticsDesc: 'Help us understand site usage.',
+    marketingDesc: 'To show relevant ads.',
+    savePreferences: 'Save',
+    cancel: 'Cancel',
+  },
+
+  notFound: {
+    title: 'Page not found | Reservas Kalawala',
+    heading: 'We could not find that page',
+    body: 'The link may be broken, or the page may have moved.',
+    cta: 'Back to home',
+  },
+
+  whyStayWithUs: {
+    title: 'Why book with us?',
+    benefits: [
+      'Strategic locations',
+      'Fully equipped houses',
+      'Direct booking and local support',
+      'No platform commissions',
+    ],
+    ctaText: 'View all our properties',
+  },
+
+  imagesModal: {
+    close: 'Close',
+    photos: 'photos',
+    previous: 'Previous',
+    next: 'Next',
+    empty: 'No images available',
+  },
+
+  // Looked up by the exact English `stayType` string stored on each review
+  // (see reviewsData.ts / HomeReviews's own review objects) — not renamed
+  // keys, so a new stayType value falls back to the raw English string
+  // instead of silently mapping to the wrong label.
+  reviewTags: {
+    'Stayed a few nights': 'Stayed a few nights',
+    'Stayed one night': 'Stayed one night',
+    'Stayed with kids': 'Stayed with kids',
+    'Stayed with a pet': 'Stayed with a pet',
+    'Stayed about a week': 'Stayed about a week',
   },
 };
 

--- a/src/i18n/messages/es.ts
+++ b/src/i18n/messages/es.ts
@@ -65,6 +65,7 @@ export const es: Messages = {
     otherListingsHeading: '¡Revisa nuestras otras opciones!',
     readBlog: (title: string) => `Leer blog: ${title}`,
     weOfferEquipped: 'Ofrecemos casas completamente equipadas:',
+    ourPhotosHeading: 'Fotos',
   },
 
   contact: {
@@ -139,5 +140,57 @@ export const es: Messages = {
     bedrooms: (count: number) => `${count} ${count === 1 ? 'habitación' : 'habitaciones'}`,
     bathrooms: (count: number) => `${count} ${count === 1 ? 'baño' : 'baños'}`,
     upToGuests: (count: number) => `Hasta ${count} ${count === 1 ? 'huésped' : 'huéspedes'}`,
+    viewHomeCta: 'Ver casa →',
+  },
+
+  cookieBanner: {
+    title: '🍪 Cookies',
+    description: 'Usamos cookies para mejorar tu experiencia y analizar el tráfico.',
+    acceptAll: 'Aceptar',
+    rejectAll: 'Rechazar',
+    customize: 'Opciones',
+    essential: 'Esenciales',
+    analytics: 'Análisis',
+    marketing: 'Marketing',
+    required: '(Req.)',
+    essentialDesc: 'Necesarias para el funcionamiento del sitio.',
+    analyticsDesc: 'Nos ayudan a entender el uso del sitio.',
+    marketingDesc: 'Para mostrar anuncios relevantes.',
+    savePreferences: 'Guardar',
+    cancel: 'Cancelar',
+  },
+
+  notFound: {
+    title: 'Página no encontrada | Reservas Kalawala',
+    heading: 'No encontramos esta página',
+    body: 'Es posible que el enlace esté roto o que la página se haya movido.',
+    cta: 'Volver al inicio',
+  },
+
+  whyStayWithUs: {
+    title: '¿Por qué reservar con nosotros?',
+    benefits: [
+      'Ubicaciones estratégicas',
+      'Casas totalmente equipadas',
+      'Reserva directa y soporte local',
+      'Sin comisiones de plataformas',
+    ],
+    ctaText: 'Ver todas nuestras propiedades',
+  },
+
+  imagesModal: {
+    close: 'Cerrar',
+    photos: 'fotos',
+    previous: 'Anterior',
+    next: 'Siguiente',
+    empty: 'No hay fotos disponibles',
+  },
+
+  reviewTags: {
+    'Stayed a few nights': 'Estadía de algunas noches',
+    'Stayed one night': 'Estadía de una noche',
+    'Stayed with kids': 'Estadía con niños',
+    'Stayed with a pet': 'Estadía con mascota',
+    'Stayed about a week': 'Estadía de aproximadamente una semana',
   },
 };

--- a/src/i18n/messages/fr.ts
+++ b/src/i18n/messages/fr.ts
@@ -60,6 +60,7 @@ export const fr: Messages = {
     otherListingsHeading: 'Découvrez nos autres options !',
     readBlog: (title: string) => `Lire l’article : ${title}`,
     weOfferEquipped: 'Nous proposons des maisons entièrement équipées :',
+    ourPhotosHeading: 'Photos',
   },
 
   contact: {
@@ -127,5 +128,57 @@ export const fr: Messages = {
     bedrooms: (count: number) => `${count} ${count > 1 ? 'chambres' : 'chambre'}`,
     bathrooms: (count: number) => `${count} ${count > 1 ? 'salles de bain' : 'salle de bain'}`,
     upToGuests: (count: number) => `Jusqu’à ${count} ${count > 1 ? 'personnes' : 'personne'}`,
+    viewHomeCta: 'Voir la maison →',
   },
+  cookieBanner: {
+    title: '🍪 Cookies',
+    description: 'Nous utilisons des cookies pour améliorer votre expérience et analyser le trafic.',
+    acceptAll: 'Accepter',
+    rejectAll: 'Refuser',
+    customize: 'Options',
+    essential: 'Essentiels',
+    analytics: 'Analyse',
+    marketing: 'Marketing',
+    required: '(Req.)',
+    essentialDesc: 'Nécessaires au fonctionnement du site.',
+    analyticsDesc: 'Nous aident à comprendre l\'utilisation du site.',
+    marketingDesc: 'Pour afficher des publicités pertinentes.',
+    savePreferences: 'Enregistrer',
+    cancel: 'Annuler',
+  },
+
+  notFound: {
+    title: 'Page introuvable | Reservas Kalawala',
+    heading: 'Nous n\'avons pas trouvé cette page',
+    body: 'Il est possible que le lien soit rompu ou que la page ait été déplacée.',
+    cta: 'Retour à l\'accueil',
+  },
+
+  whyStayWithUs: {
+    title: 'Pourquoi réserver avec nous ?',
+    benefits: [
+      'Emplacements stratégiques',
+      'Maisons entièrement équipées',
+      'Réservation directe et assistance locale',
+      'Aucune commission de plateforme',
+    ],
+    ctaText: 'Voir toutes nos propriétés',
+  },
+
+  imagesModal: {
+    close: 'Fermer',
+    photos: 'photos',
+    previous: 'Précédent',
+    next: 'Suivant',
+    empty: 'Aucune photo disponible',
+  },
+
+  reviewTags: {
+    'Stayed a few nights': 'Séjour de quelques nuits',
+    'Stayed one night': 'Séjour d\'une nuit',
+    'Stayed with kids': 'Séjour avec des enfants',
+    'Stayed with a pet': 'Séjour avec un animal de compagnie',
+    'Stayed about a week': 'Séjour d\'environ une semaine',
+  },
+
 };

--- a/src/i18n/messages/he.ts
+++ b/src/i18n/messages/he.ts
@@ -67,6 +67,7 @@ export const he: Messages = {
     otherListingsHeading: 'גלו את האפשרויות הנוספות שלנו!',
     readBlog: (title: string) => `קריאת הפוסט: ${title}`,
     weOfferEquipped: 'אנו מציעים בתים מאובזרים במלואם:',
+    ourPhotosHeading: 'תמונות',
   },
 
   contact: {
@@ -134,5 +135,57 @@ export const he: Messages = {
     bedrooms: (count: number) => `${count} ${count === 1 ? 'חדר שינה' : 'חדרי שינה'}`,
     bathrooms: (count: number) => `${count} ${count === 1 ? 'חדר רחצה' : 'חדרי רחצה'}`,
     upToGuests: (count: number) => `עד ${count} ${count === 1 ? 'אורח' : 'אורחים'}`,
+    viewHomeCta: 'צפייה בבית →',
   },
+  cookieBanner: {
+    title: '🍪 עוגיות',
+    description: 'אנו משתמשים בעוגיות כדי לשפר את חווייתך ולנתח את התנועה באתר.',
+    acceptAll: 'קבל הכול',
+    rejectAll: 'דחה הכול',
+    customize: 'אפשרויות',
+    essential: 'חיוניות',
+    analytics: 'אנליטיקה',
+    marketing: 'שיווק',
+    required: '(חובה)',
+    essentialDesc: 'נדרשות לתפקוד האתר.',
+    analyticsDesc: 'עוזרות לנו להבין את השימוש באתר.',
+    marketingDesc: 'להצגת מודעות רלוונטיות.',
+    savePreferences: 'שמור',
+    cancel: 'ביטול',
+  },
+
+  notFound: {
+    title: 'עמוד לא נמצא | Reservas Kalawala',
+    heading: 'לא הצלחנו למצוא את העמוד הזה',
+    body: 'ייתכן שהקישור שבור או שהעמוד הועבר.',
+    cta: 'חזרה לדף הבית',
+  },
+
+  whyStayWithUs: {
+    title: 'למה להזמין איתנו?',
+    benefits: [
+      'מיקומים אסטרטגיים',
+      'בתים מאובזרים במלואם',
+      'הזמנה ישירה ותמיכה מקומית',
+      'ללא עמלות פלטפורמה',
+    ],
+    ctaText: 'צפייה בכל הנכסים שלנו',
+  },
+
+  imagesModal: {
+    close: 'סגור',
+    photos: 'תמונות',
+    previous: 'הקודם',
+    next: 'הבא',
+    empty: 'אין תמונות זמינות',
+  },
+
+  reviewTags: {
+    'Stayed a few nights': 'שהות של כמה לילות',
+    'Stayed one night': 'שהות של לילה אחד',
+    'Stayed with kids': 'שהות עם ילדים',
+    'Stayed with a pet': 'שהות עם חיית מחמד',
+    'Stayed about a week': 'שהות של כשבוע',
+  },
+
 };

--- a/src/i18n/messages/hi.ts
+++ b/src/i18n/messages/hi.ts
@@ -61,6 +61,7 @@ export const hi: Messages = {
     otherListingsHeading: 'हमारे अन्य विकल्प देखें!',
     readBlog: (title: string) => `ब्लॉग पढ़ें: ${title}`,
     weOfferEquipped: 'हम पूरी तरह सुसज्जित घर उपलब्ध कराते हैं:',
+    ourPhotosHeading: 'तस्वीरें',
   },
 
   contact: {
@@ -128,5 +129,57 @@ export const hi: Messages = {
     bedrooms: (count: number) => `${count} ${count === 1 ? 'कमरा' : 'कमरे'}`,
     bathrooms: (count: number) => `${count} बाथरूम`,
     upToGuests: (count: number) => `${count} तक मेहमान`,
+    viewHomeCta: 'घर देखें →',
   },
+  cookieBanner: {
+    title: '🍪 कुकीज़',
+    description: 'हम आपके अनुभव को बेहतर बनाने और ट्रैफ़िक का विश्लेषण करने के लिए कुकीज़ का उपयोग करते हैं।',
+    acceptAll: 'स्वीकार करें',
+    rejectAll: 'अस्वीकार करें',
+    customize: 'विकल्प',
+    essential: 'आवश्यक',
+    analytics: 'विश्लेषण',
+    marketing: 'मार्केटिंग',
+    required: '(आवश्यक)',
+    essentialDesc: 'साइट के कार्य करने के लिए आवश्यक।',
+    analyticsDesc: 'हमें साइट के उपयोग को समझने में मदद करता है।',
+    marketingDesc: 'प्रासंगिक विज्ञापन दिखाने के लिए।',
+    savePreferences: 'सहेजें',
+    cancel: 'रद्द करें',
+  },
+
+  notFound: {
+    title: 'पेज नहीं मिला | Reservas Kalawala',
+    heading: 'हमें वह पेज नहीं मिला',
+    body: 'हो सकता है लिंक टूटा हो, या पेज हटा दिया गया हो।',
+    cta: 'होम पर वापस जाएं',
+  },
+
+  whyStayWithUs: {
+    title: 'हमारे साथ बुकिंग क्यों करें?',
+    benefits: [
+      'रणनीतिक स्थान',
+      'पूरी तरह से सुसज्जित घर',
+      'सीधी बुकिंग और स्थानीय सहायता',
+      'कोई प्लेटफ़ॉर्म कमीशन नहीं',
+    ],
+    ctaText: 'हमारी सभी संपत्तियां देखें',
+  },
+
+  imagesModal: {
+    close: 'बंद करें',
+    photos: 'तस्वीरें',
+    previous: 'पिछला',
+    next: 'अगला',
+    empty: 'कोई तस्वीर उपलब्ध नहीं है',
+  },
+
+  reviewTags: {
+    'Stayed a few nights': 'कुछ रातें ठहरे',
+    'Stayed one night': 'एक रात ठहरे',
+    'Stayed with kids': 'बच्चों के साथ ठहरे',
+    'Stayed with a pet': 'पालतू जानवर के साथ ठहरे',
+    'Stayed about a week': 'लगभग एक हफ्ते ठहरे',
+  },
+
 };

--- a/src/i18n/messages/it.ts
+++ b/src/i18n/messages/it.ts
@@ -58,6 +58,7 @@ export const it: Messages = {
     otherListingsHeading: 'Scopri le nostre altre proposte!',
     readBlog: (title: string) => `Leggi l’articolo: ${title}`,
     weOfferEquipped: 'Offriamo case completamente attrezzate:',
+    ourPhotosHeading: 'Foto',
   },
 
   contact: {
@@ -125,5 +126,57 @@ export const it: Messages = {
     bedrooms: (count: number) => `${count} ${count === 1 ? 'camera da letto' : 'camere da letto'}`,
     bathrooms: (count: number) => `${count} ${count === 1 ? 'bagno' : 'bagni'}`,
     upToGuests: (count: number) => `Fino a ${count} ${count === 1 ? 'ospite' : 'ospiti'}`,
+    viewHomeCta: 'Vedi la casa →',
   },
+  cookieBanner: {
+    title: '🍪 Cookies',
+    description: 'Utilizziamo i cookie per migliorare la tua esperienza e analizzare il traffico.',
+    acceptAll: 'Accetta',
+    rejectAll: 'Rifiuta',
+    customize: 'Opzioni',
+    essential: 'Essenziali',
+    analytics: 'Analisi',
+    marketing: 'Marketing',
+    required: '(Nec.)',
+    essentialDesc: 'Necessari per il funzionamento del sito.',
+    analyticsDesc: 'Ci aiutano a capire l\'utilizzo del sito.',
+    marketingDesc: 'Per mostrare annunci pertinenti.',
+    savePreferences: 'Salva',
+    cancel: 'Annulla',
+  },
+
+  notFound: {
+    title: 'Pagina non trovata | Reservas Kalawala',
+    heading: 'Non siamo riusciti a trovare questa pagina',
+    body: 'Il link potrebbe essere danneggiato oppure la pagina potrebbe essere stata spostata.',
+    cta: 'Torna alla home',
+  },
+
+  whyStayWithUs: {
+    title: 'Perché prenotare con noi?',
+    benefits: [
+      'Posizioni strategiche',
+      'Case completamente attrezzate',
+      'Prenotazione diretta e supporto locale',
+      'Nessuna commissione di piattaforma',
+    ],
+    ctaText: 'Vedi tutte le nostre proprietà',
+  },
+
+  imagesModal: {
+    close: 'Chiudi',
+    photos: 'foto',
+    previous: 'Precedente',
+    next: 'Successivo',
+    empty: 'Nessuna immagine disponibile',
+  },
+
+  reviewTags: {
+    'Stayed a few nights': 'Soggiorno di alcune notti',
+    'Stayed one night': 'Soggiorno di una notte',
+    'Stayed with kids': 'Soggiorno con bambini',
+    'Stayed with a pet': 'Soggiorno con animale domestico',
+    'Stayed about a week': 'Soggiorno di circa una settimana',
+  },
+
 };

--- a/src/i18n/messages/pt.ts
+++ b/src/i18n/messages/pt.ts
@@ -59,6 +59,7 @@ export const pt: Messages = {
     otherListingsHeading: 'Veja as nossas outras opções!',
     readBlog: (title: string) => `Ler artigo: ${title}`,
     weOfferEquipped: 'Oferecemos casas totalmente equipadas:',
+    ourPhotosHeading: 'Fotos',
   },
 
   contact: {
@@ -126,5 +127,57 @@ export const pt: Messages = {
     bedrooms: (count: number) => `${count} ${count === 1 ? 'quarto' : 'quartos'}`,
     bathrooms: (count: number) => `${count} ${count === 1 ? 'casa de banho' : 'casas de banho'}`,
     upToGuests: (count: number) => `Até ${count} ${count === 1 ? 'hóspede' : 'hóspedes'}`,
+    viewHomeCta: 'Ver casa →',
   },
+  cookieBanner: {
+    title: '🍪 Cookies',
+    description: 'Utilizamos cookies para melhorar a sua experiência e analisar o tráfego.',
+    acceptAll: 'Aceitar',
+    rejectAll: 'Rejeitar',
+    customize: 'Opções',
+    essential: 'Essenciais',
+    analytics: 'Análise',
+    marketing: 'Marketing',
+    required: '(Obrig.)',
+    essentialDesc: 'Necessários para o funcionamento do site.',
+    analyticsDesc: 'Ajudam-nos a compreender a utilização do site.',
+    marketingDesc: 'Para mostrar anúncios relevantes.',
+    savePreferences: 'Guardar',
+    cancel: 'Cancelar',
+  },
+
+  notFound: {
+    title: 'Página não encontrada | Reservas Kalawala',
+    heading: 'Não conseguimos encontrar essa página',
+    body: 'A ligação pode estar quebrada ou a página pode ter sido movida.',
+    cta: 'Voltar ao início',
+  },
+
+  whyStayWithUs: {
+    title: 'Porquê reservar connosco?',
+    benefits: [
+      'Localizações estratégicas',
+      'Casas totalmente equipadas',
+      'Reserva direta e apoio local',
+      'Sem comissões de plataformas',
+    ],
+    ctaText: 'Ver todas as nossas propriedades',
+  },
+
+  imagesModal: {
+    close: 'Fechar',
+    photos: 'fotos',
+    previous: 'Anterior',
+    next: 'Seguinte',
+    empty: 'Não há imagens disponíveis',
+  },
+
+  reviewTags: {
+    'Stayed a few nights': 'Estadia de algumas noites',
+    'Stayed one night': 'Estadia de uma noite',
+    'Stayed with kids': 'Estadia com crianças',
+    'Stayed with a pet': 'Estadia com animal de estimação',
+    'Stayed about a week': 'Estadia de cerca de uma semana',
+  },
+
 };

--- a/src/pages/Blog/BlogIndex.page.tsx
+++ b/src/pages/Blog/BlogIndex.page.tsx
@@ -7,7 +7,9 @@ import FixedNavigation from '../../components/FixedNavigation/FixedNavigation.co
 import Footer from '../../components/Footer/Footer.component';
 import { BLOG_ARTICLES } from '../../utils/constants';
 import { useLocale, useMessages } from '../../i18n';
+import { blogArticleHeading } from '../../i18n/blogArticleHeadings';
 import { canonicalUrl, hreflangLinks } from '../../i18n/seo';
+import { pathForKey } from '../../routes.config';
 
 /**
  * The nav's "Blog" link used to go straight to a single article — the other
@@ -45,8 +47,8 @@ const BlogIndex = () => {
           <ul style={{ listStyle: 'none', padding: 0, marginTop: '2rem' }}>
             {BLOG_ARTICLES.map((article) => (
               <li key={article.key} style={{ marginBottom: '1.25rem', paddingBottom: '1.25rem', borderBottom: '1px solid rgba(0,0,0,0.1)' }}>
-                <Link to={locale === 'es' ? article.pathEs : article.pathEn} style={{ fontSize: '1.2rem', fontWeight: 600 }}>
-                  {locale === 'es' ? article.titleEs : article.titleEn}
+                <Link to={pathForKey(article.routeKey, locale)} style={{ fontSize: '1.2rem', fontWeight: 600 }}>
+                  {blogArticleHeading(article.routeKey, locale)}
                 </Link>
               </li>
             ))}

--- a/src/pages/Blog/Components/OtherBlogs.Component.tsx
+++ b/src/pages/Blog/Components/OtherBlogs.Component.tsx
@@ -1,19 +1,20 @@
 import React, { FC, useEffect, useState, useCallback, useMemo } from "react";
 import './OtherBlogs.style.scss'
-import { BlogType } from "../../../utils/types";
+import { blogs } from "../../../assets/blogs/blogs";
 import { useNavigate } from "react-router-dom";
 import Slider from "react-slick";
 import { SampleNextArrow, SamplePrevArrow } from "../../../components/CustomSlick/SlickDarkArrow.Component";
 import { cdnImage } from "../../../utils/imageCdn";
-import { useMessages } from '../../../i18n';
-import { pathForLegacyId } from '../../../routes.config';
+import { useMessages, type Locale } from '../../../i18n';
+import { blogArticleHeading } from '../../../i18n/blogArticleHeadings';
+import { routeKeyForSlug, pathForKey } from '../../../routes.config';
 
 interface IOtherBlogs {
   currentBlog: string
-  blogs: BlogType[]
+  locale: Locale
 }
 
-const OtherBlogs: FC<IOtherBlogs> = ({ currentBlog, blogs }) => {
+const OtherBlogs: FC<IOtherBlogs> = ({ currentBlog, locale }) => {
   const m = useMessages();
   // Seeded null, not window.innerWidth — react-snap's puppeteer viewport at
   // prerender time and a real visitor's viewport at hydration time are
@@ -36,14 +37,22 @@ const OtherBlogs: FC<IOtherBlogs> = ({ currentBlog, blogs }) => {
     return () => window.removeEventListener("resize", handleResize)
   }, [handleResize])
 
-  // Found while merging Phase 3c: this used to compare against `blog.title`
-  // (a human-readable sentence), but every call site passes an `id`-shaped
-  // slug. The two never matched, so the "exclude the current article"
-  // filter was a no-op on all 20 pre-merge pages — every carousel included a
-  // card linking back to the page you were already on.
+  // `blogs` (assets/blogs/blogs.ts) is locale-invariant now — id and
+  // thumbnail only, no per-locale title. The card title comes from
+  // blogArticleHeading, reusing blog.tsx's own Phase-8 translations instead
+  // of maintaining a second copy. Matched by routeKeyForSlug rather than a
+  // raw string compare (blogs.ts's ids are inconsistently cased — e.g.
+  // "TenHoursInPuerto", "cahuitaParkwhattodo" — routeKeyForSlug already
+  // lowercases both sides) so "exclude the current article" keeps working
+  // regardless of casing drift between the two tables.
+  const currentRouteKey = routeKeyForSlug(currentBlog);
   const filteredBlogs = useMemo(() =>
-    blogs.filter(blog => blog.id !== currentBlog),
-    [blogs, currentBlog]
+    blogs
+      .map((blog) => ({ ...blog, routeKey: routeKeyForSlug(blog.id) }))
+      .filter((blog): blog is typeof blog & { routeKey: NonNullable<typeof blog.routeKey> } =>
+        blog.routeKey !== undefined && blog.routeKey !== currentRouteKey
+      ),
+    [currentRouteKey]
   )
 
   const sliderSettings = useMemo(() => ({
@@ -73,9 +82,10 @@ const OtherBlogs: FC<IOtherBlogs> = ({ currentBlog, blogs }) => {
     ]
   }), [windowWidth, filteredBlogs.length])
 
-  const handleBlogClick = useCallback((id: string) => {
-    navigate(pathForLegacyId(id))
-  }, [navigate])
+  const handleBlogClick = useCallback((routeKey: ReturnType<typeof routeKeyForSlug>) => {
+    if (!routeKey) return;
+    navigate(pathForKey(routeKey, locale))
+  }, [navigate, locale])
 
   if (filteredBlogs.length === 0) {
     return null
@@ -86,26 +96,29 @@ const OtherBlogs: FC<IOtherBlogs> = ({ currentBlog, blogs }) => {
       <h2 className="other-blogs-header">{m.sections.otherBlogsHeading}</h2>
       <div className="other-blogs-slider">
         <Slider {...sliderSettings}>
-          {filteredBlogs.map(({ title, thumbnail, id }) => (
-            <div key={id} className="blog-slide">
-              <div
-                className="blog-card"
-                onClick={() => handleBlogClick(id)}
-                role="button"
-                tabIndex={0}
-                onKeyDown={(e) => e.key === 'Enter' && handleBlogClick(id)}
-                aria-label={m.sections.readBlog(title)}
-              >
+          {filteredBlogs.map(({ thumbnail, id, routeKey }) => {
+            const title = blogArticleHeading(routeKey, locale);
+            return (
+              <div key={id} className="blog-slide">
                 <div
-                  className="blog-card-image"
-                  style={{ backgroundImage: `url(${cdnImage(thumbnail, 400)})` }}
-                />
-                <div className="blog-card-content">
-                  <h3 className="blog-card-title">{title}</h3>
+                  className="blog-card"
+                  onClick={() => handleBlogClick(routeKey)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => e.key === 'Enter' && handleBlogClick(routeKey)}
+                  aria-label={m.sections.readBlog(title)}
+                >
+                  <div
+                    className="blog-card-image"
+                    style={{ backgroundImage: `url(${cdnImage(thumbnail, 400)})` }}
+                  />
+                  <div className="blog-card-content">
+                    <h3 className="blog-card-title">{title}</h3>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </Slider>
       </div>
     </div>

--- a/src/pages/Blog/staticPages/BestTimeToVisitPuerto.tsx
+++ b/src/pages/Blog/staticPages/BestTimeToVisitPuerto.tsx
@@ -4,14 +4,13 @@ import '../../Listing/Listing.style.scss';
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import ContactUs from "../../../components/ContactUs/ContactUs.component";
 import { Helmet } from "react-helmet";
-import { blogs, blogsES } from "../../../assets/blogs/blogs";
 import OtherBlogs from "../Components/OtherBlogs.Component";
 import Smoobu2 from "../../../components/Smoobu2/Smoobu2.component";
 import StayRecommendation from "../../../components/StayRecommendation/StayRecommendation.component";
 import WhyStayWithUs from "../../../components/WhyStayWithUs/WhyStayWithUs.component";
-import { GENERAL_PUERTO_VIEJO_RECOMMENDATIONS, GENERAL_PUERTO_VIEJO_RECOMMENDATIONS_ES } from "../../../utils/constants";
+import { generalPuertoViejoRecommendations } from "../../../utils/constants";
 import { useLocale, useMessages } from "../../../i18n";
-import { localeSuffix, bookingLanguage, homePath } from "../../../i18n/paths";
+import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { bestTimeToVisitContent } from "../../../i18n/content/blog";
 
@@ -21,8 +20,6 @@ const BestTimeToVisitPuerto = () => {
     const locale = useLocale();
     const m = useMessages();
     const content = bestTimeToVisitContent(locale);
-    const lang = bookingLanguage(locale);
-    const selfId = `bestTimeToVisitPuerto${localeSuffix(locale)}`;
 
     useEffect(() => {
         window.scrollTo(0, 0);
@@ -93,8 +90,7 @@ const BestTimeToVisitPuerto = () => {
                         {/* Stay Recommendation Component - positioned in middle of article */}
                         <StayRecommendation
                             title={content.stayRecommendationTitle}
-                            properties={locale === 'es' ? GENERAL_PUERTO_VIEJO_RECOMMENDATIONS_ES : GENERAL_PUERTO_VIEJO_RECOMMENDATIONS}
-                            language={lang}
+                            properties={generalPuertoViejoRecommendations(locale)}
                         />
 
                         <h2>{content.hardToPredictHeading}</h2>
@@ -135,7 +131,7 @@ const BestTimeToVisitPuerto = () => {
 
                         {/* Why Stay With Us Component - after main content, before OtherBlogs */}
                         <div style={{ maxWidth: 1000 }}>
-                            <WhyStayWithUs language={lang} ctaLink={homePath(locale)} />
+                            <WhyStayWithUs locale={locale} ctaLink={homePath(locale)} />
                         </div>
 
                         <br />
@@ -167,7 +163,7 @@ const BestTimeToVisitPuerto = () => {
                         </div>
                     </div>
 
-                    <OtherBlogs currentBlog={selfId} blogs={locale === 'es' ? blogsES : blogs} />
+                    <OtherBlogs currentBlog="bestTimeToVisitPuerto" locale={locale} />
                 </Col>
             </Row>
 

--- a/src/pages/Blog/staticPages/BusHours.tsx
+++ b/src/pages/Blog/staticPages/BusHours.tsx
@@ -4,14 +4,13 @@ import '../../Listing/Listing.style.scss';
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import ContactUs from "../../../components/ContactUs/ContactUs.component";
 import { Helmet } from "react-helmet";
-import { blogs, blogsES } from "../../../assets/blogs/blogs";
 import OtherBlogs from "../Components/OtherBlogs.Component";
 import Smoobu2 from "../../../components/Smoobu2/Smoobu2.component";
 import StayRecommendation from "../../../components/StayRecommendation/StayRecommendation.component";
 import WhyStayWithUs from "../../../components/WhyStayWithUs/WhyStayWithUs.component";
-import { GENERAL_PUERTO_VIEJO_RECOMMENDATIONS, GENERAL_PUERTO_VIEJO_RECOMMENDATIONS_ES } from "../../../utils/constants";
+import { generalPuertoViejoRecommendations } from "../../../utils/constants";
 import { useLocale, useMessages } from "../../../i18n";
-import { localeSuffix, bookingLanguage, homePath } from "../../../i18n/paths";
+import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { busHoursContent, BusHoursContent } from "../../../i18n/content/blog";
 
@@ -73,8 +72,6 @@ const BusHours = () => {
     const locale = useLocale();
     const m = useMessages();
     const content = busHoursContent(locale);
-    const lang = bookingLanguage(locale);
-    const selfId = `bushours${localeSuffix(locale)}`;
 
     useEffect(() => {
         window.scrollTo(0, 0);
@@ -139,8 +136,7 @@ const BusHours = () => {
                         {/* Stay Recommendation Component - positioned in middle of article */}
                         <StayRecommendation
                             title={content.stayRecommendationTitle}
-                            properties={locale === 'es' ? GENERAL_PUERTO_VIEJO_RECOMMENDATIONS_ES : GENERAL_PUERTO_VIEJO_RECOMMENDATIONS}
-                            language={lang}
+                            properties={generalPuertoViejoRecommendations(locale)}
                         />
                         <br />
 
@@ -194,7 +190,7 @@ const BusHours = () => {
                     {/* Why Stay With Us Component - after main content, before OtherBlogs */}
                     <div style={{ maxWidth: 1000 }}>
                         <WhyStayWithUs
-                            language={lang}
+                            locale={locale}
                             ctaLink={homePath(locale)}
                         />
                     </div>
@@ -225,7 +221,7 @@ const BusHours = () => {
                         </div>
                     </div>
 
-                    <OtherBlogs currentBlog={selfId} blogs={locale === 'es' ? blogsES : blogs} />
+                    <OtherBlogs currentBlog="bushours" locale={locale} />
                 </Col>
             </Row>
             <ContactUs />

--- a/src/pages/Blog/staticPages/CahuitaPark.tsx
+++ b/src/pages/Blog/staticPages/CahuitaPark.tsx
@@ -4,14 +4,13 @@ import '../../Listing/Listing.style.scss';
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import ContactUs from "../../../components/ContactUs/ContactUs.component";
 import { Helmet } from "react-helmet";
-import { blogs, blogsES } from "../../../assets/blogs/blogs";
 import OtherBlogs from "../Components/OtherBlogs.Component";
 import Smoobu2 from "../../../components/Smoobu2/Smoobu2.component";
 import StayRecommendation from "../../../components/StayRecommendation/StayRecommendation.component";
 import WhyStayWithUs from "../../../components/WhyStayWithUs/WhyStayWithUs.component";
-import { GENERAL_PUERTO_VIEJO_RECOMMENDATIONS, GENERAL_PUERTO_VIEJO_RECOMMENDATIONS_ES } from "../../../utils/constants";
+import { generalPuertoViejoRecommendations } from "../../../utils/constants";
 import { useLocale, useMessages } from "../../../i18n";
-import { localeSuffix, bookingLanguage, homePath } from "../../../i18n/paths";
+import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { cahuitaParkContent } from "../../../i18n/content/blog";
 
@@ -21,8 +20,6 @@ const CahuitaPark = () => {
     const locale = useLocale();
     const m = useMessages();
     const content = cahuitaParkContent(locale);
-    const lang = bookingLanguage(locale);
-    const selfId = `cahuitaParkwhattodo${localeSuffix(locale)}`;
 
     useEffect(() => {
         window.scrollTo(0, 0);
@@ -88,8 +85,7 @@ const CahuitaPark = () => {
                         {/* Stay Recommendation Component - positioned in middle of article */}
                         <StayRecommendation
                             title={content.stayRecommendationTitle}
-                            properties={locale === 'es' ? GENERAL_PUERTO_VIEJO_RECOMMENDATIONS_ES : GENERAL_PUERTO_VIEJO_RECOMMENDATIONS}
-                            language={lang}
+                            properties={generalPuertoViejoRecommendations(locale)}
                         />
                         <br />
 
@@ -118,7 +114,7 @@ const CahuitaPark = () => {
                     {/* Why Stay With Us Component - after main content, before OtherBlogs */}
                     <div style={{ maxWidth: 1000 }}>
                         <WhyStayWithUs
-                            language={lang}
+                            locale={locale}
                             ctaLink={homePath(locale)}
                         />
                     </div>
@@ -154,7 +150,7 @@ const CahuitaPark = () => {
                         </div>
                     </div>
 
-                    <OtherBlogs currentBlog={selfId} blogs={locale === 'es' ? blogsES : blogs} />
+                    <OtherBlogs currentBlog="cahuitaParkwhattodo" locale={locale} />
                 </Col>
             </Row>
             <ContactUs />

--- a/src/pages/Blog/staticPages/GettingToGandoca.tsx
+++ b/src/pages/Blog/staticPages/GettingToGandoca.tsx
@@ -3,7 +3,6 @@ import { cdnImage, cdnSrcSet } from '../../../utils/imageCdn';
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
 
-import { blogs, blogsES } from "../../../assets/blogs/blogs";
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import OtherBlogs from "../Components/OtherBlogs.Component";
 import ContactUs from "../../../components/ContactUs/ContactUs.component";
@@ -11,9 +10,9 @@ import { Helmet } from "react-helmet";
 import Smoobu2 from "../../../components/Smoobu2/Smoobu2.component";
 import StayRecommendation from "../../../components/StayRecommendation/StayRecommendation.component";
 import WhyStayWithUs from "../../../components/WhyStayWithUs/WhyStayWithUs.component";
-import { GENERAL_PUERTO_VIEJO_RECOMMENDATIONS, GENERAL_PUERTO_VIEJO_RECOMMENDATIONS_ES } from "../../../utils/constants";
+import { generalPuertoViejoRecommendations } from "../../../utils/constants";
 import { useLocale, useMessages } from "../../../i18n";
-import { localeSuffix, bookingLanguage, homePath } from "../../../i18n/paths";
+import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { gettingToGandocaContent } from "../../../i18n/content/blog";
 
@@ -37,8 +36,6 @@ const GettingToGandoca = () => {
     const locale = useLocale();
     const m = useMessages();
     const content = gettingToGandocaContent(locale);
-    const lang = bookingLanguage(locale);
-    const selfId = `gettingtogandoca${localeSuffix(locale)}`;
 
     useEffect(() => {
         window.scrollTo(0, 0);
@@ -100,8 +97,7 @@ const GettingToGandoca = () => {
                         {/* Stay Recommendation Component - positioned in middle of article */}
                         <StayRecommendation
                             title={content.stayRecommendationTitle}
-                            properties={locale === 'es' ? GENERAL_PUERTO_VIEJO_RECOMMENDATIONS_ES : GENERAL_PUERTO_VIEJO_RECOMMENDATIONS}
-                            language={lang}
+                            properties={generalPuertoViejoRecommendations(locale)}
                         />
                         <br />
 
@@ -133,7 +129,7 @@ const GettingToGandoca = () => {
                         {/* Why Stay With Us Component - after main content, before OtherBlogs */}
                         <div style={{ maxWidth: 1000 }}>
                             <WhyStayWithUs
-                                language={lang}
+                                locale={locale}
                                 ctaLink={homePath(locale)}
                             />
                         </div>
@@ -160,7 +156,7 @@ const GettingToGandoca = () => {
                         </div>
                     </div>
 
-                    <OtherBlogs currentBlog={selfId} blogs={locale === 'es' ? blogsES : blogs} />
+                    <OtherBlogs currentBlog="gettingtogandoca" locale={locale} />
                 </Col>
             </Row>
             <ContactUs />

--- a/src/pages/Blog/staticPages/IndigenousTravel.tsx
+++ b/src/pages/Blog/staticPages/IndigenousTravel.tsx
@@ -4,14 +4,13 @@ import '../../Listing/Listing.style.scss';
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import ContactUs from "../../../components/ContactUs/ContactUs.component";
 import { Helmet } from "react-helmet";
-import { blogs, blogsES } from "../../../assets/blogs/blogs";
 import OtherBlogs from "../Components/OtherBlogs.Component";
 import Smoobu2 from "../../../components/Smoobu2/Smoobu2.component";
 import StayRecommendation from "../../../components/StayRecommendation/StayRecommendation.component";
 import WhyStayWithUs from "../../../components/WhyStayWithUs/WhyStayWithUs.component";
-import { GENERAL_PUERTO_VIEJO_RECOMMENDATIONS, GENERAL_PUERTO_VIEJO_RECOMMENDATIONS_ES } from "../../../utils/constants";
+import { generalPuertoViejoRecommendations } from "../../../utils/constants";
 import { useLocale, useMessages } from "../../../i18n";
-import { localeSuffix, bookingLanguage, homePath } from "../../../i18n/paths";
+import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { indigenousTravelContent } from "../../../i18n/content/blog";
 
@@ -21,8 +20,6 @@ const IndigenousTravel = () => {
     const locale = useLocale();
     const m = useMessages();
     const content = indigenousTravelContent(locale);
-    const lang = bookingLanguage(locale);
-    const selfId = `indigenousTravelPV${localeSuffix(locale)}`;
 
     useEffect(() => {
         window.scrollTo(0, 0);
@@ -87,8 +84,7 @@ const IndigenousTravel = () => {
                         {/* Stay Recommendation Component - positioned in middle of article */}
                         <StayRecommendation
                             title={content.stayRecommendationTitle}
-                            properties={locale === 'es' ? GENERAL_PUERTO_VIEJO_RECOMMENDATIONS_ES : GENERAL_PUERTO_VIEJO_RECOMMENDATIONS}
-                            language={lang}
+                            properties={generalPuertoViejoRecommendations(locale)}
                         />
 
                         <p>{content.afterStayParagraph}</p>
@@ -156,7 +152,7 @@ const IndigenousTravel = () => {
                         {/* Why Stay With Us Component - after main content, before OtherBlogs */}
                         <div style={{ maxWidth: 1000 }}>
                             <WhyStayWithUs
-                                language={lang}
+                                locale={locale}
                                 ctaLink={homePath(locale)}
                             />
                         </div>
@@ -203,8 +199,8 @@ const IndigenousTravel = () => {
                     </div>
 
                     <OtherBlogs
-                        currentBlog={selfId}
-                        blogs={locale === 'es' ? blogsES : blogs}
+                        currentBlog="indigenousTravelPV"
+                        locale={locale}
                     />
                 </Col>
             </Row>

--- a/src/pages/Blog/staticPages/PuertoHiddenGems.tsx
+++ b/src/pages/Blog/staticPages/PuertoHiddenGems.tsx
@@ -4,15 +4,14 @@ import '../../Listing/Listing.style.scss';
 
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import OtherBlogs from "../Components/OtherBlogs.Component";
-import { GENERAL_PUERTO_VIEJO_RECOMMENDATIONS, GENERAL_PUERTO_VIEJO_RECOMMENDATIONS_ES } from "../../../utils/constants";
+import { generalPuertoViejoRecommendations } from "../../../utils/constants";
 import ContactUs from "../../../components/ContactUs/ContactUs.component";
 import { Helmet } from "react-helmet";
-import { blogs, blogsES } from "../../../assets/blogs/blogs";
 import Smoobu2 from "../../../components/Smoobu2/Smoobu2.component";
 import StayRecommendation from "../../../components/StayRecommendation/StayRecommendation.component";
 import WhyStayWithUs from "../../../components/WhyStayWithUs/WhyStayWithUs.component";
 import { useLocale, useMessages } from "../../../i18n";
-import { localeSuffix, bookingLanguage, homePath } from "../../../i18n/paths";
+import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { puertoHiddenGemsContent, HiddenGemSection } from "../../../i18n/content/blog";
 
@@ -46,8 +45,6 @@ const PuertoHiddenGems = () => {
     const locale = useLocale();
     const m = useMessages();
     const content = puertoHiddenGemsContent(locale);
-    const lang = bookingLanguage(locale);
-    const selfId = `puertoHiddenGems${localeSuffix(locale)}`;
 
     useEffect(() => {
         window.scrollTo(0, 0);
@@ -110,8 +107,7 @@ const PuertoHiddenGems = () => {
                         {/* Optional: Stay Recommendation Component - place near the top */}
                         <StayRecommendation
                             title={content.stayRecommendationTitle}
-                            properties={locale === 'es' ? GENERAL_PUERTO_VIEJO_RECOMMENDATIONS_ES : GENERAL_PUERTO_VIEJO_RECOMMENDATIONS}
-                            language={lang}
+                            properties={generalPuertoViejoRecommendations(locale)}
                         />
                         <br />
 
@@ -121,7 +117,7 @@ const PuertoHiddenGems = () => {
 
                         {/* Why Stay With Us Component - after main content, before OtherBlogs */}
                         <div style={{ maxWidth: 1000 }}>
-                            <WhyStayWithUs language={lang} ctaLink={homePath(locale)} />
+                            <WhyStayWithUs locale={locale} ctaLink={homePath(locale)} />
                         </div>
 
                         <h2>{content.tipsHeading}</h2>
@@ -145,7 +141,7 @@ const PuertoHiddenGems = () => {
                         </div>
                     </div>
 
-                    <OtherBlogs currentBlog={selfId} blogs={locale === 'es' ? blogsES : blogs} />
+                    <OtherBlogs currentBlog="puertoHiddenGems" locale={locale} />
                 </Col>
             </Row>
             <ContactUs />

--- a/src/pages/Blog/staticPages/PuertoViejoByPlane.tsx
+++ b/src/pages/Blog/staticPages/PuertoViejoByPlane.tsx
@@ -3,7 +3,6 @@ import { cdnImage, cdnSrcSet } from '../../../utils/imageCdn';
 import { Col, Row } from "react-bootstrap";
 import '../../Listing/Listing.style.scss';
 
-import { blogs, blogsES } from "../../../assets/blogs/blogs";
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import OtherBlogs from "../Components/OtherBlogs.Component";
 import ContactUs from "../../../components/ContactUs/ContactUs.component";
@@ -11,9 +10,9 @@ import { Helmet } from "react-helmet";
 import Smoobu2 from "../../../components/Smoobu2/Smoobu2.component";
 import StayRecommendation from "../../../components/StayRecommendation/StayRecommendation.component";
 import WhyStayWithUs from "../../../components/WhyStayWithUs/WhyStayWithUs.component";
-import { GENERAL_PUERTO_VIEJO_RECOMMENDATIONS, GENERAL_PUERTO_VIEJO_RECOMMENDATIONS_ES } from "../../../utils/constants";
+import { generalPuertoViejoRecommendations } from "../../../utils/constants";
 import { useLocale, useMessages } from "../../../i18n";
-import { localeSuffix, bookingLanguage, homePath } from "../../../i18n/paths";
+import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { puertoViejoByPlaneContent } from "../../../i18n/content/blog";
 
@@ -28,8 +27,6 @@ const PuertoViejoByPlane = () => {
     const locale = useLocale();
     const m = useMessages();
     const content = puertoViejoByPlaneContent(locale);
-    const lang = bookingLanguage(locale);
-    const selfId = `puertoviejobyplane${localeSuffix(locale)}`;
 
     useEffect(() => {
         window.scrollTo(0, 0);
@@ -91,8 +88,7 @@ const PuertoViejoByPlane = () => {
                         {/* Stay Recommendation Component - positioned in middle of article */}
                         <StayRecommendation
                             title={content.stayRecommendationTitle}
-                            properties={locale === 'es' ? GENERAL_PUERTO_VIEJO_RECOMMENDATIONS_ES : GENERAL_PUERTO_VIEJO_RECOMMENDATIONS}
-                            language={lang}
+                            properties={generalPuertoViejoRecommendations(locale)}
                         />
                         <br />
 
@@ -106,7 +102,7 @@ const PuertoViejoByPlane = () => {
                         {/* Why Stay With Us Component - after main content, before OtherBlogs */}
                         <div style={{ maxWidth: 1000 }}>
                             <WhyStayWithUs
-                                language={lang}
+                                locale={locale}
                                 ctaLink={homePath(locale)}
                             />
                         </div>
@@ -128,7 +124,7 @@ const PuertoViejoByPlane = () => {
                         </div>
                     </div>
 
-                    <OtherBlogs currentBlog={selfId} blogs={locale === 'es' ? blogsES : blogs} />
+                    <OtherBlogs currentBlog="puertoviejobyplane" locale={locale} />
                 </Col>
             </Row>
             <ContactUs />

--- a/src/pages/Blog/staticPages/TenHoursInPuerto.tsx
+++ b/src/pages/Blog/staticPages/TenHoursInPuerto.tsx
@@ -7,13 +7,12 @@ import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation
 import OtherBlogs from "../Components/OtherBlogs.Component";
 import ContactUs from "../../../components/ContactUs/ContactUs.component";
 import { Helmet } from "react-helmet";
-import { blogs, blogsES } from "../../../assets/blogs/blogs";
 import StayRecommendation from "../../../components/StayRecommendation/StayRecommendation.component";
 import WhyStayWithUs from "../../../components/WhyStayWithUs/WhyStayWithUs.component";
 import Smoobu2 from "../../../components/Smoobu2/Smoobu2.component";
-import { CAHUITA_AREA_RECOMMENDATIONS, CAHUITA_AREA_RECOMMENDATIONS_ES } from "../../../utils/constants";
+import { cahuitaAreaRecommendations } from "../../../utils/constants";
 import { useLocale, useMessages } from "../../../i18n";
-import { localeSuffix, bookingLanguage, homePath } from "../../../i18n/paths";
+import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { tenHoursInPuertoContent } from "../../../i18n/content/blog";
 
@@ -24,8 +23,6 @@ const TenHoursInPuerto = () => {
     const locale = useLocale();
     const m = useMessages();
     const content = tenHoursInPuertoContent(locale);
-    const lang = bookingLanguage(locale);
-    const selfId = `TenHoursInPuerto${localeSuffix(locale)}`;
 
     useEffect(() => {
         window.scrollTo(0, 0);
@@ -90,8 +87,7 @@ const TenHoursInPuerto = () => {
                         {/* Stay Recommendation Component - positioned in middle of article */}
                         <StayRecommendation
                             title={content.stayRecommendationTitle}
-                            properties={locale === 'es' ? CAHUITA_AREA_RECOMMENDATIONS_ES : CAHUITA_AREA_RECOMMENDATIONS}
-                            language={lang}
+                            properties={cahuitaAreaRecommendations(locale)}
                         />
                         <br />
 
@@ -107,7 +103,7 @@ const TenHoursInPuerto = () => {
                     {/* Why Stay With Us Component - after main content, before OtherBlogs */}
                     <div style={{ maxWidth: 1000 }}>
                         <WhyStayWithUs
-                            language={lang}
+                            locale={locale}
                             ctaLink={homePath(locale)}
                         />
                     </div>
@@ -125,7 +121,7 @@ const TenHoursInPuerto = () => {
                         </div>
                     </div>
 
-                    <OtherBlogs currentBlog={selfId} blogs={locale === 'es' ? blogsES : blogs} />
+                    <OtherBlogs currentBlog="tenhoursinpuerto" locale={locale} />
                 </Col>
             </Row>
             <ContactUs />

--- a/src/pages/Blog/staticPages/TravellingToPuerto.tsx
+++ b/src/pages/Blog/staticPages/TravellingToPuerto.tsx
@@ -5,15 +5,14 @@ import '../../Listing/Listing.style.scss';
 
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import { Helmet } from "react-helmet";
-import { blogs, blogsES } from "../../../assets/blogs/blogs";
 import ContactUs from "../../../components/ContactUs/ContactUs.component";
 import OtherBlogs from "../Components/OtherBlogs.Component";
 import StayRecommendation from "../../../components/StayRecommendation/StayRecommendation.component";
 import WhyStayWithUs from "../../../components/WhyStayWithUs/WhyStayWithUs.component";
 import Smoobu2 from "../../../components/Smoobu2/Smoobu2.component";
-import { GENERAL_PUERTO_VIEJO_RECOMMENDATIONS, GENERAL_PUERTO_VIEJO_RECOMMENDATIONS_ES } from "../../../utils/constants";
+import { generalPuertoViejoRecommendations } from "../../../utils/constants";
 import { useLocale, useMessages } from "../../../i18n";
-import { localeSuffix, bookingLanguage, homePath } from "../../../i18n/paths";
+import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { travellingToPuertoContent } from "../../../i18n/content/blog";
 
@@ -24,8 +23,6 @@ const TravellingToPuerto = () => {
     const locale = useLocale();
     const m = useMessages();
     const content = travellingToPuertoContent(locale);
-    const lang = bookingLanguage(locale);
-    const selfId = `travellingtopuertoviejo${localeSuffix(locale)}`;
 
     useEffect(() => {
         window.scrollTo(0, 0);
@@ -90,8 +87,7 @@ const TravellingToPuerto = () => {
                         {/* Stay Recommendation Component - positioned in middle of article */}
                         <StayRecommendation
                             title={content.stayRecommendationTitle}
-                            properties={locale === 'es' ? GENERAL_PUERTO_VIEJO_RECOMMENDATIONS_ES : GENERAL_PUERTO_VIEJO_RECOMMENDATIONS}
-                            language={lang}
+                            properties={generalPuertoViejoRecommendations(locale)}
                         />
                         <br />
 
@@ -106,7 +102,7 @@ const TravellingToPuerto = () => {
                     {/* Why Stay With Us Component - after main content, before OtherBlogs */}
                     <div style={{ maxWidth: 1000 }}>
                         <WhyStayWithUs
-                            language={lang}
+                            locale={locale}
                             ctaLink={homePath(locale)}
                         />
                     </div>
@@ -119,7 +115,7 @@ const TravellingToPuerto = () => {
                         </div>
                     </div>
 
-                    <OtherBlogs currentBlog={selfId} blogs={locale === 'es' ? blogsES : blogs} />
+                    <OtherBlogs currentBlog="travellingtopuertoviejo" locale={locale} />
                 </Col>
             </Row>
             <ContactUs />

--- a/src/pages/Blog/staticPages/TwoDaysInPV.tsx
+++ b/src/pages/Blog/staticPages/TwoDaysInPV.tsx
@@ -5,15 +5,14 @@ import '../../Listing/Listing.style.scss';
 
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import OtherBlogs from "../Components/OtherBlogs.Component";
-import { PUERTO_VIEJO_BLOG_RECOMMENDATIONS, PUERTO_VIEJO_BLOG_RECOMMENDATIONS_ES } from "../../../utils/constants";
+import { puertoViejoBlogRecommendations } from "../../../utils/constants";
 import ContactUs from "../../../components/ContactUs/ContactUs.component";
 import { Helmet } from "react-helmet";
-import { blogs, blogsES } from "../../../assets/blogs/blogs";
 import Smoobu2 from "../../../components/Smoobu2/Smoobu2.component";
 import StayRecommendation from "../../../components/StayRecommendation/StayRecommendation.component";
 import WhyStayWithUs from "../../../components/WhyStayWithUs/WhyStayWithUs.component";
 import { useLocale, useMessages } from "../../../i18n";
-import { localeSuffix, bookingLanguage, homePath } from "../../../i18n/paths";
+import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { twoDaysInPVContent } from "../../../i18n/content/blog";
 
@@ -24,8 +23,6 @@ const TwoDaysInPV = () => {
     const locale = useLocale();
     const m = useMessages();
     const content = twoDaysInPVContent(locale);
-    const lang = bookingLanguage(locale);
-    const selfId = `twodaysinpuertoviejo${localeSuffix(locale)}`;
 
     useEffect(() => {
         window.scrollTo(0, 0);
@@ -85,8 +82,7 @@ const TwoDaysInPV = () => {
                         {/* Stay Recommendation Component - positioned in middle of article */}
                         <StayRecommendation
                             title={content.stayRecommendationTitle}
-                            properties={locale === 'es' ? PUERTO_VIEJO_BLOG_RECOMMENDATIONS_ES : PUERTO_VIEJO_BLOG_RECOMMENDATIONS}
-                            language={lang}
+                            properties={puertoViejoBlogRecommendations(locale)}
                         />
                         <br />
 
@@ -100,7 +96,7 @@ const TwoDaysInPV = () => {
                         {/* Why Stay With Us Component - after main content, before OtherBlogs */}
                         <div style={{ maxWidth: 1000 }}>
                             <WhyStayWithUs
-                                language={lang}
+                                locale={locale}
                                 ctaLink={homePath(locale)}
                             />
                         </div>
@@ -125,7 +121,7 @@ const TwoDaysInPV = () => {
                         </div>
                     </div>
 
-                    <OtherBlogs currentBlog={selfId} blogs={locale === 'es' ? blogsES : blogs} />
+                    <OtherBlogs currentBlog="twodaysinpuertoviejo" locale={locale} />
                 </Col>
             </Row>
             <ContactUs />

--- a/src/pages/Home/Home.page.tsx
+++ b/src/pages/Home/Home.page.tsx
@@ -62,7 +62,7 @@ const Home = () => {
       </Helmet>
       <WelcomeSlider />
       <FixedNavigation isBlog={false} />
-      <HelpMeChoose title={m.home.helpMeChooseTitle} titleHighlight={m.home.helpMeChooseTitleHighlight} options={helpMeChooseOptions} />
+      <HelpMeChoose title={m.home.helpMeChooseTitle} titleHighlight={m.home.helpMeChooseTitleHighlight} options={helpMeChooseOptions} locale={locale} />
       <HomeReviews locale={locale} />
       <OurHomes houseDataList={locale === 'es' ? houseDataList : houseDataEngList} />
       <OurOtherHomes />

--- a/src/pages/Listing/components/Amenities/Amenities.component.tsx
+++ b/src/pages/Listing/components/Amenities/Amenities.component.tsx
@@ -2,6 +2,7 @@ import React, { FC } from "react";
 import { AmenityType } from "../../../../utils/types";
 import AmenityIcon from "../../../../components/AmenityIcon/AmenityIcon.component";
 import { getCapacityFacts } from "../../../../utils/propertyCapacity";
+import { AMENITY_LABELS } from "../../../../i18n/amenityLabels";
 import './Amenities.style.scss'
 import type { Locale } from '../../../../i18n';
 
@@ -15,6 +16,11 @@ interface IAmenities {
 
 const Amenities: FC<IAmenities> = ({ amenities, propertyKey, locale = 'en' }) => {
     const capacityFacts = propertyKey ? getCapacityFacts(propertyKey, locale) : [];
+    // `name` here is already correctly localized for en/es (houseDataByLangCode
+    // resolves straight to the Spanish-suffixed entry) — only the six locales
+    // that fall back to the English entry need this table.
+    const translateName = (name: string) =>
+        (locale !== 'en' && locale !== 'es' ? AMENITY_LABELS[name]?.[locale] : undefined) ?? name;
 
     return (
         <div className="amenitiesCont d-flex justify-content-center">
@@ -32,7 +38,7 @@ const Amenities: FC<IAmenities> = ({ amenities, propertyKey, locale = 'en' }) =>
                     amenities.map(({ icon, name }) => {
                         return (
                             <div className="col" key={name}>
-                                <AmenityIcon icon={icon} name={name} />
+                                <AmenityIcon icon={icon} name={translateName(name)} />
                             </div>
                         );
                     })

--- a/src/pages/Listing/components/ImagesModal/ImagesModal.component.tsx
+++ b/src/pages/Listing/components/ImagesModal/ImagesModal.component.tsx
@@ -2,20 +2,17 @@ import React, { useCallback, useEffect, useState } from "react";
 import './ImagesModal.style.scss';
 import { getHouseImages } from "../../../../utils/houseImages";
 import ZoomableImage from "./ZoomableImage.component";
-import type { Locale } from '../../../../i18n';
+import { getMessages, type Locale } from '../../../../i18n';
 
 
 interface IIMagesModal {
   closeModal: () => void;
   houseName: string;
+  locale: Locale;
 }
 
-/** House codes carry their own language: "GecoES" is the Spanish listing. */
-const localeOfHouse = (houseName: string): Locale => (houseName.endsWith('ES') ? 'es' : 'en');
-
-const ImagesModal = ({ closeModal, houseName }: IIMagesModal) => {
+const ImagesModal = ({ closeModal, houseName, locale }: IIMagesModal) => {
   const images = getHouseImages(houseName);
-  const spanish = localeOfHouse(houseName) === 'es';
   const [viewerIndex, setViewerIndex] = useState<number | null>(null);
   const isViewerOpen = viewerIndex !== null;
 
@@ -56,9 +53,7 @@ const ImagesModal = ({ closeModal, houseName }: IIMagesModal) => {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [closeModal, closeViewer, isViewerOpen, step]);
 
-  const strings = spanish
-    ? { close: 'Cerrar', photos: 'fotos', previous: 'Anterior', next: 'Siguiente', empty: 'No hay fotos disponibles' }
-    : { close: 'Close', photos: 'photos', previous: 'Previous', next: 'Next', empty: 'No images available' };
+  const strings = getMessages(locale).imagesModal;
 
   return (
     <div className="imagesModal" role="dialog" aria-modal="true">

--- a/src/pages/Listing/components/ImagesModal/__tests__/ImagesModal.test.tsx
+++ b/src/pages/Listing/components/ImagesModal/__tests__/ImagesModal.test.tsx
@@ -21,8 +21,8 @@ describe('ImagesModal', () => {
     document.body.style.overflow = '';
   });
 
-  const openGrid = (houseName = 'Geco') =>
-    render(<ImagesModal closeModal={closeModal} houseName={houseName} />);
+  const openGrid = (houseName = 'Geco', locale: 'en' | 'es' = 'en') =>
+    render(<ImagesModal closeModal={closeModal} houseName={houseName} locale={locale} />);
 
   const thumbs = () => screen.getAllByRole('button', { name: /./ }).filter((b) => b.querySelector('img'));
 
@@ -99,7 +99,7 @@ describe('ImagesModal', () => {
   });
 
   test('labels controls in Spanish on the ES routes', () => {
-    openGrid('DelfinES');
+    openGrid('DelfinES', 'es');
 
     expect(
       screen.getByText(`${delfinImageDescriptionsES.length} fotos`)
@@ -108,7 +108,7 @@ describe('ImagesModal', () => {
   });
 
   test('renders a message instead of an empty grid for an unknown house', () => {
-    render(<ImagesModal closeModal={closeModal} houseName="NotAHouse" />);
+    render(<ImagesModal closeModal={closeModal} houseName="NotAHouse" locale="en" />);
 
     expect(screen.getByText('No images available')).toBeInTheDocument();
     expect(thumbs()).toHaveLength(0);

--- a/src/pages/Listing/staticPages/ListingAreka.page.tsx
+++ b/src/pages/Listing/staticPages/ListingAreka.page.tsx
@@ -121,7 +121,7 @@ const ListingAreka = () => {
             <div className="other-listings-bottom">
                 <OtherListings listings={NamSnippet} currentListing={listing || ''} />
             </div>
-            {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            {show && <ImagesModal closeModal={handleClose} houseName={listing!} locale={locale} />}
             <Footer locale={locale} />
 
         </div>

--- a/src/pages/Listing/staticPages/ListingDelfin.page.tsx
+++ b/src/pages/Listing/staticPages/ListingDelfin.page.tsx
@@ -122,7 +122,7 @@ const ListingDelfin = () => {
             <div className="other-listings-bottom">
                 <OtherListings listings={homesSnippet} currentListing={listing || ''} />
             </div>
-            {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            {show && <ImagesModal closeModal={handleClose} houseName={listing!} locale={locale} />}
             <Footer locale={locale} />
 
         </div>

--- a/src/pages/Listing/staticPages/ListingGeco.page.tsx
+++ b/src/pages/Listing/staticPages/ListingGeco.page.tsx
@@ -123,7 +123,7 @@ const ListingGeco = () => {
             <div className="other-listings-bottom">
                 <OtherListings listings={homesSnippet} currentListing={listing || ''} />
             </div>
-            {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            {show && <ImagesModal closeModal={handleClose} houseName={listing!} locale={locale} />}
             <Footer locale={locale} />
 
         </div>

--- a/src/pages/Listing/staticPages/ListingGiulia.page.tsx
+++ b/src/pages/Listing/staticPages/ListingGiulia.page.tsx
@@ -119,7 +119,7 @@ const ListingGiulia = () => {
             <div className="other-listings-bottom">
                 <OtherListings listings={NamSnippet} currentListing={listing || ''} />
             </div>
-            {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            {show && <ImagesModal closeModal={handleClose} houseName={listing!} locale={locale} />}
             <Footer locale={locale} />
 
         </div>

--- a/src/pages/Listing/staticPages/ListingPappagallo.page.tsx
+++ b/src/pages/Listing/staticPages/ListingPappagallo.page.tsx
@@ -120,7 +120,7 @@ const ListingPappagallo = () => {
             <div className="other-listings-bottom">
                 <OtherListings listings={homesSnippet} currentListing={listing || ''} />
             </div>
-            {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            {show && <ImagesModal closeModal={handleClose} houseName={listing!} locale={locale} />}
             <Footer locale={locale} />
 
         </div>

--- a/src/pages/Listing/staticPages/ListingPlumeria.page.tsx
+++ b/src/pages/Listing/staticPages/ListingPlumeria.page.tsx
@@ -119,7 +119,7 @@ const ListingPlumeria = () => {
             <div className="other-listings-bottom">
                 <OtherListings listings={NamSnippet} currentListing={listing || ''} />
             </div>
-            {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            {show && <ImagesModal closeModal={handleClose} houseName={listing!} locale={locale} />}
             <Footer locale={locale} />
 
         </div>

--- a/src/pages/Listing/staticPages/ListingRana.page.tsx
+++ b/src/pages/Listing/staticPages/ListingRana.page.tsx
@@ -121,7 +121,7 @@ const ListingRana = () => {
             <div className="other-listings-bottom">
                 <OtherListings listings={homesSnippet} currentListing={listing || ''} />
             </div>
-            {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            {show && <ImagesModal closeModal={handleClose} houseName={listing!} locale={locale} />}
             <Footer locale={locale} />
 
         </div>

--- a/src/pages/Listing/staticPages/ListingTucano.page.tsx
+++ b/src/pages/Listing/staticPages/ListingTucano.page.tsx
@@ -119,7 +119,7 @@ const ListingTucano = () => {
             <div className="other-listings-bottom">
                 <OtherListings listings={homesSnippet} currentListing={listing || ''} />
             </div>
-            {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            {show && <ImagesModal closeModal={handleClose} houseName={listing!} locale={locale} />}
             <Footer locale={locale} />
             
         </div>

--- a/src/pages/Listing/staticPages/ListingVillaCoral.page.tsx
+++ b/src/pages/Listing/staticPages/ListingVillaCoral.page.tsx
@@ -127,7 +127,7 @@ const ListingVillaCoral = () => {
             <div className="other-listings-bottom">
                 <OtherListings listings={VillaSnippet} currentListing={listing || ''} />
             </div>
-            {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            {show && <ImagesModal closeModal={handleClose} houseName={listing!} locale={locale} />}
             <Footer locale={locale} />
 
         </div>

--- a/src/pages/Listing/staticPages/ListingVillaMar.page.tsx
+++ b/src/pages/Listing/staticPages/ListingVillaMar.page.tsx
@@ -127,7 +127,7 @@ const ListingVillaMar = () => {
             <div className="other-listings-bottom">
                 <OtherListings listings={VillaSnippet} currentListing={listing || ''} />
             </div>
-            {show && <ImagesModal closeModal={handleClose} houseName={listing!} />}
+            {show && <ImagesModal closeModal={handleClose} houseName={listing!} locale={locale} />}
             <Footer locale={locale} />
 
         </div>

--- a/src/pages/NotFound.page.tsx
+++ b/src/pages/NotFound.page.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import { Link, useLocation } from 'react-router-dom';
-import { detectLocaleFromPath } from '../i18n';
+import { detectLocaleFromPath, getMessages } from '../i18n';
 import { pathForKey } from '../routes.config';
 
 /**
@@ -19,21 +19,10 @@ const NotFound = () => {
   const { pathname } = useLocation();
   const locale = detectLocaleFromPath(pathname);
 
-  const copy = (locale === 'es')
-    ? {
-        title: 'Página no encontrada | Reservas Kalawala',
-        heading: 'No encontramos esta página',
-        body: 'Es posible que el enlace esté roto o que la página se haya movido.',
-        cta: 'Volver al inicio',
-        home: pathForKey('home', locale),
-      }
-    : {
-        title: 'Page not found | Reservas Kalawala',
-        heading: 'We could not find that page',
-        body: 'The link may be broken, or the page may have moved.',
-        cta: 'Back to home',
-        home: pathForKey('home', locale),
-      };
+  const copy = {
+    ...getMessages(locale).notFound,
+    home: pathForKey('home', locale),
+  };
 
   return (
     <main className="container" style={{ padding: '120px 16px', textAlign: 'center' }}>

--- a/src/utils/__tests__/propertyMarketingConfig.test.ts
+++ b/src/utils/__tests__/propertyMarketingConfig.test.ts
@@ -37,7 +37,7 @@ describe('Property Marketing Configuration', () => {
     expect(typeof config.descriptiveTitle.en).toBe('string');
     expect(typeof config.descriptiveTitle.es).toBe('string');
     expect(config.descriptiveTitle.en.length).toBeGreaterThan(0);
-    expect(config.descriptiveTitle.es.length).toBeGreaterThan(0);
+    expect(config.descriptiveTitle.es!.length).toBeGreaterThan(0);
     
     // Verify price structure
     expect(config.price).toBeDefined();
@@ -55,7 +55,7 @@ describe('Property Marketing Configuration', () => {
     expect(typeof config.socialStatement.en).toBe('string');
     expect(typeof config.socialStatement.es).toBe('string');
     expect(config.socialStatement.en.length).toBeGreaterThan(0);
-    expect(config.socialStatement.es.length).toBeGreaterThan(0);
+    expect(config.socialStatement.es!.length).toBeGreaterThan(0);
     
     // Verify feature highlights structure
     expect(config.featureHighlights).toBeDefined();
@@ -64,7 +64,7 @@ describe('Property Marketing Configuration', () => {
     expect(Array.isArray(config.featureHighlights.en)).toBe(true);
     expect(Array.isArray(config.featureHighlights.es)).toBe(true);
     expect(config.featureHighlights.en.length).toBeGreaterThan(0);
-    expect(config.featureHighlights.es.length).toBeGreaterThan(0);
+    expect(config.featureHighlights.es!.length).toBeGreaterThan(0);
     
     // Verify each feature highlight contains an emoji
     config.featureHighlights.en.forEach((feature, index) => {
@@ -74,7 +74,7 @@ describe('Property Marketing Configuration', () => {
       expect(/[\u{1F300}-\u{1F9FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]/u.test(feature)).toBe(true);
     });
     
-    config.featureHighlights.es.forEach((feature, index) => {
+    config.featureHighlights.es!.forEach((feature, index) => {
       expect(typeof feature).toBe('string');
       expect(feature.length).toBeGreaterThan(0);
       // Check that feature contains at least one emoji (basic check for non-ASCII characters)

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,5 +1,6 @@
 import { HouseDataType, ListingType, PropertyCapacity, PropertyMarketingContent } from "./types";
-import { pathForKey, pathForLegacyId } from "../routes.config";
+import { pathForKey, type RouteKey } from "../routes.config";
+import { pickLocalized, type Locale, type LocalizedValue } from "../i18n";
 
 // Random popup configuration
 export const RANDOM_POPUP_CONFIG = {
@@ -2022,12 +2023,24 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
         propertyKey: 'Rana',
         descriptiveTitle: {
             en: 'Family home, pet friendly with air conditioning',
-            es: 'Casa familiar, pet friendly con aire acondicionado'
+            es: 'Casa familiar, pet friendly con aire acondicionado',
+            de: 'Familienhaus, haustierfreundlich mit Klimaanlage',
+            fr: 'Maison familiale, climatisée et adaptée aux animaux',
+            it: 'Casa familiare, pet friendly con aria condizionata',
+            pt: 'Casa familiar, aceita animais de estimação, com ar condicionado',
+            he: 'בית משפחתי, ידידותי לחיות מחמד עם מיזוג אוויר',
+            hi: 'पारिवारिक घर, एयर कंडीशनिंग के साथ पालतू-अनुकूल'
         },
         price: { crc: 80000, usd: 160 },
         socialStatement: {
             en: 'Chosen for its private internal parking and small garden for pets',
-            es: 'Elegida por su parqueo privado interno y pequeño jardín para las mascotas'
+            es: 'Elegida por su parqueo privado interno y pequeño jardín para las mascotas',
+            de: 'Ausgewählt wegen des privaten Innenparkplatzes und des kleinen Gartens für Haustiere',
+            fr: 'Choisie pour son parking privé intérieur et son petit jardin pour les animaux',
+            it: 'Scelta per il suo parcheggio interno privato e il piccolo giardino per gli animali',
+            pt: 'Escolhida pelo seu estacionamento interno privado e pequeno jardim para animais de estimação',
+            he: 'נבחר בזכות חניה פרטית פנימית וגינה קטנה לחיות מחמד',
+            hi: 'निजी आंतरिक पार्किंग और पालतू जानवरों के लिए छोटे बगीचे के कारण चुना गया'
         },
         featureHighlights: {
             en: [
@@ -2043,6 +2056,48 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
                 '❄️ A/C en habitaciones',
                 '💻 WiFi rápido ideal para trabajo remoto',
                 '🐾 Pet-friendly con espacio exterior'
+            ],
+            de: [
+                '📍 Fußläufige Lage im Zentrum von Puerto Viejo',
+                '🏡 Privater Bereich für bis zu 5 Personen',
+                '❄️ Klimaanlage in den Schlafzimmern',
+                '💻 Schnelles WLAN, ideal für Remote-Arbeit',
+                '🐾 Haustierfreundlich mit Außenbereich'
+            ],
+            fr: [
+                '📍 Emplacement accessible à pied dans le centre de Puerto Viejo',
+                '🏡 Espace privé pour jusqu\'à 5 personnes',
+                '❄️ Climatisation dans les chambres',
+                '💻 WiFi rapide, idéal pour le télétravail',
+                '🐾 Adapté aux animaux avec espace extérieur'
+            ],
+            it: [
+                '📍 Posizione raggiungibile a piedi nel centro di Puerto Viejo',
+                '🏡 Spazio privato per un massimo di 5 persone',
+                '❄️ Aria condizionata nelle camere',
+                '💻 WiFi veloce ideale per il lavoro da remoto',
+                '🐾 Pet friendly con spazio esterno'
+            ],
+            pt: [
+                '📍 Localização acessível a pé no centro de Puerto Viejo',
+                '🏡 Espaço privado para até 5 pessoas',
+                '❄️ Ar condicionado nos quartos',
+                '💻 Wi-Fi rápido, ideal para trabalho remoto',
+                '🐾 Aceita animais de estimação, com espaço exterior'
+            ],
+            he: [
+                '📍 מיקום נגיש ברגל במרכז פוארטו ויחו',
+                '🏡 מרחב פרטי לעד 5 אנשים',
+                '❄️ מיזוג אוויר בחדרי השינה',
+                '💻 WiFi מהיר, אידיאלי לעבודה מרחוק',
+                '🐾 ידידותי לחיות מחמד עם שטח חוץ'
+            ],
+            hi: [
+                '📍 डाउनटाउन Puerto Viejo में पैदल दूरी पर स्थान',
+                '🏡 5 लोगों तक के लिए निजी स्थान',
+                '❄️ बेडरूम में A/C',
+                '💻 रिमोट वर्क के लिए तेज़ वाई-फाई',
+                '🐾 बाहरी स्थान के साथ पालतू-अनुकूल'
             ]
         }
     },
@@ -2050,12 +2105,24 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
         propertyKey: 'Geco',
         descriptiveTitle: {
             en: 'Family home, pet friendly with air conditioning',
-            es: 'Casa familiar, pet friendly con aire acondicionado'
+            es: 'Casa familiar, pet friendly con aire acondicionado',
+            de: 'Familienhaus, haustierfreundlich mit Klimaanlage',
+            fr: 'Maison familiale, climatisée et adaptée aux animaux',
+            it: 'Casa familiare, pet friendly con aria condizionata',
+            pt: 'Casa familiar, aceita animais de estimação, com ar condicionado',
+            he: 'בית משפחתי, ידידותי לחיות מחמד עם מיזוג אוויר',
+            hi: 'पारिवारिक घर, एयर कंडीशनिंग के साथ पालतू-अनुकूल'
         },
         price: { crc: 80000, usd: 160 },
         socialStatement: {
             en: 'Chosen for its private internal parking and small garden for pets',
-            es: 'Elegida por su parqueo privado interno y pequeño jardín para las mascotas'
+            es: 'Elegida por su parqueo privado interno y pequeño jardín para las mascotas',
+            de: 'Ausgewählt wegen des privaten Innenparkplatzes und des kleinen Gartens für Haustiere',
+            fr: 'Choisie pour son parking privé intérieur et son petit jardin pour les animaux',
+            it: 'Scelta per il suo parcheggio interno privato e il piccolo giardino per gli animali',
+            pt: 'Escolhida pelo seu estacionamento interno privado e pequeno jardim para animais de estimação',
+            he: 'נבחר בזכות חניה פרטית פנימית וגינה קטנה לחיות מחמד',
+            hi: 'निजी आंतरिक पार्किंग और पालतू जानवरों के लिए छोटे बगीचे के कारण चुना गया'
         },
         featureHighlights: {
             en: [
@@ -2071,6 +2138,48 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
                 '❄️ A/C en habitaciones',
                 '💻 WiFi rápido ideal para trabajo remoto',
                 '🐾 Pet-friendly con espacio exterior'
+            ],
+            de: [
+                '📍 Fußläufige Lage im Zentrum von Puerto Viejo',
+                '🏡 Privater Bereich für bis zu 5 Personen',
+                '❄️ Klimaanlage in den Schlafzimmern',
+                '💻 Schnelles WLAN, ideal für Remote-Arbeit',
+                '🐾 Haustierfreundlich mit Außenbereich'
+            ],
+            fr: [
+                '📍 Emplacement accessible à pied dans le centre de Puerto Viejo',
+                '🏡 Espace privé pour jusqu\'à 5 personnes',
+                '❄️ Climatisation dans les chambres',
+                '💻 WiFi rapide, idéal pour le télétravail',
+                '🐾 Adapté aux animaux avec espace extérieur'
+            ],
+            it: [
+                '📍 Posizione raggiungibile a piedi nel centro di Puerto Viejo',
+                '🏡 Spazio privato per un massimo di 5 persone',
+                '❄️ Aria condizionata nelle camere',
+                '💻 WiFi veloce ideale per il lavoro da remoto',
+                '🐾 Pet friendly con spazio esterno'
+            ],
+            pt: [
+                '📍 Localização acessível a pé no centro de Puerto Viejo',
+                '🏡 Espaço privado para até 5 pessoas',
+                '❄️ Ar condicionado nos quartos',
+                '💻 Wi-Fi rápido, ideal para trabalho remoto',
+                '🐾 Aceita animais de estimação, com espaço exterior'
+            ],
+            he: [
+                '📍 מיקום נגיש ברגל במרכז פוארטו ויחו',
+                '🏡 מרחב פרטי לעד 5 אנשים',
+                '❄️ מיזוג אוויר בחדרי השינה',
+                '💻 WiFi מהיר, אידיאלי לעבודה מרחוק',
+                '🐾 ידידותי לחיות מחמד עם שטח חוץ'
+            ],
+            hi: [
+                '📍 डाउनटाउन Puerto Viejo में पैदल दूरी पर स्थान',
+                '🏡 5 लोगों तक के लिए निजी स्थान',
+                '❄️ बेडरूम में A/C',
+                '💻 रिमोट वर्क के लिए तेज़ वाई-फाई',
+                '🐾 बाहरी स्थान के साथ पालतू-अनुकूल'
             ]
         }
     },
@@ -2078,12 +2187,24 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
         propertyKey: 'Tucano',
         descriptiveTitle: {
             en: 'Central apartment above Italian bakery',
-            es: 'Apartamento céntrico sobre panadería italiana'
+            es: 'Apartamento céntrico sobre panadería italiana',
+            de: 'Zentral gelegenes Apartment über einer italienischen Bäckerei',
+            fr: 'Appartement central au-dessus d\'une boulangerie italienne',
+            it: 'Appartamento centrale sopra una panetteria italiana',
+            pt: 'Apartamento central por cima de uma padaria italiana',
+            he: 'דירה מרכזית מעל מאפייה איטלקית',
+            hi: 'इतालवी बेकरी के ऊपर केंद्रीय अपार्टमेंट'
         },
         price: { crc: 84000, usd: 169 },
         socialStatement: {
             en: 'Chosen for its central location perfect for bars and restaurants',
-            es: 'Elegida por su ubicación céntrica perfecta para bares y restaurantes'
+            es: 'Elegida por su ubicación céntrica perfecta para bares y restaurantes',
+            de: 'Ausgewählt wegen seiner zentralen Lage, perfekt für Bars und Restaurants',
+            fr: 'Choisi pour son emplacement central, parfait pour les bars et restaurants',
+            it: 'Scelto per la sua posizione centrale, perfetta per bar e ristoranti',
+            pt: 'Escolhido pela sua localização central, perfeita para bares e restaurantes',
+            he: 'נבחרה בזכות המיקום המרכזי, אידיאלי לברים ומסעדות',
+            hi: 'बार और रेस्तरां के लिए बिल्कुल सही केंद्रीय स्थान के कारण चुना गया'
         },
         featureHighlights: {
             en: [
@@ -2099,6 +2220,48 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
                 '❄️ A/C en habitaciones',
                 '💻 WiFi rápido ideal para trabajo remoto',
                 '🍞 15% descuento en panadería de abajo'
+            ],
+            de: [
+                '📍 Zentrale Lage über einer italienischen Bäckerei',
+                '🏡 Gemütliches Apartment für bis zu 5 Personen',
+                '❄️ Klimaanlage in den Schlafzimmern',
+                '💻 Schnelles WLAN, ideal für Remote-Arbeit',
+                '🍞 15 % Rabatt in der Bäckerei im Erdgeschoss'
+            ],
+            fr: [
+                '📍 Emplacement central au-dessus d\'une boulangerie italienne',
+                '🏡 Appartement chaleureux pour jusqu\'à 5 personnes',
+                '❄️ Climatisation dans les chambres',
+                '💻 WiFi rapide, idéal pour le télétravail',
+                '🍞 15 % de réduction à la boulangerie du rez-de-chaussée'
+            ],
+            it: [
+                '📍 Posizione centrale sopra una panetteria italiana',
+                '🏡 Appartamento accogliente per un massimo di 5 persone',
+                '❄️ Aria condizionata nelle camere',
+                '💻 WiFi veloce ideale per il lavoro da remoto',
+                '🍞 Sconto del 15% presso la panetteria al piano terra'
+            ],
+            pt: [
+                '📍 Localização central por cima de uma padaria italiana',
+                '🏡 Apartamento acolhedor para até 5 pessoas',
+                '❄️ Ar condicionado nos quartos',
+                '💻 Wi-Fi rápido, ideal para trabalho remoto',
+                '🍞 15% de desconto na padaria do rés do chão'
+            ],
+            he: [
+                '📍 מיקום מרכזי מעל מאפייה איטלקית',
+                '🏡 דירה נעימה לעד 5 אנשים',
+                '❄️ מיזוג אוויר בחדרי השינה',
+                '💻 WiFi מהיר, אידיאלי לעבודה מרחוק',
+                '🍞 הנחה של 15% במאפייה שבקומה התחתונה'
+            ],
+            hi: [
+                '📍 इतालवी बेकरी के ऊपर केंद्रीय स्थान',
+                '🏡 5 लोगों तक के लिए आरामदायक अपार्टमेंट',
+                '❄️ बेडरूम में A/C',
+                '💻 रिमोट वर्क के लिए तेज़ वाई-फाई',
+                '🍞 नीचे की बेकरी में 15% छूट'
             ]
         }
     },
@@ -2106,12 +2269,24 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
         propertyKey: 'Pappagallo',
         descriptiveTitle: {
             en: 'Central apartment above Italian bakery',
-            es: 'Apartamento céntrico sobre panadería italiana'
+            es: 'Apartamento céntrico sobre panadería italiana',
+            de: 'Zentral gelegenes Apartment über einer italienischen Bäckerei',
+            fr: 'Appartement central au-dessus d\'une boulangerie italienne',
+            it: 'Appartamento centrale sopra una panetteria italiana',
+            pt: 'Apartamento central por cima de uma padaria italiana',
+            he: 'דירה מרכזית מעל מאפייה איטלקית',
+            hi: 'इतालवी बेकरी के ऊपर केंद्रीय अपार्टमेंट'
         },
         price: { crc: 84000, usd: 169 },
         socialStatement: {
             en: 'Chosen for its central location perfect for bars and restaurants',
-            es: 'Elegida por su ubicación céntrica perfecta para bares y restaurantes'
+            es: 'Elegida por su ubicación céntrica perfecta para bares y restaurantes',
+            de: 'Ausgewählt wegen seiner zentralen Lage, perfekt für Bars und Restaurants',
+            fr: 'Choisi pour son emplacement central, parfait pour les bars et restaurants',
+            it: 'Scelto per la sua posizione centrale, perfetta per bar e ristoranti',
+            pt: 'Escolhido pela sua localização central, perfeita para bares e restaurantes',
+            he: 'נבחרה בזכות המיקום המרכזי, אידיאלי לברים ומסעדות',
+            hi: 'बार और रेस्तरां के लिए बिल्कुल सही केंद्रीय स्थान के कारण चुना गया'
         },
         featureHighlights: {
             en: [
@@ -2127,6 +2302,48 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
                 '❄️ A/C en habitaciones',
                 '💻 WiFi rápido ideal para trabajo remoto',
                 '🍞 15% descuento en panadería de abajo'
+            ],
+            de: [
+                '📍 Zentrale Lage über einer italienischen Bäckerei',
+                '🏡 Gemütliches Apartment für bis zu 5 Personen',
+                '❄️ Klimaanlage in den Schlafzimmern',
+                '💻 Schnelles WLAN, ideal für Remote-Arbeit',
+                '🍞 15 % Rabatt in der Bäckerei im Erdgeschoss'
+            ],
+            fr: [
+                '📍 Emplacement central au-dessus d\'une boulangerie italienne',
+                '🏡 Appartement chaleureux pour jusqu\'à 5 personnes',
+                '❄️ Climatisation dans les chambres',
+                '💻 WiFi rapide, idéal pour le télétravail',
+                '🍞 15 % de réduction à la boulangerie du rez-de-chaussée'
+            ],
+            it: [
+                '📍 Posizione centrale sopra una panetteria italiana',
+                '🏡 Appartamento accogliente per un massimo di 5 persone',
+                '❄️ Aria condizionata nelle camere',
+                '💻 WiFi veloce ideale per il lavoro da remoto',
+                '🍞 Sconto del 15% presso la panetteria al piano terra'
+            ],
+            pt: [
+                '📍 Localização central por cima de uma padaria italiana',
+                '🏡 Apartamento acolhedor para até 5 pessoas',
+                '❄️ Ar condicionado nos quartos',
+                '💻 Wi-Fi rápido, ideal para trabalho remoto',
+                '🍞 15% de desconto na padaria do rés do chão'
+            ],
+            he: [
+                '📍 מיקום מרכזי מעל מאפייה איטלקית',
+                '🏡 דירה נעימה לעד 5 אנשים',
+                '❄️ מיזוג אוויר בחדרי השינה',
+                '💻 WiFi מהיר, אידיאלי לעבודה מרחוק',
+                '🍞 הנחה של 15% במאפייה שבקומה התחתונה'
+            ],
+            hi: [
+                '📍 इतालवी बेकरी के ऊपर केंद्रीय स्थान',
+                '🏡 5 लोगों तक के लिए आरामदायक अपार्टमेंट',
+                '❄️ बेडरूम में A/C',
+                '💻 रिमोट वर्क के लिए तेज़ वाई-फाई',
+                '🍞 नीचे की बेकरी में 15% छूट'
             ]
         }
     },
@@ -2134,12 +2351,24 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
         propertyKey: 'VillaMar',
         descriptiveTitle: {
             en: 'Private villa with pool for couples',
-            es: 'Villa privada con piscina para parejas'
+            es: 'Villa privada con piscina para parejas',
+            de: 'Private Villa mit Pool für Paare',
+            fr: 'Villa privée avec piscine pour couples',
+            it: 'Villa privata con piscina per coppie',
+            pt: 'Vivenda privada com piscina para casais',
+            he: 'וילה פרטית עם בריכה לזוגות',
+            hi: 'जोड़ों के लिए स्विमिंग पूल वाला निजी विला'
         },
         price: { crc: 99000, usd: 199 },
         socialStatement: {
             en: 'Chosen for its private pool perfect for romantic getaways',
-            es: 'Elegida por su piscina privada perfecta para escapadas románticas'
+            es: 'Elegida por su piscina privada perfecta para escapadas románticas',
+            de: 'Ausgewählt wegen des privaten Pools, perfekt für romantische Kurzurlaube',
+            fr: 'Choisie pour sa piscine privée, parfaite pour les escapades romantiques',
+            it: 'Scelta per la sua piscina privata, perfetta per fughe romantiche',
+            pt: 'Escolhida pela sua piscina privada, perfeita para escapadinhas românticas',
+            he: 'נבחרה בזכות הבריכה הפרטית שלה, מושלמת לחופשות רומנטיות',
+            hi: 'रोमांटिक छुट्टियों के लिए बिल्कुल सही निजी स्विमिंग पूल के कारण चुना गया'
         },
         featureHighlights: {
             en: [
@@ -2155,6 +2384,48 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
                 '❄️ A/C completo en toda la villa',
                 '💻 WiFi rápido con espacio de trabajo dedicado',
                 '🏖️ Cerca de la hermosa Playa Chiquita'
+            ],
+            de: [
+                '🏊 Privater Pool exklusiv für Gäste',
+                '💑 Perfekt für Paare, die Privatsphäre suchen',
+                '❄️ Vollklimatisierung in der gesamten Villa',
+                '💻 Schnelles WLAN mit eigenem Arbeitsbereich',
+                '🏖️ In der Nähe des wunderschönen Playa Chiquita'
+            ],
+            fr: [
+                '🏊 Piscine privée exclusive aux hôtes',
+                '💑 Parfait pour les couples en quête d\'intimité',
+                '❄️ Climatisation complète dans toute la villa',
+                '💻 WiFi rapide avec espace de travail dédié',
+                '🏖️ Proche de la magnifique Playa Chiquita'
+            ],
+            it: [
+                '🏊 Piscina privata esclusiva per gli ospiti',
+                '💑 Perfetta per coppie in cerca di privacy',
+                '❄️ Aria condizionata in tutta la villa',
+                '💻 WiFi veloce con spazio di lavoro dedicato',
+                '🏖️ Vicino alla splendida Playa Chiquita'
+            ],
+            pt: [
+                '🏊 Piscina privada, exclusiva para os hóspedes',
+                '💑 Perfeita para casais que procuram privacidade',
+                '❄️ Ar condicionado em toda a vivenda',
+                '💻 Wi-Fi rápido com espaço de trabalho dedicado',
+                '🏖️ Perto da bela Playa Chiquita'
+            ],
+            he: [
+                '🏊 בריכה פרטית בלעדית לאורחים',
+                '💑 מושלם לזוגות המחפשים פרטיות',
+                '❄️ מיזוג אוויר מלא בכל רחבי הווילה',
+                '💻 WiFi מהיר עם פינת עבודה ייעודית',
+                '🏖️ קרוב לחוף היפהפה פלייה צ\'יקיטה'
+            ],
+            hi: [
+                '🏊 मेहमानों के लिए विशेष निजी स्विमिंग पूल',
+                '💑 गोपनीयता चाहने वाले जोड़ों के लिए बिल्कुल सही',
+                '❄️ पूरे विला में पूर्ण A/C',
+                '💻 समर्पित कार्यक्षेत्र के साथ तेज़ वाई-फाई',
+                '🏖️ खूबसूरत Playa Chiquita के करीब'
             ]
         }
     },
@@ -2162,12 +2433,24 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
         propertyKey: 'VillaCoral',
         descriptiveTitle: {
             en: 'Private villa with pool for couples',
-            es: 'Villa privada con piscina para parejas'
+            es: 'Villa privada con piscina para parejas',
+            de: 'Private Villa mit Pool für Paare',
+            fr: 'Villa privée avec piscine pour couples',
+            it: 'Villa privata con piscina per coppie',
+            pt: 'Vivenda privada com piscina para casais',
+            he: 'וילה פרטית עם בריכה לזוגות',
+            hi: 'जोड़ों के लिए स्विमिंग पूल वाला निजी विला'
         },
         price: { crc: 99000, usd: 199 },
         socialStatement: {
             en: 'Chosen for its private pool perfect for romantic getaways',
-            es: 'Elegida por su piscina privada perfecta para escapadas románticas'
+            es: 'Elegida por su piscina privada perfecta para escapadas románticas',
+            de: 'Ausgewählt wegen des privaten Pools, perfekt für romantische Kurzurlaube',
+            fr: 'Choisie pour sa piscine privée, parfaite pour les escapades romantiques',
+            it: 'Scelta per la sua piscina privata, perfetta per fughe romantiche',
+            pt: 'Escolhida pela sua piscina privada, perfeita para escapadinhas românticas',
+            he: 'נבחרה בזכות הבריכה הפרטית שלה, מושלמת לחופשות רומנטיות',
+            hi: 'रोमांटिक छुट्टियों के लिए बिल्कुल सही निजी स्विमिंग पूल के कारण चुना गया'
         },
         featureHighlights: {
             en: [
@@ -2183,6 +2466,48 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
                 '❄️ A/C completo en toda la villa',
                 '💻 WiFi rápido con espacio de trabajo dedicado',
                 '🏖️ Cerca de la hermosa Playa Chiquita'
+            ],
+            de: [
+                '🏊 Privater Pool exklusiv für Gäste',
+                '💑 Perfekt für Paare, die Privatsphäre suchen',
+                '❄️ Vollklimatisierung in der gesamten Villa',
+                '💻 Schnelles WLAN mit eigenem Arbeitsbereich',
+                '🏖️ In der Nähe des wunderschönen Playa Chiquita'
+            ],
+            fr: [
+                '🏊 Piscine privée exclusive aux hôtes',
+                '💑 Parfait pour les couples en quête d\'intimité',
+                '❄️ Climatisation complète dans toute la villa',
+                '💻 WiFi rapide avec espace de travail dédié',
+                '🏖️ Proche de la magnifique Playa Chiquita'
+            ],
+            it: [
+                '🏊 Piscina privata esclusiva per gli ospiti',
+                '💑 Perfetta per coppie in cerca di privacy',
+                '❄️ Aria condizionata in tutta la villa',
+                '💻 WiFi veloce con spazio di lavoro dedicato',
+                '🏖️ Vicino alla splendida Playa Chiquita'
+            ],
+            pt: [
+                '🏊 Piscina privada, exclusiva para os hóspedes',
+                '💑 Perfeita para casais que procuram privacidade',
+                '❄️ Ar condicionado em toda a vivenda',
+                '💻 Wi-Fi rápido com espaço de trabalho dedicado',
+                '🏖️ Perto da bela Playa Chiquita'
+            ],
+            he: [
+                '🏊 בריכה פרטית בלעדית לאורחים',
+                '💑 מושלם לזוגות המחפשים פרטיות',
+                '❄️ מיזוג אוויר מלא בכל רחבי הווילה',
+                '💻 WiFi מהיר עם פינת עבודה ייעודית',
+                '🏖️ קרוב לחוף היפהפה פלייה צ\'יקיטה'
+            ],
+            hi: [
+                '🏊 मेहमानों के लिए विशेष निजी स्विमिंग पूल',
+                '💑 गोपनीयता चाहने वाले जोड़ों के लिए बिल्कुल सही',
+                '❄️ पूरे विला में पूर्ण A/C',
+                '💻 समर्पित कार्यक्षेत्र के साथ तेज़ वाई-फाई',
+                '🏖️ खूबसूरत Playa Chiquita के करीब'
             ]
         }
     },
@@ -2190,12 +2515,24 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
         propertyKey: 'Areka',
         descriptiveTitle: {
             en: 'Cozy retreat perfect for couples exploring Punta Uva',
-            es: 'Refugio acogedor perfecto para parejas explorando Punta Uva'
+            es: 'Refugio acogedor perfecto para parejas explorando Punta Uva',
+            de: 'Gemütlicher Rückzugsort, perfekt für Paare, die Punta Uva erkunden',
+            fr: 'Refuge chaleureux, parfait pour les couples explorant Punta Uva',
+            it: 'Rifugio accogliente perfetto per coppie che esplorano Punta Uva',
+            pt: 'Retiro acolhedor, perfeito para casais que exploram Punta Uva',
+            he: 'מפלט נעים ומושלם לזוגות היוצאים לגלות את פונטה אובה',
+            hi: 'Punta Uva घूमने वाले जोड़ों के लिए बिल्कुल सही आरामदायक ठिकाना'
         },
         price: { crc: 49000, usd: 99 },
         socialStatement: {
             en: 'Chosen for its peaceful location',
-            es: 'Elegida por su ubicación tranquila'
+            es: 'Elegida por su ubicación tranquila',
+            de: 'Ausgewählt wegen seiner ruhigen Lage',
+            fr: 'Choisi pour son emplacement paisible',
+            it: 'Scelto per la sua posizione tranquilla',
+            pt: 'Escolhido pela sua localização tranquila',
+            he: 'נבחר בזכות מיקומו השקט',
+            hi: 'इसके शांत स्थान के कारण चुना गया'
         },
         featureHighlights: {
             en: [
@@ -2211,6 +2548,48 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
                 '❄️ A/C para noches cómodas',
                 '💻 WiFi para mantenerse conectado',
                 '🚗 Parqueo privado externo disponible'
+            ],
+            de: [
+                '🏖️ 2 Minuten mit dem Auto vom Strand Punta Uva entfernt',
+                '💑 Intimer Raum, perfekt für Paare',
+                '❄️ Klimaanlage für angenehme Nächte',
+                '💻 WLAN, um in Verbindung zu bleiben',
+                '🚗 Privater Außenparkplatz vorhanden'
+            ],
+            fr: [
+                '🏖️ À 2 minutes en voiture de la plage de Punta Uva',
+                '💑 Espace intime parfait pour les couples',
+                '❄️ Climatisation pour des nuits confortables',
+                '💻 WiFi pour rester connecté',
+                '🚗 Parking privé extérieur disponible'
+            ],
+            it: [
+                '🏖️ A 2 minuti in auto dalla spiaggia di Punta Uva',
+                '💑 Spazio intimo perfetto per coppie',
+                '❄️ Aria condizionata per notti confortevoli',
+                '💻 WiFi per restare connessi',
+                '🚗 Parcheggio privato esterno disponibile'
+            ],
+            pt: [
+                '🏖️ A 2 minutos de carro da praia de Punta Uva',
+                '💑 Espaço íntimo, perfeito para casais',
+                '❄️ Ar condicionado para noites confortáveis',
+                '💻 Wi-Fi para se manter ligado',
+                '🚗 Estacionamento privado exterior disponível'
+            ],
+            he: [
+                '🏖️ נסיעה של 2 דקות מחוף פונטה אובה',
+                '💑 מרחב אינטימי ומושלם לזוגות',
+                '❄️ מיזוג אוויר ללילות נעימים',
+                '💻 WiFi להישארות מחוברים',
+                '🚗 חניה פרטית בחוץ זמינה'
+            ],
+            hi: [
+                '🏖️ Punta Uva समुद्र तट से 2 मिनट की ड्राइव',
+                '💑 जोड़ों के लिए बिल्कुल सही अंतरंग स्थान',
+                '❄️ आरामदायक रातों के लिए A/C',
+                '💻 जुड़े रहने के लिए वाई-फाई',
+                '🚗 बाहरी निजी पार्किंग उपलब्ध'
             ]
         }
     },
@@ -2218,12 +2597,24 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
         propertyKey: 'Plumeria',
         descriptiveTitle: {
             en: 'Cozy retreat perfect for couples exploring Punta Uva',
-            es: 'Refugio acogedor perfecto para parejas explorando Punta Uva'
+            es: 'Refugio acogedor perfecto para parejas explorando Punta Uva',
+            de: 'Gemütlicher Rückzugsort, perfekt für Paare, die Punta Uva erkunden',
+            fr: 'Refuge chaleureux, parfait pour les couples explorant Punta Uva',
+            it: 'Rifugio accogliente perfetto per coppie che esplorano Punta Uva',
+            pt: 'Retiro acolhedor, perfeito para casais que exploram Punta Uva',
+            he: 'מפלט נעים ומושלם לזוגות היוצאים לגלות את פונטה אובה',
+            hi: 'Punta Uva घूमने वाले जोड़ों के लिए बिल्कुल सही आरामदायक ठिकाना'
         },
         price: { crc: 49000, usd: 99 },
         socialStatement: {
             en: 'Chosen for its peaceful location',
-            es: 'Elegida por su ubicación tranquila'
+            es: 'Elegida por su ubicación tranquila',
+            de: 'Ausgewählt wegen seiner ruhigen Lage',
+            fr: 'Choisi pour son emplacement paisible',
+            it: 'Scelto per la sua posizione tranquilla',
+            pt: 'Escolhido pela sua localização tranquila',
+            he: 'נבחר בזכות מיקומו השקט',
+            hi: 'इसके शांत स्थान के कारण चुना गया'
         },
         featureHighlights: {
             en: [
@@ -2239,6 +2630,48 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
                 '❄️ A/C para noches cómodas',
                 '💻 WiFi para mantenerse conectado',
                 '🚗 Parqueo privado externo disponible'
+            ],
+            de: [
+                '🏖️ 2 Minuten mit dem Auto vom Strand Punta Uva entfernt',
+                '💑 Intimer Raum, perfekt für Paare',
+                '❄️ Klimaanlage für angenehme Nächte',
+                '💻 WLAN, um in Verbindung zu bleiben',
+                '🚗 Privater Außenparkplatz vorhanden'
+            ],
+            fr: [
+                '🏖️ À 2 minutes en voiture de la plage de Punta Uva',
+                '💑 Espace intime parfait pour les couples',
+                '❄️ Climatisation pour des nuits confortables',
+                '💻 WiFi pour rester connecté',
+                '🚗 Parking privé extérieur disponible'
+            ],
+            it: [
+                '🏖️ A 2 minuti in auto dalla spiaggia di Punta Uva',
+                '💑 Spazio intimo perfetto per coppie',
+                '❄️ Aria condizionata per notti confortevoli',
+                '💻 WiFi per restare connessi',
+                '🚗 Parcheggio privato esterno disponibile'
+            ],
+            pt: [
+                '🏖️ A 2 minutos de carro da praia de Punta Uva',
+                '💑 Espaço íntimo, perfeito para casais',
+                '❄️ Ar condicionado para noites confortáveis',
+                '💻 Wi-Fi para se manter ligado',
+                '🚗 Estacionamento privado exterior disponível'
+            ],
+            he: [
+                '🏖️ נסיעה של 2 דקות מחוף פונטה אובה',
+                '💑 מרחב אינטימי ומושלם לזוגות',
+                '❄️ מיזוג אוויר ללילות נעימים',
+                '💻 WiFi להישארות מחוברים',
+                '🚗 חניה פרטית בחוץ זמינה'
+            ],
+            hi: [
+                '🏖️ Punta Uva समुद्र तट से 2 मिनट की ड्राइव',
+                '💑 जोड़ों के लिए बिल्कुल सही अंतरंग स्थान',
+                '❄️ आरामदायक रातों के लिए A/C',
+                '💻 जुड़े रहने के लिए वाई-फाई',
+                '🚗 बाहरी निजी पार्किंग उपलब्ध'
             ]
         }
     },
@@ -2246,12 +2679,24 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
         propertyKey: 'Giulia',
         descriptiveTitle: {
             en: 'Family-friendly house near Punta Uva',
-            es: 'Casa familiar cerca de Punta Uva'
+            es: 'Casa familiar cerca de Punta Uva',
+            de: 'Familienfreundliches Haus in der Nähe von Punta Uva',
+            fr: 'Maison familiale près de Punta Uva',
+            it: 'Casa adatta alle famiglie vicino a Punta Uva',
+            pt: 'Casa familiar perto de Punta Uva',
+            he: 'בית ידידותי למשפחות ליד פונטה אובה',
+            hi: 'Punta Uva के पास पारिवारिक-अनुकूल घर'
         },
         price: { crc: 84000, usd: 169 },
         socialStatement: {
             en: 'Chosen for its family-friendly amenities and beach proximity',
-            es: 'Elegida por sus comodidades familiares y proximidad a la playa'
+            es: 'Elegida por sus comodidades familiares y proximidad a la playa',
+            de: 'Ausgewählt wegen der familienfreundlichen Ausstattung und der Strandnähe',
+            fr: 'Choisie pour ses équipements adaptés aux familles et sa proximité avec la plage',
+            it: 'Scelta per i suoi servizi adatti alle famiglie e la vicinanza alla spiaggia',
+            pt: 'Escolhida pelas suas comodidades familiares e proximidade à praia',
+            he: 'נבחר בזכות המתקנים הידידותיים למשפחות והקרבה לחוף',
+            hi: 'इसकी पारिवारिक-अनुकूल सुविधाओं और समुद्र तट की निकटता के कारण चुना गया'
         },
         featureHighlights: {
             en: [
@@ -2267,6 +2712,48 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
                 '❄️ A/C en habitaciones para comodidad',
                 '💻 WiFi rápido para trabajo remoto',
                 '🚗 Espacio de parqueo disponible'
+            ],
+            de: [
+                '👨‍👩‍👧‍👦 Perfekt für Familien mit Kindern',
+                '🏖️ Fußläufig zum Strand Playa Chiquita',
+                '❄️ Klimaanlage in den Schlafzimmern für mehr Komfort',
+                '💻 Schnelles WLAN für Remote-Arbeit',
+                '🚗 Parkplatz vorhanden'
+            ],
+            fr: [
+                '👨‍👩‍👧‍👦 Parfait pour les familles avec enfants',
+                '🏖️ À quelques pas de la plage de Playa Chiquita',
+                '❄️ Climatisation dans les chambres pour plus de confort',
+                '💻 WiFi rapide pour le télétravail',
+                '🚗 Place de parking disponible'
+            ],
+            it: [
+                '👨‍👩‍👧‍👦 Perfetta per famiglie con bambini',
+                '🏖️ A pochi passi dalla spiaggia di Playa Chiquita',
+                '❄️ Aria condizionata nelle camere per il massimo comfort',
+                '💻 WiFi veloce per il lavoro da remoto',
+                '🚗 Posto auto disponibile'
+            ],
+            pt: [
+                '👨‍👩‍👧‍👦 Perfeita para famílias com crianças',
+                '🏖️ A pé da praia de Playa Chiquita',
+                '❄️ Ar condicionado nos quartos para maior conforto',
+                '💻 Wi-Fi rápido para trabalho remoto',
+                '🚗 Lugar de estacionamento disponível'
+            ],
+            he: [
+                '👨‍👩‍👧‍👦 מושלם למשפחות עם ילדים',
+                '🏖️ במרחק הליכה מחוף פלייה צ\'יקיטה',
+                '❄️ מיזוג אוויר בחדרי השינה לנוחות מרבית',
+                '💻 WiFi מהיר לעבודה מרחוק',
+                '🚗 מקום חניה זמין'
+            ],
+            hi: [
+                '👨‍👩‍👧‍👦 बच्चों वाले परिवारों के लिए बिल्कुल सही',
+                '🏖️ Playa Chiquita समुद्र तट से पैदल दूरी पर',
+                '❄️ आराम के लिए बेडरूम में A/C',
+                '💻 रिमोट वर्क के लिए तेज़ वाई-फाई',
+                '🚗 पार्किंग स्थान उपलब्ध'
             ]
         }
     },
@@ -2274,12 +2761,24 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
         propertyKey: 'Delfin',
         descriptiveTitle: {
             en: 'Spacious house perfect for large families',
-            es: 'Casa espaciosa perfecta para familias grandes'
+            es: 'Casa espaciosa perfecta para familias grandes',
+            de: 'Geräumiges Haus, perfekt für große Familien',
+            fr: 'Grande maison parfaite pour les familles nombreuses',
+            it: 'Casa spaziosa perfetta per famiglie numerose',
+            pt: 'Casa espaçosa, perfeita para famílias grandes',
+            he: 'בית מרווח ומושלם למשפחות גדולות',
+            hi: 'बड़े परिवारों के लिए बिल्कुल सही विशाल घर'
         },
         price: { crc: 99000, usd: 199 },
         socialStatement: {
             en: 'Chosen for its spacious layout accommodating up to 6 guests',
-            es: 'Elegida por su diseño espacioso que acomoda hasta 6 huéspedes'
+            es: 'Elegida por su diseño espacioso que acomoda hasta 6 huéspedes',
+            de: 'Ausgewählt wegen des großzügigen Grundrisses für bis zu 6 Gäste',
+            fr: 'Choisie pour son espace généreux pouvant accueillir jusqu\'à 6 personnes',
+            it: 'Scelta per i suoi ampi spazi che ospitano fino a 6 persone',
+            pt: 'Escolhida pela sua disposição espaçosa, com capacidade para até 6 hóspedes',
+            he: 'נבחר בזכות התכנון המרווח המתאים עד 6 אורחים',
+            hi: '6 मेहमानों तक की क्षमता वाले विशाल लेआउट के कारण चुना गया'
         },
         featureHighlights: {
             en: [
@@ -2295,6 +2794,48 @@ export const PROPERTY_MARKETING_CONFIG: Record<string, PropertyMarketingContent>
                 '❄️ A/C en todas las habitaciones',
                 '💻 WiFi rápido en toda la casa',
                 '🚗 Parqueo privado cercado para 2 vehículos'
+            ],
+            de: [
+                '👨‍👩‍👧‍👦 Geräumig für bis zu 6 Personen',
+                '🏡 Zwei Badezimmer für mehr Komfort',
+                '❄️ Klimaanlage in allen Schlafzimmern',
+                '💻 Schnelles WLAN im ganzen Haus',
+                '🚗 Privater umzäunter Parkplatz für 2 Fahrzeuge'
+            ],
+            fr: [
+                '👨‍👩‍👧‍👦 Spacieuse pour jusqu\'à 6 personnes',
+                '🏡 Deux salles de bain pour plus de confort',
+                '❄️ Climatisation dans toutes les chambres',
+                '💻 WiFi rapide dans toute la maison',
+                '🚗 Parking privé clôturé pour 2 véhicules'
+            ],
+            it: [
+                '👨‍👩‍👧‍👦 Spaziosa per un massimo di 6 persone',
+                '🏡 Due bagni per maggiore comodità',
+                '❄️ Aria condizionata in tutte le camere',
+                '💻 WiFi veloce in tutta la casa',
+                '🚗 Parcheggio privato recintato per 2 veicoli'
+            ],
+            pt: [
+                '👨‍👩‍👧‍👦 Espaçosa para até 6 pessoas',
+                '🏡 Duas casas de banho para maior comodidade',
+                '❄️ Ar condicionado em todos os quartos',
+                '💻 Wi-Fi rápido em toda a casa',
+                '🚗 Estacionamento privado vedado para 2 veículos'
+            ],
+            he: [
+                '👨‍👩‍👧‍👦 מרווח לעד 6 אנשים',
+                '🏡 שני חדרי אמבטיה לנוחות',
+                '❄️ מיזוג אוויר בכל חדרי השינה',
+                '💻 WiFi מהיר בכל רחבי הבית',
+                '🚗 חניה פרטית גדורה ל-2 רכבים'
+            ],
+            hi: [
+                '👨‍👩‍👧‍👦 6 लोगों तक के लिए विशाल',
+                '🏡 सुविधा के लिए दो बाथरूम',
+                '❄️ सभी बेडरूम में A/C',
+                '💻 पूरे घर में तेज़ वाई-फाई',
+                '🚗 2 वाहनों के लिए निजी घिरी हुई पार्किंग'
             ]
         }
     }
@@ -2308,155 +2849,104 @@ export interface PropertyRecommendation {
   houseCode?: number;
 }
 
-// Found while merging Phase 3c (blog): this constant's `reason` text was
-// Spanish while its links were unsuffixed (English-style), and TwoDaysInPV.tsx
-// renders it on the *English* page — visitors were reading Spanish
-// recommendation copy under an English article. Translated to English here;
-// PUERTO_VIEJO_BLOG_RECOMMENDATIONS_ES below is the real Spanish counterpart
-// (ES-suffixed links) and was already correct.
-//
-// PHASE 4: `link` fields compute from routes.config.ts via pathForLegacyId
-// instead of hardcoding the pre-restructure `/Geco`-style paths — this file
-// is a plain-string sweep away from every other internal-link call site (the
-// `link: '/...'` fields here are single-quoted; the sweep that caught the
-// rest of the codebase's hardcoded paths only searched double-quoted
-// strings), so StayRecommendation's rendered hrefs would otherwise have kept
-// pointing at pre-Phase-4 URLs.
-export const PUERTO_VIEJO_BLOG_RECOMMENDATIONS: PropertyRecommendation[] = [
-  {
-    name: 'Casa Geco',
-    reason: 'Ideal for getting around on foot',
-    link: pathForLegacyId('Geco'),
-    houseCode: 1
+// Each `reason` phrase translated into all 8 locales, keyed by its exact
+// English source string. Was three EN consts plus three separately
+// hand-maintained _ES consts (PHASE 3c) — that pattern has no room for six
+// more languages, so this is now three `(locale) => PropertyRecommendation[]`
+// functions sharing one translation table instead. `link` now goes through
+// `pathForKey` directly (every locale), not `pathForLegacyId` (English/Spanish
+// only, by construction — see its own doc comment in routes.config.ts).
+const RECOMMENDATION_REASONS: Record<string, LocalizedValue<string>> = {
+  'Ideal for getting around on foot': {
+    en: 'Ideal for getting around on foot', es: 'Ideal si quieres moverte caminando',
+    de: 'Ideal, um zu Fuß unterwegs zu sein', fr: 'Idéal pour se déplacer à pied',
+    it: 'Ideale per spostarsi a piedi', pt: 'Ideal para se deslocar a pé',
+    he: 'אידיאלי להתניידות ברגל', hi: 'पैदल घूमने के लिए आदर्श',
   },
-  {
-    name: 'Casa Plumeria',
-    reason: 'Perfect for relaxing near the beach',
-    link: pathForLegacyId('Plumeria'),
-    houseCode: 8
+  'Perfect for relaxing near the beach': {
+    en: 'Perfect for relaxing near the beach', es: 'Perfecta para descansar cerca de la playa',
+    de: 'Perfekt zum Entspannen in Strandnähe', fr: 'Parfait pour se détendre près de la plage',
+    it: 'Perfetta per rilassarsi vicino alla spiaggia', pt: 'Perfeita para relaxar perto da praia',
+    he: 'מושלם למנוחה ליד החוף', hi: 'समुद्र तट के पास आराम करने के लिए एकदम सही',
   },
-  {
-    name: 'Villa Coral',
-    reason: 'Great for a short getaway with a private pool',
-    link: pathForLegacyId('VillaCoral'),
-    houseCode: 6
-  }
-];
+  'Great for a short getaway with a private pool': {
+    en: 'Great for a short getaway with a private pool', es: 'Si buscas una escapada corta con piscina privada',
+    de: 'Toll für einen Kurzurlaub mit Privatpool', fr: 'Idéal pour une courte escapade avec piscine privée',
+    it: 'Ottima per una breve fuga con piscina privata', pt: 'Ótima para uma escapadela curta com piscina privada',
+    he: 'מצוין לחופשה קצרה עם בריכה פרטית', hi: 'निजी पूल के साथ छोटी छुट्टी के लिए बढ़िया',
+  },
+  'Perfect for exploring on foot': {
+    en: 'Perfect for exploring on foot', es: 'Perfecta para explorar a pie',
+    de: 'Perfekt, um zu Fuß zu erkunden', fr: 'Parfait pour explorer à pied',
+    it: 'Perfetta per esplorare a piedi', pt: 'Perfeita para explorar a pé',
+    he: 'מושלם לחקירה ברגל', hi: 'पैदल घूमने के लिए बिल्कुल सही',
+  },
+  'Ideal for beach relaxation': {
+    en: 'Ideal for beach relaxation', es: 'Ideal para relajarte cerca de la playa',
+    de: 'Ideal zum Entspannen am Strand', fr: 'Idéal pour se détendre à la plage',
+    it: 'Ideale per rilassarsi in spiaggia', pt: 'Ideal para relaxar na praia',
+    he: 'אידיאלי למנוחה בחוף הים', hi: 'समुद्र तट पर आराम के लिए आदर्श',
+  },
+  'Great for short getaways with private pool': {
+    en: 'Great for short getaways with private pool', es: 'Excelente para escapadas cortas con piscina privada',
+    de: 'Toll für Kurzurlaube mit Privatpool', fr: "Idéal pour de courtes escapades avec piscine privée",
+    it: 'Ottima per brevi fughe con piscina privata', pt: 'Ótima para escapadelas curtas com piscina privada',
+    he: 'מצוין לחופשות קצרות עם בריכה פרטית', hi: 'निजी पूल के साथ छोटी छुट्टियों के लिए बढ़िया',
+  },
+  'Perfect Retreat for Couples': {
+    en: 'Perfect Retreat for Couples', es: 'Retiro Perfecto para Parejas',
+    de: 'Perfekter Rückzugsort für Paare', fr: 'Retraite parfaite pour les couples',
+    it: 'Rifugio perfetto per coppie', pt: 'Refúgio perfeito para casais',
+    he: 'מפלט מושלם לזוגות', hi: 'जोड़ों के लिए बेहतरीन ठिकाना',
+  },
+  'Easy access to transportation': {
+    en: 'Easy access to transportation', es: 'Fácil acceso al transporte',
+    de: 'Einfacher Zugang zu Transportmitteln', fr: 'Accès facile aux transports',
+    it: 'Facile accesso ai trasporti', pt: 'Fácil acesso a transportes',
+    he: 'גישה נוחה לתחבורה', hi: 'परिवहन तक आसान पहुंच',
+  },
+  'Perfect for relaxing after park visits': {
+    en: 'Perfect for relaxing after park visits', es: 'Perfecta para relajarte después de visitar el parque',
+    de: 'Perfekt zum Entspannen nach einem Parkbesuch', fr: 'Parfait pour se détendre après la visite du parc',
+    it: 'Perfetta per rilassarsi dopo la visita al parco', pt: 'Perfeita para relaxar depois de visitar o parque',
+    he: 'מושלם למנוחה אחרי ביקור בפארק', hi: 'पार्क घूमने के बाद आराम के लिए बिल्कुल सही',
+  },
+};
+
+function withReason(name: string, reasonEn: string, routeKey: RouteKey, houseCode: number) {
+  return (locale: Locale): PropertyRecommendation => ({
+    name,
+    reason: pickLocalized(RECOMMENDATION_REASONS[reasonEn], locale),
+    link: pathForKey(routeKey, locale),
+    houseCode,
+  });
+}
+
+export function puertoViejoBlogRecommendations(locale: Locale): PropertyRecommendation[] {
+  return [
+    withReason('Casa Geco', 'Ideal for getting around on foot', 'geco', 1)(locale),
+    withReason('Casa Plumeria', 'Perfect for relaxing near the beach', 'plumeria', 8)(locale),
+    withReason('Villa Coral', 'Great for a short getaway with a private pool', 'villacoral', 6)(locale),
+  ];
+}
 
 // General Puerto Viejo area recommendations for travel-focused blogs
-export const GENERAL_PUERTO_VIEJO_RECOMMENDATIONS: PropertyRecommendation[] = [
-  {
-    name: 'Casa Geco',
-    reason: 'Perfect for exploring on foot',
-    link: pathForLegacyId('Geco'),
-    houseCode: 1
-  },
-  {
-    name: 'Casa Plumeria',
-    reason: 'Ideal for beach relaxation',
-    link: pathForLegacyId('Plumeria'),
-    houseCode: 8
-  },
-  {
-    name: 'Villa Coral',
-    reason: 'Great for short getaways with private pool',
-    link: pathForLegacyId('VillaCoral'),
-    houseCode: 6
-  }
-];
-
-// Spanish counterpart of GENERAL_PUERTO_VIEJO_RECOMMENDATIONS. Did not exist
-// before Phase 3c — every Spanish page whose English twin used the general set
-// was falling back to PUERTO_VIEJO_BLOG_RECOMMENDATIONS_ES instead (or, on
-// BestTimeToVisitPuertoES/PuertoHiddenGemsES, rendering the raw English array).
-export const GENERAL_PUERTO_VIEJO_RECOMMENDATIONS_ES: PropertyRecommendation[] = [
-  {
-    name: 'Casa Geco',
-    reason: 'Perfecta para explorar a pie',
-    link: pathForLegacyId('GecoES'),
-    houseCode: 1
-  },
-  {
-    name: 'Casa Plumeria',
-    reason: 'Ideal para relajarte cerca de la playa',
-    link: pathForLegacyId('PlumeriaES'),
-    houseCode: 8
-  },
-  {
-    name: 'Villa Coral',
-    reason: 'Excelente para escapadas cortas con piscina privada',
-    link: pathForLegacyId('VillaCoralES'),
-    houseCode: 6
-  }
-];
+export function generalPuertoViejoRecommendations(locale: Locale): PropertyRecommendation[] {
+  return [
+    withReason('Casa Geco', 'Perfect for exploring on foot', 'geco', 1)(locale),
+    withReason('Casa Plumeria', 'Ideal for beach relaxation', 'plumeria', 8)(locale),
+    withReason('Villa Coral', 'Great for short getaways with private pool', 'villacoral', 6)(locale),
+  ];
+}
 
 // Cahuita-focused recommendations
-export const CAHUITA_AREA_RECOMMENDATIONS: PropertyRecommendation[] = [
-  {
-    name: 'Casa Plumeria',
-    reason: 'Perfect Retreat for Couples',
-    link: pathForLegacyId('Plumeria'),
-    houseCode: 8
-  },
-  {
-    name: 'Casa Geco',
-    reason: 'Easy access to transportation',
-    link: pathForLegacyId('Geco'),
-    houseCode: 1
-  },
-  {
-    name: 'Villa Coral',
-    reason: 'Perfect for relaxing after park visits',
-    link: pathForLegacyId('VillaCoral'),
-    houseCode: 6
-  }
-];
-
-// Spanish counterpart of CAHUITA_AREA_RECOMMENDATIONS. Did not exist before
-// Phase 3c — TenHoursInPuertoES's "¿Dónde hospedarte cuando explores Cahuita?"
-// heading was followed by the generic Puerto Viejo list, not a Cahuita one.
-export const CAHUITA_AREA_RECOMMENDATIONS_ES: PropertyRecommendation[] = [
-  {
-    name: 'Casa Plumeria',
-    reason: 'Retiro Perfecto para Parejas',
-    link: pathForLegacyId('PlumeriaES'),
-    houseCode: 8
-  },
-  {
-    name: 'Casa Geco',
-    reason: 'Fácil acceso al transporte',
-    link: pathForLegacyId('GecoES'),
-    houseCode: 1
-  },
-  {
-    name: 'Villa Coral',
-    reason: 'Perfecta para relajarte después de visitar el parque',
-    link: pathForLegacyId('VillaCoralES'),
-    houseCode: 6
-  }
-];
-
-// Spanish versions for ES blog pages
-export const PUERTO_VIEJO_BLOG_RECOMMENDATIONS_ES: PropertyRecommendation[] = [
-  {
-    name: 'Casa Geco',
-    reason: 'Ideal si quieres moverte caminando',
-    link: pathForLegacyId('GecoES'),
-    houseCode: 1
-  },
-  {
-    name: 'Casa Plumeria',
-    reason: 'Perfecta para descansar cerca de la playa',
-    link: pathForLegacyId('PlumeriaES'),
-    houseCode: 8
-  },
-  {
-    name: 'Villa Coral',
-    reason: 'Si buscas una escapada corta con piscina privada',
-    link: pathForLegacyId('VillaCoralES'),
-    houseCode: 6
-  }
-];
+export function cahuitaAreaRecommendations(locale: Locale): PropertyRecommendation[] {
+  return [
+    withReason('Casa Plumeria', 'Perfect Retreat for Couples', 'plumeria', 8)(locale),
+    withReason('Casa Geco', 'Easy access to transportation', 'geco', 1)(locale),
+    withReason('Villa Coral', 'Perfect for relaxing after park visits', 'villacoral', 6)(locale),
+  ];
+}
 /**
  * Largest party any single property can host. Derived from the house data so a
  * capacity change in one place is enough — the booking search widget uses this
@@ -2488,34 +2978,27 @@ export const PORTFOLIO_GUEST_RANGE: { min: number; max: number } = CAPACITY_VALU
 
 export interface BlogArticle {
   key: string;
-  titleEn: string;
-  titleEs: string;
-  pathEn: string;
-  pathEs: string;
+  routeKey: RouteKey;
 }
 
 /**
  * The ten travel guides, in one place, so the footer and the blog index don't
- * drift apart. Titles here are short link labels, not the full SEO <title> —
- * see src/pages/Blog/staticPages(_ES) for the per-article long-form title.
- *
- * PHASE 4: pathEn/pathEs are computed from routes.config.ts (the actual route
- * table) instead of being hand-maintained literals, so this can't drift from
- * what Router.tsx serves the way the old `/TenHoursInPuerto` /
- * `/bestTimeToVisitPuerto` casing already had (routes.config.ts's slugs are
- * uniformly lowercase).
+ * drift apart. `title(locale)`/`path(locale)` below read straight from
+ * routes.config.ts and the Phase-8-translated blog.tsx content — no
+ * per-locale literal here to drift, and no EN/ES-only ceiling the way the old
+ * titleEn/titleEs/pathEn/pathEs fields had.
  */
 export const BLOG_ARTICLES: BlogArticle[] = [
-  { key: 'twodays', titleEn: '2 Days in Puerto Viejo', titleEs: '2 días en Puerto Viejo', pathEn: pathForKey('blogTwodays', 'en'), pathEs: pathForKey('blogTwodays', 'es') },
-  { key: 'gandoca', titleEn: 'Getting to Gandoca-Manzanillo', titleEs: 'Cómo llegar a Gandoca-Manzanillo', pathEn: pathForKey('blogGandoca', 'en'), pathEs: pathForKey('blogGandoca', 'es') },
-  { key: 'sanjose', titleEn: 'From San José to Puerto Viejo', titleEs: 'De San José a Puerto Viejo', pathEn: pathForKey('blogSanjose', 'en'), pathEs: pathForKey('blogSanjose', 'es') },
-  { key: 'byplane', titleEn: 'Getting to Puerto Viejo by Plane', titleEs: 'Llegar a Puerto Viejo en avión', pathEn: pathForKey('blogByplane', 'en'), pathEs: pathForKey('blogByplane', 'es') },
-  { key: 'tenhours', titleEn: 'Ten Hours to Explore Cahuita', titleEs: 'Diez horas para explorar Cahuita', pathEn: pathForKey('blogTenhours', 'en'), pathEs: pathForKey('blogTenhours', 'es') },
-  { key: 'bushours', titleEn: 'Bus Schedule & Routes', titleEs: 'Horarios de autobuses', pathEn: pathForKey('blogBushours', 'en'), pathEs: pathForKey('blogBushours', 'es') },
-  { key: 'cahuitapark', titleEn: 'Visiting Cahuita National Park', titleEs: 'Visitar el Parque Nacional Cahuita', pathEn: pathForKey('blogCahuitapark', 'en'), pathEs: pathForKey('blogCahuitapark', 'es') },
-  { key: 'indigenous', titleEn: 'Indigenous Culture Nearby', titleEs: 'Cultura indígena cercana', pathEn: pathForKey('blogIndigenous', 'en'), pathEs: pathForKey('blogIndigenous', 'es') },
-  { key: 'besttime', titleEn: 'Best Time to Visit', titleEs: 'Mejor época para visitar', pathEn: pathForKey('blogBesttime', 'en'), pathEs: pathForKey('blogBesttime', 'es') },
-  { key: 'hiddengems', titleEn: 'Hidden Gems in Puerto Viejo', titleEs: 'Joyas escondidas', pathEn: pathForKey('blogHiddengems', 'en'), pathEs: pathForKey('blogHiddengems', 'es') },
+  { key: 'twodays', routeKey: 'blogTwodays' },
+  { key: 'gandoca', routeKey: 'blogGandoca' },
+  { key: 'sanjose', routeKey: 'blogSanjose' },
+  { key: 'byplane', routeKey: 'blogByplane' },
+  { key: 'tenhours', routeKey: 'blogTenhours' },
+  { key: 'bushours', routeKey: 'blogBushours' },
+  { key: 'cahuitapark', routeKey: 'blogCahuitapark' },
+  { key: 'indigenous', routeKey: 'blogIndigenous' },
+  { key: 'besttime', routeKey: 'blogBesttime' },
+  { key: 'hiddengems', routeKey: 'blogHiddengems' },
 ];
 
 /**

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,3 +1,5 @@
+import type { LocalizedValue } from '../i18n';
+
 export type ListingType = {
     name: string
     mainImage: string
@@ -39,20 +41,11 @@ export interface PropertyCapacity {
 
 export interface PropertyMarketingContent {
     propertyKey: string;           // e.g., 'Rana', 'RanaES'
-    descriptiveTitle: {
-        en: string;
-        es: string;
-    };
+    descriptiveTitle: LocalizedValue<string>;
     price: {
         crc: number;                 // e.g., 75000
         usd: number;                 // e.g., 150
     };
-    socialStatement: {
-        en: string;
-        es: string;
-    };
-    featureHighlights: {
-        en: string[];
-        es: string[];
-    };
+    socialStatement: LocalizedValue<string>;
+    featureHighlights: LocalizedValue<string[]>;
 }


### PR DESCRIPTION
## Summary
- Fixes VacationRental structured data on all 45 property pages (GSC Rich Results was failing all of them): `occupancy.maxValue` → `occupancy.value`, added a stable top-level `identifier` plus a per-property `identifier` on each `containsPlace` entry, added `additionalType`.
- Closes the remaining site-wide translation gap for the six newer locales (de/fr/it/pt/he/hi): `PROPERTY_MARKETING_CONFIG`, amenity labels, cookie banner, 404 page, `WhyStayWithUs`, guest review labels/stay-type tags, `StayRecommendation` reasons, blog cross-link titles.
- Root-caused and fixed the underlying routing bug (`pathForLegacyId` only ever resolved to `'es'`/`'en'`) so new-locale visitors land on the correctly-localized URL, not just correctly-translated text.
- Bonus fix found via spot-checking built HTML: two blog articles (`travellingToPuerto`, `gettingToGandoca`) were silently missing their entire German content block — `Partial<Record<Locale,T>>` doesn't error at compile time on a missing key.
- Booking/payment flow intentionally untouched — `bookingLanguage()` is deliberately narrower than `Locale` by existing design.

Full detail in `docs/i18n-rollout-plan.md`'s 2026-08-10 session log entry.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Full Jest suite unchanged (299 passed, same 4 pre-existing jsdom `matchMedia` failures)
- [x] Two full production builds (177/177 pages) both green
- [x] Manual spot-checks of built HTML: PROPERTY_MARKETING_CONFIG, amenities, footer links, HomeCard/HelpMeChoose routing, StayRecommendation, both newly-fixed German blog articles
- [ ] Re-run Google Rich Results test against a property page once this deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6Kuq6D38eBfGF9a7CPNJL