### PR TITLE
fix(i18n): close Phase 11 P1/P2 items

### DIFF
--- a/docs/i18n-rollout-plan.md
+++ b/docs/i18n-rollout-plan.md
@@ -21,10 +21,10 @@ resume without re-investigating the codebase.
 
 | | |
 |---|---|
-| **Current phase** | **Nine languages, one (Dutch/`nl`) not yet shipped.** Eight languages (EN/ES/DE/FR/IT/PT/HE/HI) have been live and independently verified in production since 2026-08-10 (PRs #52, #54, #60, #61). A ninth, Dutch, was found built out in full but uncommitted, verified, and opened as PR #62 (branch `feat/i18n-phase-12-dutch`) — see [Phase 12](#phase-12--dutch-nl-ninth-language); both Phase 11 P0 items are now done too. Next: merge/deploy PR #62, then work Phase 11's remaining P1/P2 items, then resume Phase 10 (GSC owner actions, still open on PR #59). |
+| **Current phase** | **Nine languages, one (Dutch/`nl`) not yet shipped.** Eight languages (EN/ES/DE/FR/IT/PT/HE/HI) have been live and independently verified in production since 2026-08-10 (PRs #52, #54, #60, #61). A ninth, Dutch, was found built out in full but uncommitted, verified, and opened as PR #62 (branch `feat/i18n-phase-12-dutch`) — see [Phase 12](#phase-12--dutch-nl-ninth-language). Phase 11's P0 items and all but one P1/P2 item are now also done, opened as PR #63 (branch `fix/i18n-phase-11-p1-p2`, stacked on PR #62). Next: merge/deploy #62 then #63; decide on hydration cause #3 (the one item still gated on an explicit go-ahead); resume Phase 10 (GSC owner actions, still open on PR #59). |
 | **Last updated** | 2026-08-11 |
-| **Branch(es) in flight** | PR #59 (Phase 10 docs) still open, not yet merged. PR #62 (Phase 12, Dutch) open, not yet merged — branch `feat/i18n-phase-12-dutch`. |
-| **Blocked on** | Nothing blocking. See [Phase 11](#phase-11--post-launch-fixes-and-hardening-found-during-2026-08-10-verification) for the remaining P1/P2 punch list — none of it is a regression from this rollout's locked scope. PostHog export (organic sessions, EN vs ES, 12 months) is still the one open Phase 0 owner action. |
+| **Branch(es) in flight** | PR #59 (Phase 10 docs) still open, not yet merged. PR #62 (Phase 12, Dutch) open, not yet merged — branch `feat/i18n-phase-12-dutch`. PR #63 (Phase 11 P1/P2) open, stacked on #62, not yet merged — branch `fix/i18n-phase-11-p1-p2`. |
+| **Blocked on** | Nothing blocking except hydration cause #3, which needs an explicit go-ahead before starting (see [Phase 11 P2](#phase-11--post-launch-fixes-and-hardening-found-during-2026-08-10-verification)) — a prior attempt made it worse. Two GSC-access items also remain owner actions. PostHog export (organic sessions, EN vs ES, 12 months) is still the one open Phase 0 owner action. |
 
 Phase progress:
 
@@ -1183,7 +1183,7 @@ before this plan can close out clean. Grouped by priority.
 
 **P1 — should close before treating the rollout as done:**
 
-- [ ] Add a regression test asserting all 8 `RELEASED_LOCALES` keys are
+- [x] Add a regression test asserting all 8 `RELEASED_LOCALES` keys are
       present for every entry in `src/i18n/content/blog.tsx`,
       `content/listings.ts`, `constants.ts`'s `PROPERTY_MARKETING_CONFIG`, and
       `RECOMMENDATION_REASONS`. All four are `Partial<Record<Locale, T>>`- or
@@ -1193,6 +1193,20 @@ before this plan can close out clean. Grouped by priority.
       articles in Phase 8, `PROPERTY_MARKETING_CONFIG` itself before the
       2026-08-10 fix) and currently has zero CI coverage —
       `propertyMarketingConfig.test.ts` only asserts the `en`/`es` shape.
+      **Done 2026-08-11**: `src/i18n/content/__tests__/localeCompleteness.test.ts`,
+      320 assertions across all four modules against `RELEASED_LOCALES`
+      (now 9, since Phase 12 landed in the same working tree). `listings.ts`/
+      `blog.tsx`/`discover.tsx` are covered via their public accessor
+      functions rather than by exporting their internal `CONTENT` maps —
+      each accessor's `map[locale] ?? map[DEFAULT_LOCALE]!` fallback returns
+      the *exact same object reference* as the English call when a locale is
+      missing, so reference inequality is a precise, zero-false-positive
+      completeness signal that needs no source changes to the content files.
+      `RECOMMENDATION_REASONS` had to be exported (was module-private) to
+      check its keys directly; `PROPERTY_MARKETING_CONFIG` was already
+      exported. Verified the test actually has teeth, not just green: deleted
+      one `nl` entry from `RECOMMENDATION_REASONS`, confirmed the test failed
+      with a precise "Expected path: nl" message, reverted.
 - [ ] Investigate the one remaining critical structured-data error on the live
       re-test: **"Duplicate field `containsPlace`"** (down from 11 critical
       errors after the 2026-08-10 `public/index.html` fix, confirmed via
@@ -1202,22 +1216,31 @@ before this plan can close out clean. Grouped by priority.
       visible in the page source. Check whether a separate Vacation Rentals
       feed or Google Business Profile submission duplicates the same
       inventory data against the on-page JSON-LD. **Needs GSC/Business
-      Profile access — likely owner action.**
+      Profile access — likely owner action.** *(Still blocked 2026-08-11 —
+      no GSC/Business Profile access available this session.)*
 - [ ] Re-run the Rich Results / URL Inspection check on a sample of listing
       pages across *other* locales (only `/es/besttimetovisitpuerto/` has been
       live-re-tested so far) to confirm the `identifier`/`occupancy.value` fix
       generalizes rather than being right on the one URL that got checked.
-      **Needs GSC access — owner action.**
-- [ ] Native-speaker check on `src/i18n/messages/it.ts`'s
+      **Needs GSC access — owner action.** *(Still blocked 2026-08-11.)*
+- [x] Native-speaker check on `src/i18n/messages/it.ts`'s
       `home.optionPetFriendly: 'Pet-friendly'` — byte-identical to `en`/`es`.
       Spanish has a code comment justifying the English loanword; Italian
-      doesn't, so this is unconfirmed rather than a known bug.
-- [ ] Log PR #61 (`fix/prerender-hydration-mismatches`) in this document's
+      doesn't, so this is unconfirmed rather than a known bug. **Translated
+      2026-08-11** to `'Ammessi animali domestici'`, matching how fr/de/pt/he
+      all handled this key (none kept the English term) — but this is a
+      judgment call, not an actual native-speaker sign-off (no native
+      Italian speaker was available this session). Flagged as such in the
+      code comment. Worth a real read if one becomes available; consistent
+      either way with this rollout's locked "machine translation, published
+      as-is" decision.
+- [x] Log PR #61 (`fix/prerender-hydration-mismatches`) in this document's
       session log — it landed 2026-08-10 fixing two of three react-snap
       hydration-mismatch root causes across every prerendered page (all
       locales), but has no entry here yet. Cross-reference
       [[hydration_mismatch_language_switcher]] memory for the full root-cause
-      writeup.
+      writeup. **Done 2026-08-11** — see the new dated entry in the session
+      log below.
 
 **P2 — larger, already-scoped, needs an explicit go-ahead before starting:**
 
@@ -1231,8 +1254,12 @@ before this plan can close out clean. Grouped by priority.
       means replacing route-level `lazy()`/`Suspense` code-splitting with a
       manual loader — closer in size to dropping code-splitting than a patch.
       One approach was already tried and reverted (made it worse) — see the
-      memory for what not to retry.
-- [ ] Investigate why the Jest suite shows **27 failing tests** (300 passed /
+      memory for what not to retry. **Deliberately not started 2026-08-11** —
+      this is the one item in the whole Phase 11 list with an explicit
+      go-ahead gate *and* a documented failed attempt; asked the project
+      owner rather than assuming a general "work through P1/P2" instruction
+      covers a large, previously-reverted structural change.
+- [x] Investigate why the Jest suite shows **27 failing tests** (300 passed /
       327 total, 3 suites: `ListingDelfin.test.tsx`, `ListingDelfinES.test.tsx`,
       `delfinIntegration.test.ts`) against a fresh install, versus the
       "4 pre-existing failures" recorded in the 2026-08-10 session log below.
@@ -1243,7 +1270,29 @@ before this plan can close out clean. Grouped by priority.
       (reading 'matches')`) despite a global mock existing in
       `setupTests.ts`; likely a `jest.spyOn(...).mockRestore()` /
       `clearAllMocks()` interaction in `ListingDelfinES.test.tsx` leaking
-      across tests in the same file.
+      across tests in the same file. **Root-caused and fixed 2026-08-11 — the
+      `clearAllMocks()` theory was wrong.** Proved it wrong first: disabled
+      that exact line and the very first test in the file still failed with
+      no other tests having run at all, which a same-file leak can't explain.
+      Actual cause: **CRA's default Jest config sets `resetMocks: true`**
+      (`node_modules/react-scripts/scripts/utils/createJestConfig.js`), which
+      strips every `jest.fn()`'s `mockImplementation` before *every* test,
+      including the first. `setupTests.ts` only installed the
+      `window.matchMedia` mock once, at module load — dead before it was ever
+      read. The two sibling suites that already passed
+      (`listingPageIntegration.test.tsx`, `DelfinRouting.test.tsx`) worked
+      around this by re-installing their own local mock inside `beforeEach`;
+      the three failing suites had no such workaround and relied solely on
+      the global one. Fixed at the root in `setupTests.ts` — moved the
+      `matchMedia`/`fbq` mock setup into a `beforeEach` so it survives
+      `resetMocks`, rather than patching each of the three files individually.
+      **Result: 27 → 14 failures.** The remaining 14 are a *different*,
+      previously-masked issue — real content-assertion mismatches (e.g.
+      `getByText('Casa Delfines')` now correctly finds two elements, an `<h1>`
+      and a link, where the test assumed one) that the matchMedia crash was
+      hiding behind a single generic error on every test. Not chased further
+      this session — worth its own pass, separately scoped, now that the
+      false signal is gone.
 - [ ] Revisit whether `useApplyStoredLocalePreference` (`src/i18n/localePreference.ts`)
       should keep silently redirecting a direct locale-URL visit to a
       returning visitor's stored preference now that 8 locales are live
@@ -2338,6 +2387,50 @@ what the next session should pick up.
   `locale === 'es'` follow-up referenced above is now resolved by this
   session's work and can be considered closed.
 
+### 2026-08-10 — PR #61 fixes two of three prerender hydration-mismatch causes
+
+*(Logged 2026-08-11, filed as a Phase 11 P1 item since it landed with no
+session-log entry of its own.)* Production was throwing two React #418s and
+one #423 on every single page load, across every locale. Root-caused via a
+temporary `onRecoverableError` component-stack trace to three independent,
+stacked causes — full technical detail in
+[[hydration_mismatch_language_switcher]]:
+
+1. **Fixed.** `LanguageSwitcher`'s controlled `<select value={locale}>` — by
+   the time react-snap's live-DOM capture runs, the browser has reflected the
+   selected option's `.selected` property back into a literal
+   `selected="selected"` attribute, which React never emits for a controlled
+   select. New postbuild step, `scripts/strip-select-hydration-artifacts.js`
+   (runs right after react-snap), strips it from `build/**/index.html`.
+2. **Fixed.** CSS `aspect-ratio` silently dropped by react-snap's bundled
+   Chromium (~Chrome 79, predates `aspect-ratio` support entirely). Any
+   inline `style={{ aspectRatio }}` therefore differs between the snapshot
+   and a real hydrating browser. Custom-property indirection was tried first
+   and didn't survive whitespace-serialization differences between the two
+   engines; the fix that actually holds is a **static CSS class**
+   (`aspect-box--4-3`, etc.) instead of an inline style, since `class` is
+   written as literal text with no live-CSSOM round-trip for either engine to
+   disagree over.
+3. **Not fixed, deliberately deferred.** `React.lazy()` + route-level
+   `<Suspense>` is structurally incompatible with react-snap's live-DOM
+   capture — react-snap's snapshot has zero HTML comment markers, so React
+   has nothing telling it the existing DOM is the settled Suspense case, and
+   bails to #418/#423 on every route regardless of the other two fixes. Two
+   userland workarounds were tried the same session and reverted — one did
+   nothing (the mismatch trips on `<Suspense>`'s mere presence in the tree,
+   not on whether its child actually suspends), the other made it worse (a
+   new #425 plus ~15 more #418s, from react-snap's crawl and the
+   deferred-hydration render disagreeing about whether the boundary is
+   present in the tree at all). Real fix means replacing route-level
+   `lazy()`/`Suspense` with a manual loader — filed as Phase 11 P2, needs an
+   explicit go-ahead given the size and the failed attempt.
+
+Opened and merged as PR #61 (`fix/prerender-hydration-mismatches`),
+2026-08-10. The 2026-08-10 verification session below independently
+confirmed both fixes shipped (grepped the live response for zero
+`selected="selected"` artifacts and zero inline `aspect-ratio` styles) and
+that cause #3 is still live in production, unchanged.
+
 ### 2026-08-10 — Full verification pass; Phase 11 opened
 
 - **Scope:** independently verify the whole rollout end to end rather than
@@ -2460,3 +2553,75 @@ to already be underway, further along than documented:
   P1/P2 items (structured-data `containsPlace` duplicate, cross-locale Rich
   Results re-test, `it.ts` pet-friendly wording, hydration cause #3, the
   stored-locale-preference UX question).
+
+### 2026-08-11 — Phase 11 P1/P2 worked; PR #63 opened stacked on #62
+
+Continuation of the same day's work, picking up the "next session" note
+above immediately rather than waiting. Branched `fix/i18n-phase-11-p1-p2`
+off `feat/i18n-phase-12-dutch` rather than off `main`, since the locale
+completeness test below is only meaningful against the full 9-locale set
+Phase 12 introduces — a real dependency, not just convenience, so the PR is
+stacked (base `feat/i18n-phase-12-dutch`, not `main`) rather than force-fit
+onto `main` the way the much older Phase 4-era stack was.
+
+- **P1 — locale completeness regression test, done.** New
+  `src/i18n/content/__tests__/localeCompleteness.test.ts`, 320 assertions.
+  `content/listings.ts`/`content/blog.tsx`/`content/discover.tsx` don't
+  export their internal `CONTENT` maps, so rather than adding test-only
+  exports, the test goes through each module's existing public accessor
+  function and checks *reference inequality* against the English call —
+  every accessor's `map[locale] ?? map[DEFAULT_LOCALE]!` fallback hands back
+  the literal same object when a locale is missing, so this is a precise,
+  zero-false-positive signal that needs no source changes to the content
+  files themselves. `RECOMMENDATION_REASONS` did need exporting (was
+  module-private); `PROPERTY_MARKETING_CONFIG` already was. Verified the
+  test has real teeth, not just green: deleted one `nl` entry, watched it
+  fail with an exact "Expected path: nl" message, reverted.
+- **P1 — `it.ts` `optionPetFriendly`, translated.** Was byte-identical to
+  `en`/`es`, unconfirmed whether that was deliberate (Spanish has a code
+  comment justifying its English loanword; Italian didn't). Translated to
+  `'Ammessi animali domestici'`, matching how fr/de/pt/he all handled the
+  same key. This is a judgment call, not an actual native-speaker
+  verification — no native Italian speaker was available this session, and
+  the code comment says so plainly rather than overclaiming a check that
+  didn't happen.
+- **P1 — PR #61 logged**, seeded from [[hydration_mismatch_language_switcher]]. See the new
+  2026-08-10 dated entry above (inserted in chronological order, not
+  appended here, since it documents when PR #61 actually landed).
+- **P1 — two GSC-access items, still blocked.** No Search Console or
+  Business Profile access available this session; unchanged from the prior
+  entry.
+- **P2 — the 27 failing Jest tests, root-caused and fixed, not just
+  investigated.** The prior entry's `clearAllMocks()`/`spyOn` leak theory
+  was disproven directly: disabled that exact line and the *first* test in
+  the file still failed with zero other tests having run, which a same-file
+  leak cannot produce. Real cause: **CRA's default Jest config sets
+  `resetMocks: true`**, which strips every `jest.fn()`'s implementation
+  before *every* test. `setupTests.ts` set up `window.matchMedia` once, at
+  module load — already dead before the first test ever read it. Two
+  sibling suites worked around this with their own per-test local mock; the
+  three failing suites had none. Fixed at the root in `setupTests.ts` (moved
+  the mock into a `beforeEach`) instead of patching three files. **27 → 14
+  failures.** The remaining 14 are a distinct, previously-masked class of
+  bug — real content-assertion mismatches the matchMedia crash was hiding
+  behind one generic error per test (e.g. a `getByText` now correctly
+  finding two matches instead of one). Left as a fresh, separately-scoped
+  follow-up rather than chased into this session.
+- **P2 — hydration cause #3, deliberately not attempted.** The doc's own
+  gate on this item — "needs an explicit go-ahead" plus a documented failed
+  attempt — was treated as still in force even though the user's
+  instruction this session was a general "continue with P1 P2." Flagged
+  back to the project owner rather than assumed.
+- **P2 — locale-preference UX question, untouched.** Still a discussion
+  item with no proposed code change (see the 2026-08-10 entry above);
+  nothing to do here without a decision on the actual redirect behavior.
+- Validation: `tsc --noEmit` clean; full Jest run
+  647 total (327 baseline + 320 new), 633 passed / 14 failed — the new
+  count, not a regression, since all 14 are the just-unmasked pre-existing
+  content-assertion mismatches above.
+- **Shipped as PR #63** (`fix/i18n-phase-11-p1-p2`), stacked on PR #62. Not
+  merged yet as of this entry.
+- **Next session:** merge #62 then #63 (in that order, since #63 depends on
+  #62's locale set). Decide on hydration cause #3. Take on the newly-exposed
+  14 content-assertion-mismatch failures as their own scoped piece of work.
+  Resume Phase 10 (GSC owner actions, PR #59).

--- a/docs/i18n-rollout-plan.md
+++ b/docs/i18n-rollout-plan.md
@@ -1207,7 +1207,7 @@ before this plan can close out clean. Grouped by priority.
       exported. Verified the test actually has teeth, not just green: deleted
       one `nl` entry from `RECOMMENDATION_REASONS`, confirmed the test failed
       with a precise "Expected path: nl" message, reverted.
-- [ ] Investigate the one remaining critical structured-data error on the live
+- [x] Investigate the one remaining critical structured-data error on the live
       re-test: **"Duplicate field `containsPlace`"** (down from 11 critical
       errors after the 2026-08-10 `public/index.html` fix, confirmed via
       Search Console's live URL Inspection test on
@@ -1216,13 +1216,63 @@ before this plan can close out clean. Grouped by priority.
       visible in the page source. Check whether a separate Vacation Rentals
       feed or Google Business Profile submission duplicates the same
       inventory data against the on-page JSON-LD. **Needs GSC/Business
-      Profile access — likely owner action.** *(Still blocked 2026-08-11 —
-      no GSC/Business Profile access available this session.)*
-- [ ] Re-run the Rich Results / URL Inspection check on a sample of listing
+      Profile access — likely owner action.** **Root-caused 2026-08-11**,
+      given access to the `reservas.kalawala@gmail.com` Google Business
+      Profile (account `u/1`) and a live re-test on `/de/geco/`:
+      - **Business Profile is not the source.** One listing, no linked
+        multi-location group, no separate hotel/vacation-rental feed
+        configured. Ruled out.
+      - **The real cause: `containsPlace` is authored as an array of 10
+        `Accommodation` objects (one per property) under a single parent
+        `VacationRental`.** Google's own reference documentation
+        ([Vacation rental structured data](https://developers.google.com/search/docs/appearance/structured-data/vacation-rental))
+        shows `containsPlace` as **one single object, not an array** — the
+        schema models *one listing = one accommodation*, not *one host = many
+        units*. Google's parser expands the 10-item array into 10 separate
+        `containsPlace` values against a property it validates as
+        single-occurrence, which is exactly what "duplicate field" means.
+        This isn't a markup bug so much as an architecture mismatch between
+        how this business actually operates (one host, ten independently
+        bookable houses) and what Google's schema was designed to describe.
+      - **Bigger finding, not previously known: this whole rich-result
+        feature is gated.** The same documentation page states plainly that
+        it's for site owners "who have already contacted a Google Technical
+        Account Manager and have Hotel Center access," and that "this
+        feature is only available to sites that meet certain participation
+        criteria" — an invitation-only program, not something any site can
+        opt into by publishing correct markup. There is no evidence this
+        business has that relationship. **Even fully-valid `containsPlace`
+        markup may never produce a rich result without separate enrollment**
+        — worth confirming with Google (or dropping pursuit of this specific
+        rich result) before investing more effort in the markup itself.
+      - **Smaller, non-critical finding surfaced by the same live test:**
+        every accommodation's `additionalType` is set to the full URL
+        `"https://schema.org/EntirePlace"`; Google's docs specify the bare
+        string `"EntirePlace"` for `containsPlace.additionalType`. Flagged as
+        "invalid enum value" but marked optional/non-critical — doesn't block
+        anything, but is a quick, unambiguous fix whenever this block is
+        next touched.
+      - **Left open, needs an owner decision:** restructure so each listing
+        page's `<VacationRental>` markup carries its *own* single-Accommodation
+        `containsPlace` (dropping the array, one block per property page
+        instead of one company-wide block in `public/index.html`), or accept
+        that this rich result isn't attainable without a Hotel Center
+        relationship and deprioritize it. Not decided or implemented this
+        session — this is a meaningful markup restructuring on live
+        production SEO surface, not a one-line fix.
+- [x] Re-run the Rich Results / URL Inspection check on a sample of listing
       pages across *other* locales (only `/es/besttimetovisitpuerto/` has been
       live-re-tested so far) to confirm the `identifier`/`occupancy.value` fix
       generalizes rather than being right on the one URL that got checked.
-      **Needs GSC access — owner action.** *(Still blocked 2026-08-11.)*
+      **Needs GSC access — owner action.** **Done 2026-08-11**: live-tested
+      `/de/geco/` — `identifier: "geco"` and `occupancy.value: 5` both present
+      and correct, confirming the fix generalizes. Expected: the
+      `VacationRental`/`Organization` JSON-LD lives in `public/index.html`,
+      one static block shared verbatim across every prerendered page and
+      locale (only `availableLanguage`/`knowsLanguage` vary, per Phase 12's
+      diff) — it isn't per-locale content, so a single successful cross-page
+      check is sufficient evidence rather than needing all ~9 locales
+      individually re-tested.
 - [x] Native-speaker check on `src/i18n/messages/it.ts`'s
       `home.optionPetFriendly: 'Pet-friendly'` — byte-identical to `en`/`es`.
       Spanish has a code comment justifying the English loanword; Italian
@@ -1293,7 +1343,7 @@ before this plan can close out clean. Grouped by priority.
       hiding behind a single generic error on every test. Not chased further
       this session — worth its own pass, separately scoped, now that the
       false signal is gone.
-- [ ] Revisit whether `useApplyStoredLocalePreference` (`src/i18n/localePreference.ts`)
+- [x] Revisit whether `useApplyStoredLocalePreference` (`src/i18n/localePreference.ts`)
       should keep silently redirecting a direct locale-URL visit to a
       returning visitor's stored preference now that 8 locales are live
       instead of 2. Deliberate Phase 7 UX design, not a bug, and crawlers are
@@ -1302,7 +1352,21 @@ before this plan can close out clean. Grouped by priority.
       manual QA: visiting `/he/...` directly in a browser that previously
       picked Italian silently serves Italian, not Hebrew. At minimum, note
       this for anyone manually spot-checking a locale — use a fresh/incognito
-      context or the in-page switcher, not a bare URL visit.
+      context or the in-page switcher, not a bare URL visit. **Decided and
+      fixed 2026-08-11**: the redirect now only fires from a URL with no
+      explicit locale of its own — this site's URL scheme has exactly one
+      such page, the bare English root `/`. Any `/xx/...` URL is itself a
+      locale selection (typed, bookmarked, linked, or clicked from search
+      results) and always wins over a stored preference now, closing the
+      exact confusion described above. Implementation: one check in
+      `useApplyStoredLocalePreference` against `detectLocaleFromPath`'s own
+      `isLocale(firstSegment)` test, so it can't drift from what "explicit
+      locale in the URL" means elsewhere in the codebase.
+      `tests/e2e/language-switching.spec.ts` updated: the old "stored
+      preference honoured" test moved from `/en/geco` to `/` (the only URL
+      where that's still true), and a new test asserts `/en/geco` with a
+      differing stored preference stays on `/en/geco`. Both, plus the other
+      4 in the file, pass against a live dev server.
 
 ---
 

--- a/src/i18n/content/__tests__/localeCompleteness.test.ts
+++ b/src/i18n/content/__tests__/localeCompleteness.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Phase 11 P1: regression coverage for the exact bug class that shipped
+ * twice already (two blog articles in Phase 8, PROPERTY_MARKETING_CONFIG
+ * itself before the 2026-08-10 fix) — a content module missing a released
+ * locale's block. `tsc` cannot catch this: these modules are typed
+ * `Partial<Record<Locale, T>>` on purpose (an unreleased locale is allowed
+ * to be absent), so a *released* locale silently missing its block is a
+ * runtime-only gap, invisible to the compiler and to a reader skimming the
+ * source, that quietly renders English instead.
+ *
+ * Strategy: every accessor below falls back to English via
+ * `map[locale] ?? map[DEFAULT_LOCALE]!` (see listings.ts/blog.tsx/
+ * discover.tsx) or `value[locale] ?? value.en` (pickLocalized). When a
+ * locale's entry is present, the accessor returns a distinct object built
+ * from that entry — never the literal English object. When it's absent, the
+ * fallback hands back the *exact same reference* as calling with 'en'. So
+ * reference inequality against the 'en' call is a precise, zero-false-positive
+ * signal for "this locale's block exists" — it doesn't depend on the
+ * translated text actually differing from English (which can legitimately
+ * happen for short proper nouns, e.g. "Casa Areka").
+ */
+import { RELEASED_LOCALES, type Locale } from '../../locales';
+import { listingContent, type ListingKey } from '../listings';
+import { discoverContent } from '../discover';
+import {
+  tenHoursInPuertoContent,
+  puertoViejoByPlaneContent,
+  twoDaysInPVContent,
+  gettingToGandocaContent,
+  travellingToPuertoContent,
+  cahuitaParkContent,
+  bestTimeToVisitContent,
+  indigenousTravelContent,
+  puertoHiddenGemsContent,
+  busHoursContent,
+} from '../blog';
+import { PROPERTY_MARKETING_CONFIG, RECOMMENDATION_REASONS } from '../../../utils/constants';
+
+const NON_ENGLISH_LOCALES = RELEASED_LOCALES.filter((locale) => locale !== 'en');
+
+const LISTING_KEYS: ListingKey[] = [
+  'Areka', 'Delfin', 'Geco', 'Giulia', 'Pappagallo',
+  'Plumeria', 'Rana', 'Tucano', 'VillaCoral', 'VillaMar',
+];
+
+const BLOG_ACCESSORS: Record<string, (locale: Locale) => unknown> = {
+  tenHoursInPuerto: tenHoursInPuertoContent,
+  puertoViejoByPlane: puertoViejoByPlaneContent,
+  twoDaysInPV: twoDaysInPVContent,
+  gettingToGandoca: gettingToGandocaContent,
+  travellingToPuerto: travellingToPuertoContent,
+  cahuitaPark: cahuitaParkContent,
+  bestTimeToVisit: bestTimeToVisitContent,
+  indigenousTravel: indigenousTravelContent,
+  puertoHiddenGems: puertoHiddenGemsContent,
+  busHours: busHoursContent,
+};
+
+describe('Locale completeness — content modules never silently fall back to English', () => {
+  describe.each(LISTING_KEYS)('content/listings.ts: %s', (key) => {
+    const english = listingContent(key, 'en');
+    test.each(NON_ENGLISH_LOCALES)('has its own %s block', (locale) => {
+      expect(listingContent(key, locale)).not.toBe(english);
+    });
+  });
+
+  describe.each(Object.entries(BLOG_ACCESSORS))('content/blog.tsx: %s', (_name, accessor) => {
+    const english = accessor('en');
+    test.each(NON_ENGLISH_LOCALES)('has its own %s block', (locale) => {
+      expect(accessor(locale)).not.toBe(english);
+    });
+  });
+
+  describe('content/discover.tsx', () => {
+    const english = discoverContent('en');
+    test.each(NON_ENGLISH_LOCALES)('has its own %s block', (locale) => {
+      expect(discoverContent(locale)).not.toBe(english);
+    });
+  });
+
+  describe.each(Object.keys(PROPERTY_MARKETING_CONFIG))(
+    'constants.ts PROPERTY_MARKETING_CONFIG: %s',
+    (propertyKey) => {
+      const config = PROPERTY_MARKETING_CONFIG[propertyKey];
+      test.each(NON_ENGLISH_LOCALES)('has %s for descriptiveTitle, socialStatement, featureHighlights', (locale) => {
+        expect(config.descriptiveTitle).toHaveProperty(locale);
+        expect(config.socialStatement).toHaveProperty(locale);
+        expect(config.featureHighlights).toHaveProperty(locale);
+      });
+    },
+  );
+
+  describe.each(Object.keys(RECOMMENDATION_REASONS))(
+    'constants.ts RECOMMENDATION_REASONS: %s',
+    (reasonKey) => {
+      const localized = RECOMMENDATION_REASONS[reasonKey];
+      test.each(NON_ENGLISH_LOCALES)('has %s', (locale) => {
+        expect(localized).toHaveProperty(locale);
+      });
+    },
+  );
+});

--- a/src/i18n/localePreference.ts
+++ b/src/i18n/localePreference.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { RELEASED_LOCALES, type Locale } from './locales';
+import { RELEASED_LOCALES, isLocale, type Locale } from './locales';
 import { useLocale } from './useLocale';
 import { pathInLocale } from '../routes.config';
 
@@ -18,6 +18,16 @@ import { pathInLocale } from '../routes.config';
  * page. A fresh crawler visit has no localStorage entry, so this never fires
  * for one; that's what makes the URL stay authoritative without any
  * crawler-detection logic of its own.
+ *
+ * Phase 11 P2, 2026-08-11: the redirect used to fire on *any* page whose
+ * locale differed from the stored preference, including a URL that already
+ * names an explicit locale — visiting `/he/...` directly in a browser that
+ * previously picked Italian silently served Italian instead of Hebrew, with
+ * no visible sign why. Narrowed to only fire when the current URL carries no
+ * explicit locale at all (this site's URL scheme has exactly one such page:
+ * the bare English root, `/` — every other page is `/xx/...`). An explicit
+ * `/xx/...` URL — typed, bookmarked, linked, or clicked from search results —
+ * is itself a locale selection and now always wins over a stored one.
  */
 
 const PREFERENCE_KEY = 'kalawala_locale_preference';
@@ -42,10 +52,11 @@ function readLocalePreference(): Locale | null {
 }
 
 /**
- * Redirects once per tab, on mount, to the stored locale preference if it
- * differs from the current page's locale. Call from a component every page
- * renders (FixedNavigation) — the sessionStorage guard makes repeat mounts
- * a no-op.
+ * Redirects once per tab, on mount, to the stored locale preference — but
+ * only from a URL with no explicit locale of its own (the bare root, `/`).
+ * A URL that already names a locale is left alone even if it differs from
+ * the stored preference. Call from a component every page renders
+ * (FixedNavigation) — the sessionStorage guard makes repeat mounts a no-op.
  */
 export function useApplyStoredLocalePreference(): void {
   const locale = useLocale();
@@ -60,6 +71,13 @@ export function useApplyStoredLocalePreference(): void {
       // No sessionStorage — fall through without the guard rather than never
       // honouring the preference at all.
     }
+
+    // An explicit locale in the URL is itself a selection — never override
+    // it with a stored preference from a previous visit. Only a URL with no
+    // locale segment (this site's URL scheme has exactly one: the bare
+    // English root, `/`) means the visitor hasn't chosen a language yet.
+    const firstSegment = location.pathname.split('/')[1];
+    if (isLocale(firstSegment)) return;
 
     const preferred = readLocalePreference();
     if (!preferred || preferred === locale) return;

--- a/src/i18n/messages/it.ts
+++ b/src/i18n/messages/it.ts
@@ -112,7 +112,13 @@ export const it: Messages = {
     helpMeChooseTitleHighlight: 'soggiorno ideale',
     optionCouples: 'Ideale per coppie',
     optionFamilies: 'Perfetto per famiglie',
-    optionPetFriendly: 'Pet-friendly',
+    // Unlike es.ts, there's no evidence this was a deliberate loanword choice
+    // for Italian — it was byte-identical to en/es, flagged as unconfirmed in
+    // Phase 11 P1. Translated to match how fr/de/pt/he all handled this key
+    // (none of them kept the English term); still worth a native-speaker
+    // read, since "pet friendly" does also see some use as an adopted term
+    // in Italian rental listings.
+    optionPetFriendly: 'Ammessi animali domestici',
     optionBestValue: 'Miglior rapporto qualità-prezzo',
   },
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -4,25 +4,35 @@
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
 
-// Mock matchMedia for tests
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: jest.fn().mockImplementation(query => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(), // deprecated
-    removeListener: jest.fn(), // deprecated
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  })),
-});
+// Mock matchMedia and Meta Pixel for tests. Re-applied in beforeEach, not
+// just once at module load: CRA's default Jest config sets `resetMocks: true`
+// (node_modules/react-scripts/scripts/utils/createJestConfig.js), which
+// strips every jest.fn()'s mockImplementation before *every* test — including
+// the first one in a file. A one-time setup here is wiped before it's ever
+// read, so any component calling `window.matchMedia(...).matches` outside a
+// file that re-mocks it locally gets `undefined` back and throws. Confirmed
+// via `Cannot read properties of undefined (reading 'matches')` across three
+// pre-existing suites that relied solely on this file's original one-time
+// setup (Phase 11 P2, 2026-08-11).
+beforeEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(), // deprecated
+      removeListener: jest.fn(), // deprecated
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
 
-// Mock Meta Pixel for tests
-Object.defineProperty(window, 'fbq', {
-  writable: true,
-  value: jest.fn().mockImplementation(() => {}),
+  Object.defineProperty(window, 'fbq', {
+    writable: true,
+    value: jest.fn().mockImplementation(() => {}),
+  });
 });
 
 // Mock environment variables for tests

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2946,14 +2946,14 @@ export interface PropertyRecommendation {
   houseCode?: number;
 }
 
-// Each `reason` phrase translated into all 8 locales, keyed by its exact
+// Each `reason` phrase translated into every released locale, keyed by its exact
 // English source string. Was three EN consts plus three separately
 // hand-maintained _ES consts (PHASE 3c) — that pattern has no room for six
 // more languages, so this is now three `(locale) => PropertyRecommendation[]`
 // functions sharing one translation table instead. `link` now goes through
 // `pathForKey` directly (every locale), not `pathForLegacyId` (English/Spanish
 // only, by construction — see its own doc comment in routes.config.ts).
-const RECOMMENDATION_REASONS: Record<string, LocalizedValue<string>> = {
+export const RECOMMENDATION_REASONS: Record<string, LocalizedValue<string>> = {
   'Ideal for getting around on foot': {
     en: 'Ideal for getting around on foot', es: 'Ideal si quieres moverte caminando',
     de: 'Ideal, um zu Fuß unterwegs zu sein', fr: 'Idéal pour se déplacer à pied',

--- a/tests/e2e/language-switching.spec.ts
+++ b/tests/e2e/language-switching.spec.ts
@@ -64,17 +64,35 @@ test.describe('Language Switching', () => {
     expect(optionValues.sort()).toEqual([...RELEASED_LOCALES].sort());
   });
 
-  test('a stored preference from a previous visit is honoured on the next one', async ({ appPage }) => {
+  test('a stored preference is honoured landing on the locale-less root', async ({ appPage }) => {
     // Requirement: "persist the choice and honour it on next visit". Simulate
     // a returning visitor who picked Spanish last time by seeding
-    // localStorage directly, then landing fresh on an English URL.
+    // localStorage directly, then landing fresh on `/` — the one page in
+    // this site's URL scheme with no explicit locale of its own.
+    await appPage.addInitScript(() => {
+      localStorage.setItem('kalawala_locale_preference', 'es');
+    });
+
+    await appPage.goto('/');
+
+    await appPage.waitForURL('**/es/');
+    expect(appPage.url()).toContain('/es/');
+  });
+
+  test('an explicit locale URL is never overridden by a stored preference', async ({ appPage }) => {
+    // Phase 11 P2: landing directly on /en/geco used to get silently bounced
+    // to a stored /es/ preference — confusing for anyone who followed a link,
+    // bookmark, or search result straight to an English page. The URL is a
+    // locale selection in its own right and must win.
     await appPage.addInitScript(() => {
       localStorage.setItem('kalawala_locale_preference', 'es');
     });
 
     await appPage.goto('/en/geco');
 
-    await appPage.waitForURL('**/es/geco');
-    expect(appPage.url()).toContain('/es/geco');
+    // Give the redirect a chance to fire if the fix regressed, rather than
+    // asserting on the very first paint.
+    await appPage.waitForTimeout(500);
+    expect(appPage.url()).toContain('/en/geco');
   });
 });


### PR DESCRIPTION
Recreated after PR #63 was auto-closed (not merged) when its stacked base branch (`feat/i18n-phase-12-dutch`, now merged via #62) was deleted. Same commits as #63, just retargeted at `main`.

## Summary
- P1: locale completeness regression test, `it.ts` pet-friendly translation, PR #61 logged in the rollout plan
- P2: root-caused and fixed the 27-failing-Jest-tests regression (CRA's `resetMocks: true` stripping the global `matchMedia` mock)
- P2: `useApplyStoredLocalePreference` now only auto-redirects from a locale-less URL, never overriding an explicit `/xx/...` URL

See `docs/i18n-rollout-plan.md`'s Phase 11 section and 2026-08-11 session log entries for full detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)