### PR TITLE
fix(prerender): resolve two react-snap hydration mismatches

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "start": "react-scripts start",
     "prebuild": "node scripts/generate-reactsnap-include.js",
     "build": "cross-env DISABLE_ESLINT_PLUGIN=true GENERATE_SOURCEMAP=false react-scripts build",
-    "postbuild": "react-snap && node scripts/generate-404.js && node scripts/generate-redirects.js && node scripts/inject-route-preloads.js && node scripts/generate-sitemap.js && node scripts/generate-md-pages.js && node scripts/generate-llms-full.js",
+    "postbuild": "react-snap && node scripts/strip-select-hydration-artifacts.js && node scripts/generate-404.js && node scripts/generate-redirects.js && node scripts/inject-route-preloads.js && node scripts/generate-sitemap.js && node scripts/generate-md-pages.js && node scripts/generate-llms-full.js",
     "build-local": "cross-env DISABLE_ESLINT_PLUGIN=true react-scripts build",
     "booking-api:build": "npm --prefix booking-api run build",
     "booking-api:migrate": "npm --prefix booking-api run migrate",

--- a/scripts/strip-select-hydration-artifacts.js
+++ b/scripts/strip-select-hydration-artifacts.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Strips the `selected="selected"` attribute react-snap bakes onto the
+ * current-locale <option> in the nav's language <select>.
+ *
+ * LanguageSwitcher (src/components/FlagComponent/Flag.component.tsx) is a
+ * textbook controlled `<select value={locale}>` — React manages selectedness
+ * through the DOM property, and deliberately never writes it as markup.
+ * react-snap crawls with a real browser though, so by the time it captures
+ * the DOM, the browser has already run React and set the current option's
+ * `.selected` property. HTML's fragment-serialization algorithm reflects a
+ * live, non-dirty `<option>` selectedness back into a `selected` attribute
+ * when serializing (the same special case that keeps `<input>` checked state
+ * across a clone/innerHTML round-trip) — so the captured snapshot ends up
+ * with `selected="selected"` on the page's own-locale option, and the
+ * client's hydration render never produces that attribute. React's hydration
+ * diff treats the mismatch as error #418, then discards and re-renders the
+ * *entire* root as #423 — on every single page, since the switcher lives in
+ * the shared nav.
+ *
+ * There's no state change to gate here the way isPrerender() gates the
+ * cookie banner and image skeleton (src/utils/isPrerender.ts) — this is the
+ * browser's own serializer adding markup React never asked for — so the fix
+ * has to scrub it out of the static files after the crawl instead.
+ *
+ * Runs directly after react-snap, before any other postbuild step touches
+ * these files.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const BUILD = path.join(ROOT, 'build');
+
+// Matches `selected="selected"` (react-snap's actual output) and the bare
+// `selected` / `selected=""` forms some browsers or a future Chrome could
+// serialize instead — all mean the same DOM boolean attribute.
+const SELECTED_ATTR = /\s+selected(?:="selected"|="")?(?=[\s/>])/g;
+
+function stripFile(file) {
+  const html = fs.readFileSync(file, 'utf8');
+  const optionSelectedCount = (html.match(/<option\b[^>]*\sselected\b/g) || []).length;
+  if (!optionSelectedCount) return false;
+
+  // Scoped to <option ...> tags only — a blanket replace would also strip a
+  // legitimate `selected` on some other element this app doesn't have today
+  // but might grow later.
+  const fixed = html.replace(/<option\b[^>]*>/g, (tag) => tag.replace(SELECTED_ATTR, ''));
+  fs.writeFileSync(file, fixed);
+  return true;
+}
+
+function walk(dir, out) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (entry.name === 'index.html') out.push(full);
+  }
+}
+
+function main() {
+  if (!fs.existsSync(BUILD)) {
+    console.error('[hydration-fix] build/ does not exist — run the build first.');
+    process.exit(1);
+  }
+
+  const files = [];
+  walk(BUILD, files);
+  if (!files.length) {
+    console.error('[hydration-fix] no index.html files found under build/ — did react-snap run?');
+    process.exit(1);
+  }
+
+  let fixed = 0;
+  for (const file of files) {
+    if (stripFile(file)) fixed++;
+  }
+
+  console.log(`[hydration-fix] stripped stale <option selected> from ${fixed}/${files.length} pages`);
+}
+
+main();

--- a/src/components/AspectBox/AspectBox.component.tsx
+++ b/src/components/AspectBox/AspectBox.component.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import "./AspectBox.style.scss";
 
 type Props = React.PropsWithChildren<{
   ratio?: `${number}/${number}`; // e.g. "16/9"
@@ -6,15 +7,53 @@ type Props = React.PropsWithChildren<{
   className?: string;
 }>;
 
+// Every ratio actually passed to AspectBox today, mapped to a static class
+// rather than computed inline. Add an entry here (and the matching rule in
+// AspectBox.style.scss) before passing a new ratio value.
+const RATIO_CLASS: Record<string, string> = {
+  "16/9": "aspect-box--16-9",
+  "4/3": "aspect-box--4-3",
+  "3/2": "aspect-box--3-2",
+  "1/1": "aspect-box--1-1",
+};
+
+/**
+ * `aspect-ratio` postdates the Chromium react-snap crawls with (puppeteer
+ * 1.x, ~Chrome 79) — that engine's CSSStyleDeclaration silently drops it as
+ * an unrecognised property, so an inline `style={{ aspectRatio }}` renders
+ * with no aspect-ratio at all in the prerendered snapshot. React's own
+ * hydration render (on any real, current browser) sets it successfully, so
+ * every page using this component mismatched on hydration (#418, then #423
+ * discarding the whole root — see memory:
+ * hydration_mismatch_language_switcher for the sibling case in the nav).
+ *
+ * A `--custom-property` survives the crawl (any engine accepts the syntax
+ * even if nothing reads it) but doesn't fully solve this: the *value* the
+ * old engine's CSSOM serialises back out (`--aspect-ratio:4/3`) came out
+ * without the space after the colon that a current browser's CSSOM adds
+ * (`--aspect-ratio: 4/3`) — a still-real mismatch, just one property over.
+ * Anything that has to round-trip through a live CSSOM is at the mercy of
+ * that engine's own serialisation quirks, and the two engines here are
+ * roughly five years apart. A static class has no such round-trip: React
+ * writes the `class` attribute as literal text, identically, regardless of
+ * which engine is running. Same reasoning as the fill layer below.
+ *
+ * The inner fill layer originally set `inset: 0` inline. Splitting that into
+ * longhand `top/right/bottom/left: 0` "fixed" the crawl (that ancient engine
+ * doesn't know the `inset` shorthand, so it keeps the four longhands as
+ * written) but broke hydration a different way: a current browser's CSSOM
+ * *re-collapses* four matching longhands back into `inset` when the style
+ * attribute is serialised, so the live client's snapshot came out as
+ * `inset: 0px` again. Moved to a static class for the same reason as above.
+ */
 export default function AspectBox({ratio="16/9", minHeight=320, className="", children}: Props) {
+  const ratioClass = RATIO_CLASS[ratio] ?? RATIO_CLASS["16/9"];
   return (
-    <div className={className} style={{
-      position:"relative",
-      width:"100%",
-      aspectRatio: ratio,
-      minHeight
-    }}>
-      <div style={{position:"absolute", inset:0, width:"100%", height:"100%"}}>
+    <div
+      className={["aspect-box", ratioClass, className].filter(Boolean).join(" ")}
+      style={{ minHeight }}
+    >
+      <div className="aspect-box__fill">
         {children}
       </div>
     </div>

--- a/src/components/AspectBox/AspectBox.style.scss
+++ b/src/components/AspectBox/AspectBox.style.scss
@@ -1,0 +1,20 @@
+// aspect-ratio has to be set through a static per-ratio class, not inline on
+// the element, and the fill layer has to be a static class too rather than
+// an inline style object, so react-snap's prerender snapshot survives
+// hydration — see the comment in AspectBox.component.tsx.
+.aspect-box {
+  position: relative;
+  width: 100%;
+
+  &--16-9 { aspect-ratio: 16/9; }
+  &--4-3 { aspect-ratio: 4/3; }
+  &--3-2 { aspect-ratio: 3/2; }
+  &--1-1 { aspect-ratio: 1/1; }
+}
+
+.aspect-box__fill {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/src/components/ImageSkeleton/ImageSkeleton.component.tsx
+++ b/src/components/ImageSkeleton/ImageSkeleton.component.tsx
@@ -10,6 +10,16 @@ export interface ImageSkeletonProps {
   className?: string;
 }
 
+// Every ratio actually passed as `aspectRatio` today, mapped to a static
+// class rather than computed inline. Add an entry here (and the matching
+// rule in ImageSkeleton.style.scss) before passing a new ratio value.
+const RATIO_CLASS: Record<string, string> = {
+  '16/9': 'image-skeleton--ratio-16-9',
+  '4/3': 'image-skeleton--ratio-4-3',
+  '3/2': 'image-skeleton--ratio-3-2',
+  '1/1': 'image-skeleton--ratio-1-1',
+};
+
 const ImageSkeleton: React.FC<ImageSkeletonProps> = ({
   width,
   height,
@@ -18,17 +28,23 @@ const ImageSkeleton: React.FC<ImageSkeletonProps> = ({
   animation = 'shimmer',
   className = '',
 }) => {
+  // `aspectRatio` maps to a static class rather than an inline style — see
+  // AspectBox.component.tsx for why: the crawler react-snap uses is an
+  // ancient Chromium that both silently drops the `aspect-ratio` property
+  // and, even routed through a `--custom-property`, serialises the value
+  // with different whitespace than a current browser. A static class has no
+  // live-CSSOM round-trip to disagree over.
   const skeletonClasses = [
     'image-skeleton',
     `image-skeleton--${variant}`,
     `image-skeleton--${animation}`,
+    aspectRatio ? RATIO_CLASS[aspectRatio] : undefined,
     className
   ].filter(Boolean).join(' ');
 
   const style: React.CSSProperties = {
     width: width || '100%',
     height: height || 'auto',
-    aspectRatio: aspectRatio,
   };
 
   return (

--- a/src/components/ImageSkeleton/ImageSkeleton.style.scss
+++ b/src/components/ImageSkeleton/ImageSkeleton.style.scss
@@ -11,6 +11,13 @@
   overflow: hidden;
   width: 100%;
   min-height: 100px; // Ensure minimum height for visibility
+
+  // Set by the `aspectRatio` prop via a static class, not inline — see the
+  // comment in ImageSkeleton.component.tsx.
+  &--ratio-16-9 { aspect-ratio: 16/9; }
+  &--ratio-4-3 { aspect-ratio: 4/3; }
+  &--ratio-3-2 { aspect-ratio: 3/2; }
+  &--ratio-1-1 { aspect-ratio: 1/1; }
   animation: shimmer 1.5s infinite; // Add shimmer animation by default
   
   // Ensure shimmer animation overrides any base background


### PR DESCRIPTION
## Summary
- Every page threw React hydration errors #418/#423 on load, causing React to discard the react-snap-prerendered DOM and rebuild it entirely client-side — defeating the point of prerendering, on every single visit.
- Fixed two of the three independent causes found:
  - The nav language switcher's `<select>` had a spurious `selected="selected"` baked into the react-snap snapshot by the crawler's browser (React never emits that attribute for a controlled select). New postbuild step `scripts/strip-select-hydration-artifacts.js` strips it.
  - `AspectBox`/`ImageSkeleton` set `aspect-ratio` via inline style, which react-snap's ~2020-era bundled Chromium silently drops. Moved to static per-ratio CSS classes, which serialize identically across browser versions (inline style values don't — verified two other approaches first that each held up in one engine but not the other).
- A third cause (any `<Suspense>` boundary in the hydrated tree mismatches regardless of whether its child suspends, since react-snap's snapshot never has the `<!--$-->` markers real SSR emits) is diagnosed but **not fixed here** — resolving it means replacing route-level `React.lazy`/`Suspense` with a custom loader, a bigger change tracked separately.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Full `npm run build` (react-snap crawl of all 177 routes + postbuild) succeeds
- [x] `scripts/hydration-diff.mjs` on `/` and `/en/geco`: structure identical, both previously-failing attribute mismatches gone
- [x] Visual check in browser: language switcher renders correctly, portfolio image cards keep correct aspect ratio, no regressions
- [x] Verified in an isolated worktree against latest `main` to confirm no interaction with unrelated in-flight changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KF5372qwAcpf4YDQJW61x7