### PR TITLE
fix(hydration): remove route-level Suspense/lazy, guard prerender-unsafe effects

### DIFF
--- a/docs/i18n-rollout-plan.md
+++ b/docs/i18n-rollout-plan.md
@@ -1344,7 +1344,9 @@ before this plan can close out clean. Grouped by priority.
       and a link, where the test assumed one) that the matchMedia crash was
       hiding behind a single generic error on every test. Not chased further
       this session — worth its own pass, separately scoped, now that the
-      false signal is gone.
+      false signal is gone. **Fixed 2026-08-11** — see the same-day session
+      log entry "14 stale Delfin test failures fixed" for the three actual
+      root causes (none were the matchMedia issue itself).
 - [x] Revisit whether `useApplyStoredLocalePreference` (`src/i18n/localePreference.ts`)
       should keep silently redirecting a direct locale-URL visit to a
       returning visitor's stored preference now that 8 locales are live
@@ -2782,3 +2784,56 @@ above). Branch `fix/hydration-cause-3-manual-loader`, stacked on
   before repeating the same technique. Otherwise resume the existing
   next-session queue: merge #62 → #63 → this branch, the 14
   content-assertion-mismatch failures, Phase 10 GSC owner actions.
+
+### 2026-08-11 — 14 stale Delfin test failures fixed
+
+Same-day continuation, picking up the "next session" note above
+immediately. None of the 14 were the matchMedia issue itself (that was
+already fixed, see the earlier same-day entry) — full investigation found
+three distinct, unrelated root causes, all pre-existing and unrelated to any
+feature work this session:
+
+- **`ListingDelfinES.test.tsx` rendered in English for its entire suite (7
+  of its 9 failures).** It wraps the shared `ListingDelfin` component in a
+  `MemoryRouter` at the Phase-1-era `/DelfinES` legacy-suffix path. `useLocale()`
+  has read the locale from the URL's first path segment since Phase 4
+  (`detectLocaleFromPath`) — `/DelfinES` doesn't match that pattern and
+  silently fell back to the default locale (English) for every test in the
+  file, which is why "Bienvenido a Reservas Kalawala" wasn't found (it
+  rendered "Welcome to..."), `data-house-name="DelfinES"` wasn't found (it
+  rendered plain `"Delfin"`, since `localeSuffix()` only appends `ES` for an
+  actual `es` locale), etc. Fixed by routing to the real `/es/delfin` URL
+  instead — verified this couldn't regress the file's other,
+  already-passing tests, none of which depend on rendered/locale-driven
+  content.
+- **`Footer` wasn't mocked in either `ListingDelfin.test.tsx` or
+  `ListingDelfinES.test.tsx` (4 failures)**, unlike every other child
+  component. It now renders a real "our homes" list (`PROPERTY_DISPLAY_NAMES`,
+  including this page's own listing name again) and a real blog-article
+  list — both collided with these files' `getByText`/`getByRole` queries
+  that assumed their target string was unique on the page (`'Casa Delfines'`
+  matching twice; two links both containing "Puerto Viejo de Talamanca").
+  Fixed by mocking `Footer`, matching the existing pattern for every other
+  child component.
+- **`data-is-spanish` used to be a boolean; the mock now passes the
+  `Locale` string straight through (2 failures).** `BookingSearchWidget`'s
+  prop was renamed from an `isSpanish: boolean` to `locale: Locale` at some
+  point; the test mocks were updated to receive the new prop but the
+  assertions still checked for the old `'true'`/`'false'` strings instead of
+  `'es'`/`'en'`.
+- **Three dead content assertions removed** (`'lockbox key drop-off'` /
+  `'caja de seguridad'`, in `ListingDelfin.test.tsx`, `ListingDelfinES.test.tsx`,
+  and `delfinIntegration.test.ts`). Traced to `houseDataEngList` — a separate,
+  apparently-unused legacy data array — which still has this phrase; neither
+  `houseDataList` (what these tests and the real page actually read) nor
+  `listingContent()` (what's actually rendered) has ever had it. Asked the
+  project owner whether to restore it as live copy or remove the stale
+  assertions; **chose to remove** — not shown to any real visitor today.
+- Validation: `tsc --noEmit` clean; full Jest **647/647 passing** (was
+  633/647).
+- **Shipped as a commit on `fix/hydration-cause-3-manual-loader`**, same
+  branch as the hydration fix above (this was a `next session` pickup on the
+  same branch, not a new one).
+- **Next session:** open the PR for this branch (after #62/#63 merge). Same
+  residual-hydration-warnings note as above still applies. Resume Phase 10
+  GSC owner actions.

--- a/docs/i18n-rollout-plan.md
+++ b/docs/i18n-rollout-plan.md
@@ -21,10 +21,10 @@ resume without re-investigating the codebase.
 
 | | |
 |---|---|
-| **Current phase** | **Nine languages, one (Dutch/`nl`) not yet shipped.** Eight languages (EN/ES/DE/FR/IT/PT/HE/HI) have been live and independently verified in production since 2026-08-10 (PRs #52, #54, #60, #61). A ninth, Dutch, was found built out in full but uncommitted, verified, and opened as PR #62 (branch `feat/i18n-phase-12-dutch`) — see [Phase 12](#phase-12--dutch-nl-ninth-language). Phase 11's P0 items and all but one P1/P2 item are now also done, opened as PR #63 (branch `fix/i18n-phase-11-p1-p2`, stacked on PR #62). Next: merge/deploy #62 then #63; decide on hydration cause #3 (the one item still gated on an explicit go-ahead); resume Phase 10 (GSC owner actions, still open on PR #59). |
+| **Current phase** | **Nine languages, one (Dutch/`nl`) not yet shipped.** Eight languages (EN/ES/DE/FR/IT/PT/HE/HI) have been live and independently verified in production since 2026-08-10 (PRs #52, #54, #60, #61). A ninth, Dutch, was found built out in full but uncommitted, verified, and opened as PR #62 (branch `feat/i18n-phase-12-dutch`) — see [Phase 12](#phase-12--dutch-nl-ninth-language). Phase 11's P0 and P1/P2 items are all now done. P1/P2 minus hydration cause #3 opened as PR #63 (branch `fix/i18n-phase-11-p1-p2`, stacked on PR #62). Hydration cause #3 itself fixed and committed (not yet PR'd) on `fix/hydration-cause-3-manual-loader`, stacked on #63 — see the 2026-08-11 "Hydration cause #3 fixed" session log entry. Next: merge/deploy #62 → #63 → the hydration branch (open its PR first); resume Phase 10 (GSC owner actions, still open on PR #59). |
 | **Last updated** | 2026-08-11 |
-| **Branch(es) in flight** | PR #59 (Phase 10 docs) still open, not yet merged. PR #62 (Phase 12, Dutch) open, not yet merged — branch `feat/i18n-phase-12-dutch`. PR #63 (Phase 11 P1/P2) open, stacked on #62, not yet merged — branch `fix/i18n-phase-11-p1-p2`. |
-| **Blocked on** | Nothing blocking except hydration cause #3, which needs an explicit go-ahead before starting (see [Phase 11 P2](#phase-11--post-launch-fixes-and-hardening-found-during-2026-08-10-verification)) — a prior attempt made it worse. Two GSC-access items also remain owner actions. PostHog export (organic sessions, EN vs ES, 12 months) is still the one open Phase 0 owner action. |
+| **Branch(es) in flight** | PR #59 (Phase 10 docs) still open, not yet merged. PR #62 (Phase 12, Dutch) open, not yet merged — branch `feat/i18n-phase-12-dutch`. PR #63 (Phase 11 P1/P2) open, stacked on #62, not yet merged — branch `fix/i18n-phase-11-p1-p2`. `fix/hydration-cause-3-manual-loader`, stacked on #63, committed but no PR opened yet. |
+| **Blocked on** | Nothing blocking. Two GSC-access items remain owner actions. PostHog export (organic sessions, EN vs ES, 12 months) is still the one open Phase 0 owner action. A residual set of ~15-18 harmless-but-unexplained hydration console warnings is filed as a follow-up in the 2026-08-11 session log — needs a temporary non-minified dev build to pin down further, not blocking. |
 
 Phase progress:
 
@@ -1294,7 +1294,7 @@ before this plan can close out clean. Grouped by priority.
 
 **P2 — larger, already-scoped, needs an explicit go-ahead before starting:**
 
-- [ ] Hydration cause #3: `React.lazy()` + `<Suspense>` at the route level is
+- [x] Hydration cause #3: `React.lazy()` + `<Suspense>` at the route level is
       structurally incompatible with react-snap's live-DOM-capture prerender
       (confirmed via `onRecoverableError` component-stack trace — see
       [[hydration_mismatch_language_switcher]]). **Live-confirmed still firing
@@ -1308,7 +1308,9 @@ before this plan can close out clean. Grouped by priority.
       this is the one item in the whole Phase 11 list with an explicit
       go-ahead gate *and* a documented failed attempt; asked the project
       owner rather than assuming a general "work through P1/P2" instruction
-      covers a large, previously-reverted structural change.
+      covers a large, previously-reverted structural change. **Done
+      2026-08-11**, on explicit go-ahead — see the same-day session log entry
+      below for the fix and the bisection investigation that followed it.
 - [x] Investigate why the Jest suite shows **27 failing tests** (300 passed /
       327 total, 3 suites: `ListingDelfin.test.tsx`, `ListingDelfinES.test.tsx`,
       `delfinIntegration.test.ts`) against a fresh install, versus the
@@ -2689,3 +2691,94 @@ onto `main` the way the much older Phase 4-era stack was.
   #62's locale set). Decide on hydration cause #3. Take on the newly-exposed
   14 content-assertion-mismatch failures as their own scoped piece of work.
   Resume Phase 10 (GSC owner actions, PR #59).
+
+### 2026-08-11 — Hydration cause #3 fixed; bisection surfaced and fixed five more prerender-unsafe effects
+
+Same-day continuation, on explicit go-ahead this time (see the P2 gate note
+above). Branch `fix/hydration-cause-3-manual-loader`, stacked on
+`fix/i18n-phase-11-p1-p2`.
+
+- **The fix, per the pre-approved plan.** Route-level `lazy()`/`<Suspense>`
+  replaced with a hand-rolled promise-based loader (new `src/routeLoader.tsx`)
+  that `index.tsx` pre-warms for the current URL before the first
+  `hydrateRoot`/`createRoot` call, so `<RouteLoader>` takes its synchronous
+  cache-hit branch on that render — no Suspense boundary anywhere in the tree,
+  never conditionally reintroduced. Shipped in two commits: an additive Stage
+  A (`routeLoader.tsx` + a `LOADERS` map alongside the old `lazy()`-based one,
+  unreachable, tsc+Jest only), then Stage B (`routes.config.ts`, `Router.tsx`,
+  `index.tsx` flipped together in one commit, since removing `<Suspense>`
+  without the pre-warm gate would flash `null` over prerendered content on
+  every load).
+- **Fixing it unmasked, not created, three further prerender-unsafe effects**
+  — removing the Suspense boundary let hydration reconcile deep enough into
+  the tree to reach them for the first time. Two were found and fixed inline
+  with the plan's own verification pass: `MessageTipContainer`'s
+  `stickyCTAHeight`/`isCookieBannerVisible`/`windowWidth` state, and an
+  identical `isScreenSmall` pattern duplicated across all 10
+  `Listing*.page.tsx` files. Root mechanism for both: react-snap's actual
+  default crawl viewport is **480×850, "mobile first"**
+  (`node_modules/react-snap/index.js`), not desktop-width as several existing
+  code comments wrongly assumed — the crawl's settle-time wait gives an
+  unguarded resize/media-query effect time to fire and bake a mobile-viewport
+  state into the static HTML that a real client's null-seeded first render
+  never matches.
+- **User chose to keep digging (bisection) rather than ship-and-defer** once
+  a residual error cascade remained after those two fixes. Temporarily
+  disabling half of `ListingDelfin`'s render tree and rebuilding narrowed the
+  cascade to the untouched sidebar column, surfacing three more real bugs,
+  same root pattern, different mechanisms:
+  - **`useCalendarMonth`** reads a shared cross-component cache
+    (`peekCalendarMonth`) synchronously on every render rather than local
+    state; its fetch-triggering effect had no prerender guard, so the crawl's
+    real (404, no backend running at build time) response settled into
+    `hasError`/`isLoading` before the snapshot was taken. One hook, four call
+    sites (`PriceConfirmationSection` once, `CalendarWithPriceDots` three
+    times for the visible/anchor/anchor-next month) — fixed once at the hook.
+  - **`OtherListings`, `OtherBlogs`, `ListingAd`, `CallToAction`** — four
+    components whose own doc comments already *described* the
+    null/false-seed-then-guard-the-effect pattern (clearly copied from
+    `MessageTipContainer`'s fix) but never actually added the
+    `isPrerender()` check to the effect body. Comment and code had drifted
+    apart. Same fix applied to all four.
+  - **`useRandomPopup`** had no guard at all — a `Math.random()` roll plus a
+    multi-second `setTimeout` that, if it won the roll and fired inside
+    react-snap's settle window, baked a random marketing popup element into
+    that specific crawled page's snapshot. Non-deterministic per crawl run,
+    which is why it hadn't been pinned down by inspection alone.
+  - Confirmed each fix by diffing the *exact* DOM state at the earlier
+    diagnostic step against the static build before moving to the next lead,
+    not just by re-running the full suite and eyeballing the error count.
+- **A residual set of ~15-18 console-level hydration warnings remains,
+  verified harmless.** Two independent checks — a full structural DOM
+  tree-walk (tags/child-counts/text, prerendered vs. hydrated) and a snapshot
+  taken at the exact instant of the first `onRecoverableError` call — both
+  found **zero** surviving differences in final rendered output, across `/`,
+  `/he/`, `/de/` (default and `--cpu=4` throttled), `/en/delfin`,
+  `/es/delfin`, `/en/blog`, `/en/besttimetovisitpuerto`, and `/404`.
+  Production React's minified error messages carry no embedded diff details
+  for these specific calls, so isolating their exact cause would need a
+  temporary non-minified dev bundle hydrated against the same static HTML —
+  a materially bigger investment than the diagnostics used so far. Asked the
+  project owner: ship now vs. build the dev bundle. **Chose to ship now**,
+  given verified harmlessness. Filed here as the follow-up.
+- **`/en/book` (and the other client-only routes) intentionally still show
+  hydration errors** — there is no prerendered snapshot for them at all
+  (server sends the root shell per `public/.htaccess`, matching the plan's
+  own documented caveat), so the "prerendered" and "wanted" trees are
+  necessarily different on purpose. Confirmed the page still becomes fully
+  functional (correct title, non-empty `#root`) despite the transient
+  errors — not a regression, nothing to fix here.
+- Validation: `tsc --noEmit` clean; full Jest 647 total, 633 passed / 14
+  failed (the same pre-existing content-assertion mismatches from the prior
+  entry, confirmed via `git diff` on the failing files — no new regression);
+  full production build + react-snap crawl 199/199 clean;
+  `inject-route-preloads.js` exit 0; `hydration-diff.mjs` across the sample
+  route set above, `structure: IDENTICAL` on every one.
+- **Shipped as a commit on `fix/hydration-cause-3-manual-loader`**, stacked
+  on `fix/i18n-phase-11-p1-p2`. PR not yet opened as of this entry.
+- **Next session:** open the PR for this branch (after #62/#63 merge, since
+  it stacks on top). If the residual ~15-18 warnings are worth chasing later,
+  that needs a temporary non-minified dev build, not more DOM-diffing — flag
+  before repeating the same technique. Otherwise resume the existing
+  next-session queue: merge #62 → #63 → this branch, the 14
+  content-assertion-mismatch failures, Phase 10 GSC owner actions.

--- a/src/Router/Router.tsx
+++ b/src/Router/Router.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { CookieConsentService } from '../services/CookieConsent.service';
 import * as PostHog from '../services/PostHog.service';
@@ -7,29 +7,33 @@ import { useRandomPopup } from '../hooks/useRandomPopup';
 import PortalGuard from '../components/PortalGuard/PortalGuard.component';
 import { useLocale, RELEASED_LOCALES } from '../i18n';
 import LocaleHtmlAttrs from '../components/LocaleHtmlAttrs/LocaleHtmlAttrs.component';
-import { lazy } from 'react';
 import { ROUTES, pathForKey, RouteKey } from '../routes.config';
-
-const NotFound = lazy(() => import(/* webpackChunkName: "route-404" */ '../pages/NotFound.page'));
+import { RouteLoader } from '../routeLoader';
 
 /*
- * Every routed page is declared once in src/routes.config.ts — key, lazy
- * component, webpackChunkName, and its slug in each locale — and this file
- * turns that table into the actual <Route> tree, one element per
+ * Every routed page is declared once in src/routes.config.ts — key,
+ * loadable module, webpackChunkName, and its slug in each locale — and this
+ * file turns that table into the actual <Route> tree, one element per
  * (key, released locale) pair.
+ *
+ * No React.lazy()/<Suspense> anywhere in this file (or the rest of the
+ * app) — see routeLoader.tsx's header comment for why: react-snap's
+ * marker-less prerendered output can't hydrate cleanly against a Suspense
+ * boundary, regardless of whether its child actually suspends on a given
+ * render. <RouteLoader> is a plain promise-based loader instead;
+ * index.tsx pre-warms the current page's entry before the first render so
+ * <RouteLoader> takes its synchronous cache-hit branch on that render.
  *
  * The webpackChunkName comments living in routes.config.ts are still
  * load-bearing: scripts/inject-route-preloads.js recomputes those names
  * after build and fails if one goes missing from asset-manifest.json.
  */
 const ROUTE_ELEMENTS: React.ReactNode[] = (Object.keys(ROUTES) as RouteKey[]).flatMap((key) => {
-  const def = ROUTES[key];
-  const Component = def.component;
   return RELEASED_LOCALES.map((locale) => {
     const path = pathForKey(key, locale);
     const element = key === 'portalDetail'
-      ? <PortalGuard><Component /></PortalGuard>
-      : <Component />;
+      ? <PortalGuard><RouteLoader routeKey={key} /></PortalGuard>
+      : <RouteLoader routeKey={key} />;
     return <Route key={`${key}-${locale}`} path={path} element={element} />;
   });
 });
@@ -78,34 +82,32 @@ const AppRouter = () => {
       <LocaleHtmlAttrs />
       <PostHogPageView />
       <RandomPopupHandler />
-      <Suspense fallback={null}>
-        <Routes>
-          {ROUTE_ELEMENTS}
+      <Routes>
+        {ROUTE_ELEMENTS}
 
-          {/*
-            English keeps the bare root ('/') as its canonical home — see
-            pathForKey() in routes.config.ts. '/en' and '/en/' would otherwise
-            be a second, duplicate-content copy of the same page, so both
-            redirect client-side. Phase 5 adds the equivalent server-level
-            301 in public/.htaccess for crawlers and direct hits that never
-            load the SPA; this covers in-app navigation and dev.
-          */}
-          <Route path="/en" element={<Navigate to="/" replace />} />
-          <Route path="/en/" element={<Navigate to="/" replace />} />
+        {/*
+          English keeps the bare root ('/') as its canonical home — see
+          pathForKey() in routes.config.ts. '/en' and '/en/' would otherwise
+          be a second, duplicate-content copy of the same page, so both
+          redirect client-side. Phase 5 adds the equivalent server-level
+          301 in public/.htaccess for crawlers and direct hits that never
+          load the SPA; this covers in-app navigation and dev.
+        */}
+        <Route path="/en" element={<Navigate to="/" replace />} />
+        <Route path="/en/" element={<Navigate to="/" replace />} />
 
-          {/*
-            A dedicated route, separate from the "*" catch-all below, so
-            react-snap (which navigates to explicit paths, not wildcards — see
-            package.json's reactSnap.include) can prerender a static 404.html.
-            scripts/generate-404.js copies the resulting build/404/index.html
-            to build/404.html, and .htaccess serves it with a real HTTP 404
-            status via ErrorDocument, instead of the soft-404 (200 + blank/
-            generic page) unknown URLs used to get.
-          */}
-          <Route path="/404" element={<NotFound />} />
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </Suspense>
+        {/*
+          A dedicated route, separate from the "*" catch-all below, so
+          react-snap (which navigates to explicit paths, not wildcards — see
+          package.json's reactSnap.include) can prerender a static 404.html.
+          scripts/generate-404.js copies the resulting build/404/index.html
+          to build/404.html, and .htaccess serves it with a real HTTP 404
+          status via ErrorDocument, instead of the soft-404 (200 + blank/
+          generic page) unknown URLs used to get.
+        */}
+        <Route path="/404" element={<RouteLoader routeKey="notFound" />} />
+        <Route path="*" element={<RouteLoader routeKey="notFound" />} />
+      </Routes>
       <MessageTipContainer />
     </BrowserRouter>
   );

--- a/src/Router/__tests__/DelfinRouting.test.tsx
+++ b/src/Router/__tests__/DelfinRouting.test.tsx
@@ -154,21 +154,34 @@ describe('Delfin Routing Integration Tests', () => {
       expect(pathForKey('delfin', 'es')).toBe('/es/delfin');
     });
 
-    test('should verify proper lazy import exists in routes.config.ts', () => {
-      // routes.config.ts is where every page's lazy() import now lives
-      // (Router.tsx just consumes the resulting component references), so
-      // that's the file whose source text is meaningful to assert against.
+    test('should verify Delfin has a loader entry in routes.config.ts, and that lazy() is gone entirely', () => {
+      // routes.config.ts is where every page's dynamic import now lives
+      // (Router.tsx just renders <RouteLoader routeKey={key} />), so that's
+      // the file whose source text is meaningful to assert against.
+      //
+      // Hydration cause #3 fix (docs/i18n-rollout-plan.md, Phase 11 P2):
+      // React.lazy()/<Suspense> can't hydrate cleanly against react-snap's
+      // marker-less prerendered output, so LOADERS + routeLoader.tsx's plain
+      // promise-based loader replaced them — see routeLoader.tsx's header
+      // comment for the full account. Asserting the `lazy` import from
+      // 'react' is entirely gone (not just checking for the new pattern),
+      // so a future partial revert can't silently reintroduce a stray
+      // lazy() call with nothing here to catch it. Matching the import
+      // rather than the bare word "lazy" on purpose — this file's own
+      // comments explain the removal by name ("React.lazy()"), and without
+      // the import, lazy(...) isn't a callable identifier here regardless.
       const fs = require('fs');
       const path = require('path');
       const routesConfigPath = path.join(__dirname, '../../routes.config.ts');
       const routesConfigContent = fs.readFileSync(routesConfigPath, 'utf8');
 
       expect(routesConfigContent).toMatch(
-        /const ListingDelfin = lazy\(\(\) => import\([^)]*'\.\/pages\/Listing\/staticPages\/ListingDelfin\.page'\)\)/
+        /delfin:\s*\(\)\s*=>\s*import\([^)]*'\.\/pages\/Listing\/staticPages\/ListingDelfin\.page'\)/
       );
+      expect(routesConfigContent).not.toMatch(/import\s*\{[^}]*\blazy\b[^}]*\}\s*from\s*'react'/);
       // Phase 3b merged the Spanish page into the English one, so there is no
       // longer a separate ListingDelfinES binding — both routes render the
-      // same lazy component and the locale comes from the URL.
+      // same loaded component and the locale comes from the URL.
       expect(routesConfigContent).not.toMatch(/const ListingDelfinES\s*=/);
     });
   });

--- a/src/components/CallToAction/CallToAction.component.tsx
+++ b/src/components/CallToAction/CallToAction.component.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import './CallToAction.style.scss'
 import Smoobu2 from '../Smoobu2/Smoobu2.component';
 import { useMessages } from '../../i18n';
+import { isPrerender } from '../../utils/isPrerender';
 
 /**
  * Replaces the former CallToAction / CallToActionES pair.
@@ -21,6 +22,13 @@ const CallToAction = () => {
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
+    // react-snap's crawl gives this effect time to settle before it captures
+    // the page, so without this guard isMobile gets seeded from the crawl's
+    // own (mobile) viewport and bakes its inline style values into the
+    // static HTML — mismatching a real desktop client's false-seeded first
+    // render. Same pattern as OtherListings/MessageTipContainer; see
+    // docs/i18n-rollout-plan.md Phase 11 P2.
+    if (isPrerender()) return;
     const checkScreenSize = () => {
       setIsMobile(window.innerWidth < 768);
     };

--- a/src/components/MessageTip/MessageTipContainer.component.tsx
+++ b/src/components/MessageTip/MessageTipContainer.component.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import MessageTip from './MessageTip.component';
+import { isPrerender } from '../../utils/isPrerender';
 import './MessageTip.style.scss';
 
 export interface MessageTipData {
@@ -54,9 +55,24 @@ const MessageTipContainer: React.FC<MessageTipContainerProps> = ({ className }) 
   // Check for cookie banner visibility and sticky CTA height
   useEffect(() => {
     const checkElements = () => {
+      // Guard the state change, not the render — same reasoning as
+      // isPrerender.ts's ImageWithSkeleton/CookieConsentBanner cases.
+      // react-snap's crawl waits for the page to settle before snapshotting,
+      // which gives this effect (and the resize/mutation listeners below)
+      // plenty of time to run — long enough that a mobile-width crawl
+      // viewport bakes stickyCTAHeight/isCookieBannerVisible's post-effect
+      // values (and the containerClassName/containerStyle they drive) into
+      // the static HTML. A real hydrating browser's FIRST render always
+      // starts from this component's initial state instead, so without this
+      // guard the snapshot and the first hydration pass can disagree —
+      // React error #418, discovered 2026-08-11 once removing route-level
+      // Suspense (docs/i18n-rollout-plan.md, Phase 11 P2) let hydration
+      // reconcile far enough to reach this sibling for the first time.
+      if (isPrerender()) return;
+
       const cookieBanner = document.querySelector('.cookie-consent-banner');
       const stickyCTA = document.querySelector('.sticky-cta-mobile');
-      
+
       // Use React.startTransition to avoid act() warnings in tests
       if (typeof React.startTransition === 'function') {
         React.startTransition(() => {
@@ -72,7 +88,9 @@ const MessageTipContainer: React.FC<MessageTipContainerProps> = ({ className }) 
     // Initial check
     checkElements();
     // Real width, read only after mount — see the windowWidth state comment.
-    setWindowWidth(window.innerWidth);
+    // Same isPrerender() reasoning as checkElements() above: windowWidth
+    // drives isMobile, which gates containerStyle.bottom.
+    if (!isPrerender()) setWindowWidth(window.innerWidth);
 
     // Set up observer to watch for changes
     const observer = new MutationObserver(checkElements);
@@ -85,7 +103,7 @@ const MessageTipContainer: React.FC<MessageTipContainerProps> = ({ className }) 
 
     // Also listen for resize events to recalculate heights
     const handleResize = () => {
-      setWindowWidth(window.innerWidth);
+      if (!isPrerender()) setWindowWidth(window.innerWidth);
       checkElements();
     };
     window.addEventListener('resize', handleResize);

--- a/src/hooks/useCalendarMonth.ts
+++ b/src/hooks/useCalendarMonth.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BookingLanguage, CalendarMonthResponse } from '../services/BookingApi.service';
 import { calendarMonthKey, loadCalendarMonth, peekCalendarMonth } from '../services/calendarMonthCache';
+import { isPrerender } from '../utils/isPrerender';
 
 interface UseCalendarMonthResult {
   data: CalendarMonthResponse | undefined;
@@ -29,6 +30,18 @@ export function useCalendarMonth(
   const [errorKey, setErrorKey] = React.useState<string | null>(null);
 
   React.useEffect(() => {
+    // react-snap's crawl gives this effect time to settle before it captures
+    // the page (network-idle wait), so an unguarded fetch here bakes whatever
+    // it resolved to — including an error state once the crawl's own 404
+    // response lands — into the static HTML. A real visitor's first paint
+    // never has that: hydration then mismatches the frozen "not yet fetched"
+    // render this guard preserves instead. Same pattern as isScreenSmall in
+    // the listing pages and MessageTipContainer; see docs/i18n-rollout-plan.md
+    // Phase 11 P2.
+    if (isPrerender()) {
+      return;
+    }
+
     if (!apartmentSlug || !enabled || peekCalendarMonth(key)) {
       return;
     }

--- a/src/hooks/useRandomPopup.ts
+++ b/src/hooks/useRandomPopup.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useMessageTip } from '../components/MessageTip/MessageTipContainer.component';
 import { RANDOM_POPUP_CONFIG } from '../utils/constants';
 import { pickLocalized, type Locale } from '../i18n';
+import { isPrerender } from '../utils/isPrerender';
 
 interface UseRandomPopupOptions {
   locale?: Locale;
@@ -44,6 +45,13 @@ export const useRandomPopup = (options: UseRandomPopupOptions = {}) => {
   const { addMessageTip } = useMessageTip();
 
   useEffect(() => {
+    // react-snap's crawl waits for the page to settle, which is easily long
+    // enough for this effect's own timer to fire mid-crawl — baking a random
+    // popup (a real child element of MessageTipContainer) into that page's
+    // static HTML, keyed off a Math.random() roll a real visitor's own
+    // hydration never repeats. Same pattern as MessageTipContainer's other
+    // guarded state; see docs/i18n-rollout-plan.md Phase 11 P2.
+    if (isPrerender()) return;
     if (!enabled) return;
 
     // Check if popup was already shown using improved detection

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { CookieConsentService } from './services/CookieConsent.service';
 import { initPostHogIfConsented } from './services/PostHog.service';
+import { routeKeyForPath } from './routes.config';
+import { preloadRoute, type LoadableKey } from './routeLoader';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
@@ -30,17 +32,47 @@ initPostHogIfConsented();
 
 const rootElement = document.getElementById('root') as HTMLElement;
 
-if (rootElement.hasChildNodes()) {
-  // Pre-rendered by react-snap — hydrate instead of full render
-  ReactDOM.hydrateRoot(rootElement, <App />);
-} else {
-  const root = ReactDOM.createRoot(rootElement);
-  root.render(
-    // <React.StrictMode>
-      <App />
-    // </React.StrictMode>
-  );
+/*
+ * Hydration cause #3 (docs/i18n-rollout-plan.md, Phase 11 P2): resolve and
+ * cache the current URL's route component BEFORE the first render call.
+ * hydrateRoot's first pass reconciles synchronously against the existing
+ * (pre-rendered) DOM — anything that only resolves later, an effect or a
+ * React.lazy() throw, is too late to avoid a mismatch, since react-snap's
+ * prerendered HTML has no hydration markers for React to fall back on. See
+ * routeLoader.tsx's header comment for the full mechanism, and Router.tsx's
+ * <RouteLoader> — its cache-hit branch, taken here because of this pre-warm,
+ * is the only branch safe to take on this first render.
+ *
+ * react-snap's own crawl runs this exact module too (fresh page/context per
+ * URL, rootElement empty on first paint, same as a real cold visitor), so
+ * pre-warming benefits the prerendered snapshot as well as real hydration.
+ */
+const initialRouteMatch = routeKeyForPath(window.location.pathname);
+const initialRouteKey: LoadableKey = initialRouteMatch ? initialRouteMatch.key : 'notFound';
+
+function mount(): void {
+  if (rootElement.hasChildNodes()) {
+    // Pre-rendered by react-snap — hydrate instead of full render
+    ReactDOM.hydrateRoot(rootElement, <App />);
+  } else {
+    const root = ReactDOM.createRoot(rootElement);
+    root.render(
+      // <React.StrictMode>
+        <App />
+      // </React.StrictMode>
+    );
+  }
 }
+
+// A failed initial chunk load must not leave the page permanently
+// un-mounted (strictly worse than today's transient hydration error) — log
+// and mount anyway. <RouteLoader> falls back to its own effect-driven retry
+// for whatever didn't warm in time.
+preloadRoute(initialRouteKey)
+  .catch((error) => {
+    console.error(`[index] failed to preload initial route "${initialRouteKey}"`, error);
+  })
+  .then(mount);
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))

--- a/src/pages/Blog/Components/ListingAd/ListingAd.component.tsx
+++ b/src/pages/Blog/Components/ListingAd/ListingAd.component.tsx
@@ -6,6 +6,7 @@ import Slider from "react-slick";
 import { SampleNextArrow, SamplePrevArrow } from "../../../../components/CustomSlick/SlickDarkArrow.Component";
 import { useMessages } from '../../../../i18n';
 import { pathForLegacyId } from '../../../../routes.config';
+import { isPrerender } from '../../../../utils/isPrerender';
 
 interface IOtherListing {
     listings: ListingType[]
@@ -27,6 +28,14 @@ const ListingAd: FC<IOtherListing> = ({ listings }) => {
     const navigate = useNavigate()
 
     useEffect(() => {
+        // react-snap's crawl gives this effect time to settle before it
+        // captures the page, so without this guard windowWidth gets seeded
+        // from the crawl's own viewport and bakes a structural difference
+        // (Slider vs plain div) into the static HTML — mismatching a real
+        // client's null-seeded first render at any other viewport. Same
+        // pattern as OtherListings/MessageTipContainer; see
+        // docs/i18n-rollout-plan.md Phase 11 P2.
+        if (isPrerender()) return;
         const handleResize = () => setWindowWidth(window.innerWidth);
         handleResize(); // real width, read only after mount
         window.addEventListener("resize", handleResize);

--- a/src/pages/Blog/Components/OtherBlogs.Component.tsx
+++ b/src/pages/Blog/Components/OtherBlogs.Component.tsx
@@ -8,6 +8,7 @@ import { cdnImage } from "../../../utils/imageCdn";
 import { useMessages, type Locale } from '../../../i18n';
 import { blogArticleHeading } from '../../../i18n/blogArticleHeadings';
 import { routeKeyForSlug, pathForKey } from '../../../routes.config';
+import { isPrerender } from '../../../utils/isPrerender';
 
 interface IOtherBlogs {
   currentBlog: string
@@ -32,6 +33,13 @@ const OtherBlogs: FC<IOtherBlogs> = ({ currentBlog, locale }) => {
   }, [])
 
   useEffect(() => {
+    // react-snap's crawl gives this effect time to settle before it captures
+    // the page, so without this guard windowWidth gets seeded from the
+    // crawl's own viewport and bakes that slidesToShow into the static HTML
+    // — mismatching a real client's null-seeded first render at any other
+    // viewport. Same pattern as OtherListings/MessageTipContainer; see
+    // docs/i18n-rollout-plan.md Phase 11 P2.
+    if (isPrerender()) return
     handleResize() // real width, read only after mount
     window.addEventListener("resize", handleResize)
     return () => window.removeEventListener("resize", handleResize)

--- a/src/pages/Listing/components/OtherListings/OtherListings.component.tsx
+++ b/src/pages/Listing/components/OtherListings/OtherListings.component.tsx
@@ -4,6 +4,7 @@ import { ListingType } from "../../../../utils/types";
 import { useNavigate } from "react-router-dom";
 import { useLocale, useMessages } from "../../../../i18n";
 import { pathForKey, routeKeyForSlug } from "../../../../routes.config";
+import { isPrerender } from "../../../../utils/isPrerender";
 
 interface IOtherListings {
     currentListing: string
@@ -59,6 +60,14 @@ const OtherListings: FC<IOtherListings> = ({ currentListing, listings }) => {
     }, [])
 
     useEffect(() => {
+        // react-snap's crawl gives this effect time to settle before it
+        // captures the page, so without this guard windowWidth gets seeded
+        // from the crawl's own (mobile) viewport and bakes that layoutClass
+        // into the static HTML — mismatching a real client's null-seeded
+        // first render at any other viewport. Same pattern as isScreenSmall
+        // in the listing pages and MessageTipContainer's windowWidth; see
+        // docs/i18n-rollout-plan.md Phase 11 P2.
+        if (isPrerender()) return
         handleResize() // real width, read only after mount
         window.addEventListener("resize", handleResize)
         return () => window.removeEventListener("resize", handleResize)

--- a/src/pages/Listing/staticPages/ListingAreka.page.tsx
+++ b/src/pages/Listing/staticPages/ListingAreka.page.tsx
@@ -22,6 +22,7 @@ import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { listingContent } from "../../../i18n/content/listings";
 import { houseDataByLangCode } from "../../../utils/constants";
+import { isPrerender } from "../../../utils/isPrerender";
 
 
 const ListingAreka = () => {
@@ -33,10 +34,16 @@ const ListingAreka = () => {
     // react-snap's puppeteer viewport at prerender time and a real visitor's
     // viewport at hydration time are different numbers, and isScreenSmall
     // drives whether the sticky mobile CTA div renders at all (a structural
-    // difference, not just style). Same fix as
-    // MessageTipContainer.component.tsx: null means "not yet measured" (no
-    // CTA div, matching react-snap's desktop-sized prerender) until the
-    // effect below sets the real match post-mount.
+    // difference, not just style). null means "not yet measured" (no CTA
+    // div) until the effect below sets the real match post-mount — and that
+    // effect is now itself isPrerender()-guarded, because react-snap's
+    // actual crawl viewport is 480x850 ("mobile first", its own default),
+    // not desktop-width as previously assumed here: without the guard this
+    // media query matches true during the crawl and bakes the mobile CTA
+    // div into the snapshot, mismatching a real client's null-seeded first
+    // render. React error #418, found 2026-08-11 once removing route-level
+    // Suspense (docs/i18n-rollout-plan.md, Phase 11 P2) let hydration
+    // reconcile far enough to reach this element for the first time.
     const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
     const [show, setShow] = useState(false);
@@ -51,6 +58,7 @@ const ListingAreka = () => {
     }, [])
 
     useEffect(() => {
+        if (isPrerender()) return;
         const mq = window.matchMedia('(max-width: 992px)');
         setIsScreenSmall(mq.matches); // real match, read only after mount
         const handleChange = () => setIsScreenSmall(mq.matches);

--- a/src/pages/Listing/staticPages/ListingDelfin.page.tsx
+++ b/src/pages/Listing/staticPages/ListingDelfin.page.tsx
@@ -22,6 +22,7 @@ import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { listingContent } from "../../../i18n/content/listings";
 import { houseDataByLangCode } from "../../../utils/constants";
+import { isPrerender } from "../../../utils/isPrerender";
 
 
 const ListingDelfin = () => {
@@ -34,10 +35,16 @@ const ListingDelfin = () => {
     // react-snap's puppeteer viewport at prerender time and a real visitor's
     // viewport at hydration time are different numbers, and isScreenSmall
     // drives whether the sticky mobile CTA div renders at all (a structural
-    // difference, not just style). Same fix as
-    // MessageTipContainer.component.tsx: null means "not yet measured" (no
-    // CTA div, matching react-snap's desktop-sized prerender) until the
-    // effect below sets the real match post-mount.
+    // difference, not just style). null means "not yet measured" (no CTA
+    // div) until the effect below sets the real match post-mount — and that
+    // effect is now itself isPrerender()-guarded, because react-snap's
+    // actual crawl viewport is 480x850 ("mobile first", its own default),
+    // not desktop-width as previously assumed here: without the guard this
+    // media query matches true during the crawl and bakes the mobile CTA
+    // div into the snapshot, mismatching a real client's null-seeded first
+    // render. React error #418, found 2026-08-11 once removing route-level
+    // Suspense (docs/i18n-rollout-plan.md, Phase 11 P2) let hydration
+    // reconcile far enough to reach this element for the first time.
     const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
     const [show, setShow] = useState(false);
@@ -52,6 +59,7 @@ const ListingDelfin = () => {
     }, [])
 
     useEffect(() => {
+        if (isPrerender()) return;
         const mq = window.matchMedia('(max-width: 992px)');
         setIsScreenSmall(mq.matches); // real match, read only after mount
         const handleChange = () => setIsScreenSmall(mq.matches);

--- a/src/pages/Listing/staticPages/ListingGeco.page.tsx
+++ b/src/pages/Listing/staticPages/ListingGeco.page.tsx
@@ -23,6 +23,7 @@ import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { listingContent } from "../../../i18n/content/listings";
 import { houseDataByLangCode } from "../../../utils/constants";
+import { isPrerender } from "../../../utils/isPrerender";
 
 
 const ListingGeco = () => {
@@ -34,10 +35,16 @@ const ListingGeco = () => {
     // react-snap's puppeteer viewport at prerender time and a real visitor's
     // viewport at hydration time are different numbers, and isScreenSmall
     // drives whether the sticky mobile CTA div renders at all (a structural
-    // difference, not just style). Same fix as
-    // MessageTipContainer.component.tsx: null means "not yet measured" (no
-    // CTA div, matching react-snap's desktop-sized prerender) until the
-    // effect below sets the real match post-mount.
+    // difference, not just style). null means "not yet measured" (no CTA
+    // div) until the effect below sets the real match post-mount — and that
+    // effect is now itself isPrerender()-guarded, because react-snap's
+    // actual crawl viewport is 480x850 ("mobile first", its own default),
+    // not desktop-width as previously assumed here: without the guard this
+    // media query matches true during the crawl and bakes the mobile CTA
+    // div into the snapshot, mismatching a real client's null-seeded first
+    // render. React error #418, found 2026-08-11 once removing route-level
+    // Suspense (docs/i18n-rollout-plan.md, Phase 11 P2) let hydration
+    // reconcile far enough to reach this element for the first time.
     const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
     const [show, setShow] = useState(false);
 
@@ -53,6 +60,7 @@ const ListingGeco = () => {
     }, [])
 
     useEffect(() => {
+        if (isPrerender()) return;
         const mq = window.matchMedia('(max-width: 992px)');
         setIsScreenSmall(mq.matches); // real match, read only after mount
         const handleChange = () => setIsScreenSmall(mq.matches);

--- a/src/pages/Listing/staticPages/ListingGiulia.page.tsx
+++ b/src/pages/Listing/staticPages/ListingGiulia.page.tsx
@@ -22,6 +22,7 @@ import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { listingContent } from "../../../i18n/content/listings";
 import { houseDataByLangCode } from "../../../utils/constants";
+import { isPrerender } from "../../../utils/isPrerender";
 
 
 const ListingGiulia = () => {
@@ -33,10 +34,16 @@ const ListingGiulia = () => {
     // react-snap's puppeteer viewport at prerender time and a real visitor's
     // viewport at hydration time are different numbers, and isScreenSmall
     // drives whether the sticky mobile CTA div renders at all (a structural
-    // difference, not just style). Same fix as
-    // MessageTipContainer.component.tsx: null means "not yet measured" (no
-    // CTA div, matching react-snap's desktop-sized prerender) until the
-    // effect below sets the real match post-mount.
+    // difference, not just style). null means "not yet measured" (no CTA
+    // div) until the effect below sets the real match post-mount — and that
+    // effect is now itself isPrerender()-guarded, because react-snap's
+    // actual crawl viewport is 480x850 ("mobile first", its own default),
+    // not desktop-width as previously assumed here: without the guard this
+    // media query matches true during the crawl and bakes the mobile CTA
+    // div into the snapshot, mismatching a real client's null-seeded first
+    // render. React error #418, found 2026-08-11 once removing route-level
+    // Suspense (docs/i18n-rollout-plan.md, Phase 11 P2) let hydration
+    // reconcile far enough to reach this element for the first time.
     const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
     const [show, setShow] = useState(false);
 
@@ -50,6 +57,7 @@ const ListingGiulia = () => {
     }, [])
 
     useEffect(() => {
+        if (isPrerender()) return;
         const mq = window.matchMedia('(max-width: 992px)');
         setIsScreenSmall(mq.matches); // real match, read only after mount
         const handleChange = () => setIsScreenSmall(mq.matches);

--- a/src/pages/Listing/staticPages/ListingPappagallo.page.tsx
+++ b/src/pages/Listing/staticPages/ListingPappagallo.page.tsx
@@ -22,6 +22,7 @@ import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { listingContent } from "../../../i18n/content/listings";
 import { houseDataByLangCode } from "../../../utils/constants";
+import { isPrerender } from "../../../utils/isPrerender";
 
 
 const ListingPappagallo = () => {
@@ -33,10 +34,16 @@ const ListingPappagallo = () => {
     // react-snap's puppeteer viewport at prerender time and a real visitor's
     // viewport at hydration time are different numbers, and isScreenSmall
     // drives whether the sticky mobile CTA div renders at all (a structural
-    // difference, not just style). Same fix as
-    // MessageTipContainer.component.tsx: null means "not yet measured" (no
-    // CTA div, matching react-snap's desktop-sized prerender) until the
-    // effect below sets the real match post-mount.
+    // difference, not just style). null means "not yet measured" (no CTA
+    // div) until the effect below sets the real match post-mount — and that
+    // effect is now itself isPrerender()-guarded, because react-snap's
+    // actual crawl viewport is 480x850 ("mobile first", its own default),
+    // not desktop-width as previously assumed here: without the guard this
+    // media query matches true during the crawl and bakes the mobile CTA
+    // div into the snapshot, mismatching a real client's null-seeded first
+    // render. React error #418, found 2026-08-11 once removing route-level
+    // Suspense (docs/i18n-rollout-plan.md, Phase 11 P2) let hydration
+    // reconcile far enough to reach this element for the first time.
     const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
     const [show, setShow] = useState(false);
@@ -51,6 +58,7 @@ const ListingPappagallo = () => {
     }, [])
 
     useEffect(() => {
+        if (isPrerender()) return;
         const mq = window.matchMedia('(max-width: 992px)');
         setIsScreenSmall(mq.matches); // real match, read only after mount
         const handleChange = () => setIsScreenSmall(mq.matches);

--- a/src/pages/Listing/staticPages/ListingPlumeria.page.tsx
+++ b/src/pages/Listing/staticPages/ListingPlumeria.page.tsx
@@ -22,6 +22,7 @@ import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { listingContent } from "../../../i18n/content/listings";
 import { houseDataByLangCode } from "../../../utils/constants";
+import { isPrerender } from "../../../utils/isPrerender";
 
 
 const ListingPlumeria = () => {
@@ -33,10 +34,16 @@ const ListingPlumeria = () => {
     // react-snap's puppeteer viewport at prerender time and a real visitor's
     // viewport at hydration time are different numbers, and isScreenSmall
     // drives whether the sticky mobile CTA div renders at all (a structural
-    // difference, not just style). Same fix as
-    // MessageTipContainer.component.tsx: null means "not yet measured" (no
-    // CTA div, matching react-snap's desktop-sized prerender) until the
-    // effect below sets the real match post-mount.
+    // difference, not just style). null means "not yet measured" (no CTA
+    // div) until the effect below sets the real match post-mount — and that
+    // effect is now itself isPrerender()-guarded, because react-snap's
+    // actual crawl viewport is 480x850 ("mobile first", its own default),
+    // not desktop-width as previously assumed here: without the guard this
+    // media query matches true during the crawl and bakes the mobile CTA
+    // div into the snapshot, mismatching a real client's null-seeded first
+    // render. React error #418, found 2026-08-11 once removing route-level
+    // Suspense (docs/i18n-rollout-plan.md, Phase 11 P2) let hydration
+    // reconcile far enough to reach this element for the first time.
     const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
     const [show, setShow] = useState(false);
 
@@ -50,6 +57,7 @@ const ListingPlumeria = () => {
     }, [])
 
     useEffect(() => {
+        if (isPrerender()) return;
         const mq = window.matchMedia('(max-width: 992px)');
         setIsScreenSmall(mq.matches); // real match, read only after mount
         const handleChange = () => setIsScreenSmall(mq.matches);

--- a/src/pages/Listing/staticPages/ListingRana.page.tsx
+++ b/src/pages/Listing/staticPages/ListingRana.page.tsx
@@ -22,6 +22,7 @@ import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { listingContent } from "../../../i18n/content/listings";
 import { houseDataByLangCode } from "../../../utils/constants";
+import { isPrerender } from "../../../utils/isPrerender";
 
 
 const ListingRana = () => {
@@ -34,10 +35,16 @@ const ListingRana = () => {
     // react-snap's puppeteer viewport at prerender time and a real visitor's
     // viewport at hydration time are different numbers, and isScreenSmall
     // drives whether the sticky mobile CTA div renders at all (a structural
-    // difference, not just style). Same fix as
-    // MessageTipContainer.component.tsx: null means "not yet measured" (no
-    // CTA div, matching react-snap's desktop-sized prerender) until the
-    // effect below sets the real match post-mount.
+    // difference, not just style). null means "not yet measured" (no CTA
+    // div) until the effect below sets the real match post-mount — and that
+    // effect is now itself isPrerender()-guarded, because react-snap's
+    // actual crawl viewport is 480x850 ("mobile first", its own default),
+    // not desktop-width as previously assumed here: without the guard this
+    // media query matches true during the crawl and bakes the mobile CTA
+    // div into the snapshot, mismatching a real client's null-seeded first
+    // render. React error #418, found 2026-08-11 once removing route-level
+    // Suspense (docs/i18n-rollout-plan.md, Phase 11 P2) let hydration
+    // reconcile far enough to reach this element for the first time.
     const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
     const [show, setShow] = useState(false);
@@ -52,6 +59,7 @@ const ListingRana = () => {
     }, [])
 
     useEffect(() => {
+        if (isPrerender()) return;
         const mq = window.matchMedia('(max-width: 992px)');
         setIsScreenSmall(mq.matches); // real match, read only after mount
         const handleChange = () => setIsScreenSmall(mq.matches);

--- a/src/pages/Listing/staticPages/ListingTucano.page.tsx
+++ b/src/pages/Listing/staticPages/ListingTucano.page.tsx
@@ -22,6 +22,7 @@ import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { listingContent } from "../../../i18n/content/listings";
 import { houseDataByLangCode } from "../../../utils/constants";
+import { isPrerender } from "../../../utils/isPrerender";
 
 
 const ListingTucano = () => {
@@ -33,10 +34,16 @@ const ListingTucano = () => {
     // react-snap's puppeteer viewport at prerender time and a real visitor's
     // viewport at hydration time are different numbers, and isScreenSmall
     // drives whether the sticky mobile CTA div renders at all (a structural
-    // difference, not just style). Same fix as
-    // MessageTipContainer.component.tsx: null means "not yet measured" (no
-    // CTA div, matching react-snap's desktop-sized prerender) until the
-    // effect below sets the real match post-mount.
+    // difference, not just style). null means "not yet measured" (no CTA
+    // div) until the effect below sets the real match post-mount — and that
+    // effect is now itself isPrerender()-guarded, because react-snap's
+    // actual crawl viewport is 480x850 ("mobile first", its own default),
+    // not desktop-width as previously assumed here: without the guard this
+    // media query matches true during the crawl and bakes the mobile CTA
+    // div into the snapshot, mismatching a real client's null-seeded first
+    // render. React error #418, found 2026-08-11 once removing route-level
+    // Suspense (docs/i18n-rollout-plan.md, Phase 11 P2) let hydration
+    // reconcile far enough to reach this element for the first time.
     const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
 
     const [show, setShow] = useState(false);
@@ -51,6 +58,7 @@ const ListingTucano = () => {
     }, [])
 
     useEffect(() => {
+        if (isPrerender()) return;
         const mq = window.matchMedia('(max-width: 992px)');
         setIsScreenSmall(mq.matches); // real match, read only after mount
         const handleChange = () => setIsScreenSmall(mq.matches);

--- a/src/pages/Listing/staticPages/ListingVillaCoral.page.tsx
+++ b/src/pages/Listing/staticPages/ListingVillaCoral.page.tsx
@@ -22,6 +22,7 @@ import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { listingContent } from "../../../i18n/content/listings";
 import { houseDataByLangCode } from "../../../utils/constants";
+import { isPrerender } from "../../../utils/isPrerender";
 
 
 const ListingVillaCoral = () => {
@@ -33,10 +34,16 @@ const ListingVillaCoral = () => {
     // react-snap's puppeteer viewport at prerender time and a real visitor's
     // viewport at hydration time are different numbers, and isScreenSmall
     // drives whether the sticky mobile CTA div renders at all (a structural
-    // difference, not just style). Same fix as
-    // MessageTipContainer.component.tsx: null means "not yet measured" (no
-    // CTA div, matching react-snap's desktop-sized prerender) until the
-    // effect below sets the real match post-mount.
+    // difference, not just style). null means "not yet measured" (no CTA
+    // div) until the effect below sets the real match post-mount — and that
+    // effect is now itself isPrerender()-guarded, because react-snap's
+    // actual crawl viewport is 480x850 ("mobile first", its own default),
+    // not desktop-width as previously assumed here: without the guard this
+    // media query matches true during the crawl and bakes the mobile CTA
+    // div into the snapshot, mismatching a real client's null-seeded first
+    // render. React error #418, found 2026-08-11 once removing route-level
+    // Suspense (docs/i18n-rollout-plan.md, Phase 11 P2) let hydration
+    // reconcile far enough to reach this element for the first time.
     const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
     const [show, setShow] = useState(false);
 
@@ -58,6 +65,7 @@ const ListingVillaCoral = () => {
     }, [])
 
     useEffect(() => {
+        if (isPrerender()) return;
         const mq = window.matchMedia('(max-width: 992px)');
         setIsScreenSmall(mq.matches); // real match, read only after mount
         const handleChange = () => setIsScreenSmall(mq.matches);

--- a/src/pages/Listing/staticPages/ListingVillaMar.page.tsx
+++ b/src/pages/Listing/staticPages/ListingVillaMar.page.tsx
@@ -22,6 +22,7 @@ import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { listingContent } from "../../../i18n/content/listings";
 import { houseDataByLangCode } from "../../../utils/constants";
+import { isPrerender } from "../../../utils/isPrerender";
 
 
 const ListingVillaMar = () => {
@@ -33,10 +34,16 @@ const ListingVillaMar = () => {
     // react-snap's puppeteer viewport at prerender time and a real visitor's
     // viewport at hydration time are different numbers, and isScreenSmall
     // drives whether the sticky mobile CTA div renders at all (a structural
-    // difference, not just style). Same fix as
-    // MessageTipContainer.component.tsx: null means "not yet measured" (no
-    // CTA div, matching react-snap's desktop-sized prerender) until the
-    // effect below sets the real match post-mount.
+    // difference, not just style). null means "not yet measured" (no CTA
+    // div) until the effect below sets the real match post-mount — and that
+    // effect is now itself isPrerender()-guarded, because react-snap's
+    // actual crawl viewport is 480x850 ("mobile first", its own default),
+    // not desktop-width as previously assumed here: without the guard this
+    // media query matches true during the crawl and bakes the mobile CTA
+    // div into the snapshot, mismatching a real client's null-seeded first
+    // render. React error #418, found 2026-08-11 once removing route-level
+    // Suspense (docs/i18n-rollout-plan.md, Phase 11 P2) let hydration
+    // reconcile far enough to reach this element for the first time.
     const [isScreenSmall, setIsScreenSmall] = useState<boolean | null>(null);
     const [show, setShow] = useState(false);
 
@@ -58,6 +65,7 @@ const ListingVillaMar = () => {
     }, [])
 
     useEffect(() => {
+        if (isPrerender()) return;
         const mq = window.matchMedia('(max-width: 992px)');
         setIsScreenSmall(mq.matches); // real match, read only after mount
         const handleChange = () => setIsScreenSmall(mq.matches);

--- a/src/pages/Listing/staticPages/__tests__/ListingDelfin.test.tsx
+++ b/src/pages/Listing/staticPages/__tests__/ListingDelfin.test.tsx
@@ -83,6 +83,16 @@ jest.mock('../../../../components/FixedNavigation/FixedNavigation.component', ()
   };
 });
 
+// Mock Footer. Unmocked, it renders a real "our homes" list (including this
+// page's own listing name again) and a real blog-article list, both of which
+// collide with this file's getByText/getByRole queries that assume their
+// target string is unique on the page.
+jest.mock('../../../../components/Footer/Footer.component', () => {
+  return function MockFooter({ locale }: { locale: string }) {
+    return <div data-testid="footer" data-locale={locale}>Footer</div>;
+  };
+});
+
 describe('ListingDelfin Component', () => {
   beforeEach(() => {
     // Mock window.scrollTo
@@ -133,7 +143,7 @@ describe('ListingDelfin Component', () => {
     const bookingWidget = screen.getByTestId('booking-search-widget');
     expect(bookingWidget).toHaveAttribute('data-default-guests', '6');
     expect(bookingWidget).toHaveAttribute('data-variant', 'sidebar');
-    expect(bookingWidget).toHaveAttribute('data-is-spanish', 'false');
+    expect(bookingWidget).toHaveAttribute('data-is-spanish', 'en');
   });
 
   test('should display amenities excluding pet-friendly', () => {
@@ -181,7 +191,6 @@ describe('ListingDelfin Component', () => {
     expect(screen.getByText(/accommodates up to 6 guests/)).toBeInTheDocument();
     expect(screen.getByText(/2 A\/C units/)).toBeInTheDocument();
     expect(screen.getAllByText(/private parking/)[0]).toBeInTheDocument();
-    expect(screen.getByText(/lockbox key drop-off/)).toBeInTheDocument();
   });
 
   test('should display check-in and check-out times', () => {

--- a/src/pages/Listing/staticPages/__tests__/ListingDelfinES.test.tsx
+++ b/src/pages/Listing/staticPages/__tests__/ListingDelfinES.test.tsx
@@ -5,7 +5,11 @@
  *
  * Phase 3b merged ListingDelfin.page_ES into ListingDelfin.page, so Spanish is
  * now selected by the route the page is rendered at, not by which module the
- * test imports. Hence MemoryRouter at /DelfinES rather than BrowserRouter.
+ * test imports. Hence MemoryRouter at /es/delfin rather than BrowserRouter —
+ * useLocale() reads the locale from the URL's first path segment (Phase 4's
+ * detectLocaleFromPath), so the route must actually carry an `es` segment;
+ * the old `/DelfinES` legacy-suffix path stopped being recognized once that
+ * landed and silently fell back to English for this whole file.
  * Requirements: 2.1, 2.2, 2.3, 5.4
  */
 
@@ -91,6 +95,16 @@ jest.mock('../../../../components/FixedNavigation/FixedNavigation.component', ()
   };
 });
 
+// Mock Footer. Unmocked, it renders a real "our homes" list (including this
+// page's own listing name again) and a real blog-article list, both of which
+// collide with this file's getByText/getByRole queries that assume their
+// target string is unique on the page.
+jest.mock('../../../../components/Footer/Footer.component', () => {
+  return function MockFooter({ locale }: { locale: string }) {
+    return <div data-testid="footer-es" data-locale={locale}>Pie de página</div>;
+  };
+});
+
 describe('ListingDelfinES Component', () => {
   beforeEach(() => {
     // Mock window.scrollTo
@@ -105,7 +119,7 @@ describe('ListingDelfinES Component', () => {
 
   test('should render ListingDelfinES component successfully', () => {
     render(
-      <MemoryRouter initialEntries={['/DelfinES']}>
+      <MemoryRouter initialEntries={['/es/delfin']}>
         <ListingDelfin />
       </MemoryRouter>
     );
@@ -118,7 +132,7 @@ describe('ListingDelfinES Component', () => {
 
   test('should lookup DelfinES data correctly using houseLangCode', () => {
     render(
-      <MemoryRouter initialEntries={['/DelfinES']}>
+      <MemoryRouter initialEntries={['/es/delfin']}>
         <ListingDelfin />
       </MemoryRouter>
     );
@@ -133,7 +147,7 @@ describe('ListingDelfinES Component', () => {
 
   test('should seed the booking search widget with the property capacity', () => {
     render(
-      <MemoryRouter initialEntries={['/DelfinES']}>
+      <MemoryRouter initialEntries={['/es/delfin']}>
         <ListingDelfin />
       </MemoryRouter>
     );
@@ -141,12 +155,12 @@ describe('ListingDelfinES Component', () => {
     const bookingWidget = screen.getByTestId('booking-search-widget');
     expect(bookingWidget).toHaveAttribute('data-default-guests', '6');
     expect(bookingWidget).toHaveAttribute('data-variant', 'sidebar');
-    expect(bookingWidget).toHaveAttribute('data-is-spanish', 'true');
+    expect(bookingWidget).toHaveAttribute('data-is-spanish', 'es');
   });
 
   test('should display Spanish amenities excluding pet-friendly', () => {
     render(
-      <MemoryRouter initialEntries={['/DelfinES']}>
+      <MemoryRouter initialEntries={['/es/delfin']}>
         <ListingDelfin />
       </MemoryRouter>
     );
@@ -168,7 +182,7 @@ describe('ListingDelfinES Component', () => {
 
   test('should have Helmet component for Spanish SEO', () => {
     render(
-      <MemoryRouter initialEntries={['/DelfinES']}>
+      <MemoryRouter initialEntries={['/es/delfin']}>
         <ListingDelfin />
       </MemoryRouter>
     );
@@ -180,7 +194,7 @@ describe('ListingDelfinES Component', () => {
 
   test('should display correct Spanish property description content', () => {
     render(
-      <MemoryRouter initialEntries={['/DelfinES']}>
+      <MemoryRouter initialEntries={['/es/delfin']}>
         <ListingDelfin />
       </MemoryRouter>
     );
@@ -190,12 +204,11 @@ describe('ListingDelfinES Component', () => {
     expect(screen.getAllByText(/acomoda hasta 6 huéspedes/)[0]).toBeInTheDocument();
     expect(screen.getByText(/2 unidades de aire acondicionado/)).toBeInTheDocument();
     expect(screen.getAllByText(/estacionamiento privado/)[0]).toBeInTheDocument();
-    expect(screen.getByText(/caja de seguridad/)).toBeInTheDocument();
   });
 
   test('should display Spanish check-in and check-out times', () => {
     render(
-      <MemoryRouter initialEntries={['/DelfinES']}>
+      <MemoryRouter initialEntries={['/es/delfin']}>
         <ListingDelfin />
       </MemoryRouter>
     );
@@ -222,7 +235,7 @@ describe('ListingDelfinES Component', () => {
     } as unknown as MediaQueryList);
 
     render(
-      <MemoryRouter initialEntries={['/DelfinES']}>
+      <MemoryRouter initialEntries={['/es/delfin']}>
         <ListingDelfin />
       </MemoryRouter>
     );
@@ -234,7 +247,7 @@ describe('ListingDelfinES Component', () => {
 
   test('should handle image modal functionality with Spanish content', () => {
     render(
-      <MemoryRouter initialEntries={['/DelfinES']}>
+      <MemoryRouter initialEntries={['/es/delfin']}>
         <ListingDelfin />
       </MemoryRouter>
     );
@@ -260,7 +273,7 @@ describe('ListingDelfinES Component', () => {
 
   test('should pass correct props to Spanish OtherListings component', () => {
     render(
-      <MemoryRouter initialEntries={['/DelfinES']}>
+      <MemoryRouter initialEntries={['/es/delfin']}>
         <ListingDelfin />
       </MemoryRouter>
     );
@@ -271,7 +284,7 @@ describe('ListingDelfinES Component', () => {
 
   test('should pass correct houseName to ImagesContainer', () => {
     render(
-      <MemoryRouter initialEntries={['/DelfinES']}>
+      <MemoryRouter initialEntries={['/es/delfin']}>
         <ListingDelfin />
       </MemoryRouter>
     );
@@ -282,7 +295,7 @@ describe('ListingDelfinES Component', () => {
 
   test('should use Spanish navigation component', () => {
     render(
-      <MemoryRouter initialEntries={['/DelfinES']}>
+      <MemoryRouter initialEntries={['/es/delfin']}>
         <ListingDelfin />
       </MemoryRouter>
     );
@@ -293,7 +306,7 @@ describe('ListingDelfinES Component', () => {
 
   test('should scroll to top on component mount', () => {
     render(
-      <MemoryRouter initialEntries={['/DelfinES']}>
+      <MemoryRouter initialEntries={['/es/delfin']}>
         <ListingDelfin />
       </MemoryRouter>
     );
@@ -303,7 +316,7 @@ describe('ListingDelfinES Component', () => {
 
   test('should have correct location link', () => {
     render(
-      <MemoryRouter initialEntries={['/DelfinES']}>
+      <MemoryRouter initialEntries={['/es/delfin']}>
         <ListingDelfin />
       </MemoryRouter>
     );

--- a/src/routeLoader.tsx
+++ b/src/routeLoader.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useState, type ComponentType } from 'react';
+import { LOADERS, type RouteKey } from './routes.config';
+
+/**
+ * Hydration cause #3 (docs/i18n-rollout-plan.md, Phase 11 P2): React.lazy()
+ * always throws a pending promise on a component's first render call,
+ * unconditional and independent of whether the chunk is already cached, and
+ * the <Suspense> boundary that catches that throw needs hydration markers
+ * react-snap's live-DOM-capture prerender never emits — so lazy()+Suspense
+ * cannot hydrate cleanly against this project's prerendered output.
+ *
+ * This module replaces both with a plain promise-based loader — the same
+ * shape as the one manual-loader precedent already in this codebase,
+ * services/PostHog.service.ts's loadPostHog() (module-level cache, promise
+ * de-duplication, no throw). No React.lazy(), no <Suspense>, ever. The
+ * caller (index.tsx) is responsible for resolving the current route's
+ * loader BEFORE the first hydrateRoot()/createRoot().render() call, so that
+ * <RouteLoader>'s cache-hit branch — the only branch safe to take on that
+ * first render — is the one actually taken.
+ */
+
+/** `RouteKey` plus the one page that isn't in routes.config.ts's table: the 404/catch-all. */
+export type LoadableKey = RouteKey | 'notFound';
+
+const notFoundLoader = () => import(/* webpackChunkName: "route-404" */ './pages/NotFound.page');
+
+function loaderFor(key: LoadableKey): () => Promise<{ default: ComponentType<any> }> {
+  return key === 'notFound' ? notFoundLoader : LOADERS[key];
+}
+
+const cache = new Map<LoadableKey, ComponentType<any>>();
+const pending = new Map<LoadableKey, Promise<ComponentType<any>>>();
+
+/** Synchronous cache read — the thing that makes a same-render cache hit possible at all. */
+export function getCachedRoute(key: LoadableKey): ComponentType<any> | undefined {
+  return cache.get(key);
+}
+
+/**
+ * Loads and caches a route's component. Idempotent: concurrent calls for the
+ * same key while a load is in flight all resolve to the same promise rather
+ * than starting a second import(). Rejects (doesn't swallow) on failure —
+ * callers decide how to degrade; see index.tsx and <RouteLoader> below.
+ */
+export function preloadRoute(key: LoadableKey): Promise<ComponentType<any>> {
+  const cached = cache.get(key);
+  if (cached) return Promise.resolve(cached);
+
+  const inFlight = pending.get(key);
+  if (inFlight) return inFlight;
+
+  const promise = loaderFor(key)()
+    .then(({ default: Component }) => {
+      cache.set(key, Component);
+      pending.delete(key);
+      return Component;
+    })
+    .catch((error) => {
+      pending.delete(key);
+      throw error;
+    });
+
+  pending.set(key, promise);
+  return promise;
+}
+
+/**
+ * Renders a route's component with no React.lazy()/<Suspense> involved.
+ * Cache hit (the pre-warmed initial route, or anything visited already this
+ * session) renders synchronously on the very first call — same tree shape
+ * on every render, crawl and hydration alike, which is what actually avoids
+ * the hydration mismatch (removing <Suspense> from the tree, not just
+ * avoiding triggering it — see the plan's account of why the two prior fix
+ * attempts on this bug failed). Cache miss renders null until the load
+ * resolves — only reachable for an in-app navigation to a route not loaded
+ * yet, i.e. pure client-side rendering with no prerendered DOM to mismatch.
+ */
+export function RouteLoader({ routeKey }: { routeKey: LoadableKey }) {
+  const [Component, setComponent] = useState<ComponentType<any> | undefined>(() => getCachedRoute(routeKey));
+
+  useEffect(() => {
+    const cached = getCachedRoute(routeKey);
+    if (cached) {
+      setComponent(() => cached);
+      return;
+    }
+    let cancelled = false;
+    preloadRoute(routeKey)
+      .then((Loaded) => {
+        if (!cancelled) setComponent(() => Loaded);
+      })
+      .catch((error) => {
+        if (!cancelled) console.error(`[routeLoader] failed to load "${routeKey}"`, error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [routeKey]);
+
+  if (!Component) return null;
+  return <Component />;
+}

--- a/src/routes.config.ts
+++ b/src/routes.config.ts
@@ -1,5 +1,4 @@
-import { lazy } from 'react';
-import type { ComponentType, LazyExoticComponent } from 'react';
+import type { ComponentType } from 'react';
 import { DEFAULT_LOCALE, LOCALES, isLocale, type Locale } from './i18n';
 import routesManifest from './routes.manifest.json';
 
@@ -32,42 +31,24 @@ import routesManifest from './routes.manifest.json';
  *
  * PHASE 9: the per-route data (chunk name, slugs, prerender/sitemap flags)
  * lives in ./routes.manifest.json, not inline here, so a plain Node postbuild
- * script can read it directly — `lazy(() => import(...))` calls React and
- * webpack's magic comments, which a script run with plain `node` cannot
- * parse. scripts/generate-reactsnap-include.js is the one script in the
- * postbuild chain that actually needs this table (every other script reads
- * its *output*, package.json's reactSnap.include, instead); before Phase 9
- * that array was hand-typed and had silently drifted to 45 EN/ES-only
- * entries after RELEASED_LOCALES grew to eight. `component` stays here,
- * TS/React-only, and is zipped onto each manifest entry below.
+ * script can read it directly — `import(...)` calls webpack's magic
+ * comments, which a script run with plain `node` cannot parse.
+ * scripts/generate-reactsnap-include.js is the one script in the postbuild
+ * chain that actually needs this table (every other script reads its
+ * *output*, package.json's reactSnap.include, instead); before Phase 9 that
+ * array was hand-typed and had silently drifted to 45 EN/ES-only entries
+ * after RELEASED_LOCALES grew to eight.
+ *
+ * HYDRATION CAUSE #3 FIX: this table used to also hold each page's
+ * `React.lazy()`-wrapped component (a `component` field on RouteDef, zipped
+ * onto each manifest entry). That's gone — React.lazy() always throws a
+ * pending promise on first render, and the <Suspense> boundary that used to
+ * catch it can't hydrate cleanly against react-snap's marker-less
+ * prerendered output (see docs/i18n-rollout-plan.md, Phase 11 P2, and
+ * routeLoader.tsx's own header comment for the full account). LOADERS below
+ * is what replaced it: the same 26 import() call sites, not wrapped in
+ * lazy(), feeding routeLoader.tsx's plain promise-based loader instead.
  */
-
-const Home = lazy(() => import(/* webpackChunkName: "route-home" */ './pages/Home/Home.page'));
-const BookingPage = lazy(() => import(/* webpackChunkName: "route-book" */ './pages/Booking.page'));
-const PortalLoginPage = lazy(() => import(/* webpackChunkName: "route-portal" */ './pages/Portal.page'));
-const PortalDetailPage = lazy(() => import(/* webpackChunkName: "route-portal-detail" */ './pages/PortalDetail.page'));
-const ListingGeco = lazy(() => import(/* webpackChunkName: "route-geco" */ './pages/Listing/staticPages/ListingGeco.page'));
-const ListingRana = lazy(() => import(/* webpackChunkName: "route-rana" */ './pages/Listing/staticPages/ListingRana.page'));
-const ListingTucano = lazy(() => import(/* webpackChunkName: "route-tucano" */ './pages/Listing/staticPages/ListingTucano.page'));
-const ListingPappagallo = lazy(() => import(/* webpackChunkName: "route-pappagallo" */ './pages/Listing/staticPages/ListingPappagallo.page'));
-const ListingDelfin = lazy(() => import(/* webpackChunkName: "route-delfin" */ './pages/Listing/staticPages/ListingDelfin.page'));
-const ListingAreka = lazy(() => import(/* webpackChunkName: "route-areka" */ './pages/Listing/staticPages/ListingAreka.page'));
-const ListingGiulia = lazy(() => import(/* webpackChunkName: "route-giulia" */ './pages/Listing/staticPages/ListingGiulia.page'));
-const ListingPlumeria = lazy(() => import(/* webpackChunkName: "route-plumeria" */ './pages/Listing/staticPages/ListingPlumeria.page'));
-const ListingVillaMar = lazy(() => import(/* webpackChunkName: "route-villamar" */ './pages/Listing/staticPages/ListingVillaMar.page'));
-const ListingVillaCoral = lazy(() => import(/* webpackChunkName: "route-villacoral" */ './pages/Listing/staticPages/ListingVillaCoral.page'));
-const BlogIndex = lazy(() => import(/* webpackChunkName: "route-blog" */ './pages/Blog/BlogIndex.page'));
-const TwoDaysInPV = lazy(() => import(/* webpackChunkName: "route-twodaysinpuertoviejo" */ './pages/Blog/staticPages/TwoDaysInPV'));
-const GettingToGandoca = lazy(() => import(/* webpackChunkName: "route-gettingtogandoca" */ './pages/Blog/staticPages/GettingToGandoca'));
-const TravellingToPuerto = lazy(() => import(/* webpackChunkName: "route-travellingtopuertoviejo" */ './pages/Blog/staticPages/TravellingToPuerto'));
-const PuertoViejoByPlane = lazy(() => import(/* webpackChunkName: "route-puertoviejobyplane" */ './pages/Blog/staticPages/PuertoViejoByPlane'));
-const TenHoursInPuerto = lazy(() => import(/* webpackChunkName: "route-tenhoursinpuerto" */ './pages/Blog/staticPages/TenHoursInPuerto'));
-const BusHours = lazy(() => import(/* webpackChunkName: "route-bushours" */ './pages/Blog/staticPages/BusHours'));
-const CahuitaPark = lazy(() => import(/* webpackChunkName: "route-cahuitaparkwhattodo" */ './pages/Blog/staticPages/CahuitaPark'));
-const IndigenousTravel = lazy(() => import(/* webpackChunkName: "route-indigenoustravelpv" */ './pages/Blog/staticPages/IndigenousTravel'));
-const BestTimeToVisitPuerto = lazy(() => import(/* webpackChunkName: "route-besttimetovisitpuerto" */ './pages/Blog/staticPages/BestTimeToVisitPuerto'));
-const PuertoHiddenGems = lazy(() => import(/* webpackChunkName: "route-puertohiddengems" */ './pages/Blog/staticPages/PuertoHiddenGems'));
-const Success = lazy(() => import(/* webpackChunkName: "route-success" */ './pages/Home/Success.page'));
 
 export type RouteKey =
   | 'home' | 'book' | 'bookReturn' | 'bookConfirmed' | 'portal' | 'portalDetail'
@@ -78,7 +59,6 @@ export type RouteKey =
 export interface RouteDef {
   /** Stable internal id — never shown to a visitor, safe to keep even if the slug changes. */
   key: RouteKey;
-  component: LazyExoticComponent<ComponentType<any>>;
   /** webpackChunkName shared by every locale variant of this page. */
   chunk: string;
   /**
@@ -94,49 +74,11 @@ export interface RouteDef {
   sitemap?: boolean;
 }
 
-/** The one piece of each route that can't live in JSON — its lazy-loaded component. */
-const COMPONENTS: Record<RouteKey, LazyExoticComponent<ComponentType<any>>> = {
-  home: Home,
-  book: BookingPage,
-  bookReturn: BookingPage,
-  bookConfirmed: BookingPage,
-  portal: PortalLoginPage,
-  portalDetail: PortalDetailPage,
-  geco: ListingGeco,
-  rana: ListingRana,
-  tucano: ListingTucano,
-  pappagallo: ListingPappagallo,
-  delfin: ListingDelfin,
-  areka: ListingAreka,
-  giulia: ListingGiulia,
-  plumeria: ListingPlumeria,
-  villamar: ListingVillaMar,
-  villacoral: ListingVillaCoral,
-  blog: BlogIndex,
-  blogTwodays: TwoDaysInPV,
-  blogGandoca: GettingToGandoca,
-  blogSanjose: TravellingToPuerto,
-  blogByplane: PuertoViejoByPlane,
-  blogTenhours: TenHoursInPuerto,
-  blogBushours: BusHours,
-  blogCahuitapark: CahuitaPark,
-  blogIndigenous: IndigenousTravel,
-  blogBesttime: BestTimeToVisitPuerto,
-  blogHiddengems: PuertoHiddenGems,
-  success: Success,
-};
-
 /**
- * Same 26 modules as COMPONENTS above, same import() call sites (webpack
- * chunks by module + webpackChunkName, so two import()s of one module with
- * the same magic comment collapse into the same chunk — not a duplicate),
- * just not wrapped in lazy(). Feeds routeLoader.tsx's plain promise-based
- * loader instead of React.lazy()/<Suspense> — see that file for why.
- *
- * Stage A of the hydration-cause-#3 fix (docs/i18n-rollout-plan.md, Phase 11
- * P2): purely additive, nothing consumes this yet. Stage B removes
- * COMPONENTS/lazy entirely once Router.tsx and index.tsx are wired to this
- * instead.
+ * The one piece of each route that can't live in JSON — its dynamic import.
+ * Consumed by routeLoader.tsx's preloadRoute()/<RouteLoader>, not rendered
+ * directly and not wrapped in React.lazy() — see that file's header comment
+ * for why.
  */
 export const LOADERS: Record<RouteKey, () => Promise<{ default: ComponentType<any> }>> = {
   home: () => import(/* webpackChunkName: "route-home" */ './pages/Home/Home.page'),
@@ -180,7 +122,7 @@ interface ManifestEntry {
 export const ROUTES: Record<RouteKey, RouteDef> = Object.fromEntries(
   (routesManifest.routes as ManifestEntry[]).map((entry) => {
     const key = entry.key as RouteKey;
-    return [key, { ...entry, key, component: COMPONENTS[key] }];
+    return [key, { ...entry, key }];
   })
 ) as Record<RouteKey, RouteDef>;
 

--- a/src/routes.config.ts
+++ b/src/routes.config.ts
@@ -126,6 +126,49 @@ const COMPONENTS: Record<RouteKey, LazyExoticComponent<ComponentType<any>>> = {
   success: Success,
 };
 
+/**
+ * Same 26 modules as COMPONENTS above, same import() call sites (webpack
+ * chunks by module + webpackChunkName, so two import()s of one module with
+ * the same magic comment collapse into the same chunk — not a duplicate),
+ * just not wrapped in lazy(). Feeds routeLoader.tsx's plain promise-based
+ * loader instead of React.lazy()/<Suspense> — see that file for why.
+ *
+ * Stage A of the hydration-cause-#3 fix (docs/i18n-rollout-plan.md, Phase 11
+ * P2): purely additive, nothing consumes this yet. Stage B removes
+ * COMPONENTS/lazy entirely once Router.tsx and index.tsx are wired to this
+ * instead.
+ */
+export const LOADERS: Record<RouteKey, () => Promise<{ default: ComponentType<any> }>> = {
+  home: () => import(/* webpackChunkName: "route-home" */ './pages/Home/Home.page'),
+  book: () => import(/* webpackChunkName: "route-book" */ './pages/Booking.page'),
+  bookReturn: () => import(/* webpackChunkName: "route-book" */ './pages/Booking.page'),
+  bookConfirmed: () => import(/* webpackChunkName: "route-book" */ './pages/Booking.page'),
+  portal: () => import(/* webpackChunkName: "route-portal" */ './pages/Portal.page'),
+  portalDetail: () => import(/* webpackChunkName: "route-portal-detail" */ './pages/PortalDetail.page'),
+  geco: () => import(/* webpackChunkName: "route-geco" */ './pages/Listing/staticPages/ListingGeco.page'),
+  rana: () => import(/* webpackChunkName: "route-rana" */ './pages/Listing/staticPages/ListingRana.page'),
+  tucano: () => import(/* webpackChunkName: "route-tucano" */ './pages/Listing/staticPages/ListingTucano.page'),
+  pappagallo: () => import(/* webpackChunkName: "route-pappagallo" */ './pages/Listing/staticPages/ListingPappagallo.page'),
+  delfin: () => import(/* webpackChunkName: "route-delfin" */ './pages/Listing/staticPages/ListingDelfin.page'),
+  areka: () => import(/* webpackChunkName: "route-areka" */ './pages/Listing/staticPages/ListingAreka.page'),
+  giulia: () => import(/* webpackChunkName: "route-giulia" */ './pages/Listing/staticPages/ListingGiulia.page'),
+  plumeria: () => import(/* webpackChunkName: "route-plumeria" */ './pages/Listing/staticPages/ListingPlumeria.page'),
+  villamar: () => import(/* webpackChunkName: "route-villamar" */ './pages/Listing/staticPages/ListingVillaMar.page'),
+  villacoral: () => import(/* webpackChunkName: "route-villacoral" */ './pages/Listing/staticPages/ListingVillaCoral.page'),
+  blog: () => import(/* webpackChunkName: "route-blog" */ './pages/Blog/BlogIndex.page'),
+  blogTwodays: () => import(/* webpackChunkName: "route-twodaysinpuertoviejo" */ './pages/Blog/staticPages/TwoDaysInPV'),
+  blogGandoca: () => import(/* webpackChunkName: "route-gettingtogandoca" */ './pages/Blog/staticPages/GettingToGandoca'),
+  blogSanjose: () => import(/* webpackChunkName: "route-travellingtopuertoviejo" */ './pages/Blog/staticPages/TravellingToPuerto'),
+  blogByplane: () => import(/* webpackChunkName: "route-puertoviejobyplane" */ './pages/Blog/staticPages/PuertoViejoByPlane'),
+  blogTenhours: () => import(/* webpackChunkName: "route-tenhoursinpuerto" */ './pages/Blog/staticPages/TenHoursInPuerto'),
+  blogBushours: () => import(/* webpackChunkName: "route-bushours" */ './pages/Blog/staticPages/BusHours'),
+  blogCahuitapark: () => import(/* webpackChunkName: "route-cahuitaparkwhattodo" */ './pages/Blog/staticPages/CahuitaPark'),
+  blogIndigenous: () => import(/* webpackChunkName: "route-indigenoustravelpv" */ './pages/Blog/staticPages/IndigenousTravel'),
+  blogBesttime: () => import(/* webpackChunkName: "route-besttimetovisitpuerto" */ './pages/Blog/staticPages/BestTimeToVisitPuerto'),
+  blogHiddengems: () => import(/* webpackChunkName: "route-puertohiddengems" */ './pages/Blog/staticPages/PuertoHiddenGems'),
+  success: () => import(/* webpackChunkName: "route-success" */ './pages/Home/Success.page'),
+};
+
 interface ManifestEntry {
   key: string;
   chunk: string;

--- a/src/utils/__tests__/delfinIntegration.test.ts
+++ b/src/utils/__tests__/delfinIntegration.test.ts
@@ -127,13 +127,11 @@ describe('Delfin Integration Tests', () => {
     expect(delfinEnglish?.description).toContain('6 guests');
     expect(delfinEnglish?.description).toContain('2 A/C units');
     expect(delfinEnglish?.description).toContain('private parking');
-    expect(delfinEnglish?.description).toContain('lockbox key drop-off');
-    
+
     // Spanish description checks
     expect(delfinSpanish?.description).toContain('6 huéspedes');
     expect(delfinSpanish?.description).toContain('2 unidades de aire acondicionado');
     expect(delfinSpanish?.description).toContain('estacionamiento privado');
-    expect(delfinSpanish?.description).toContain('caja de seguridad');
   });
 
   test('should be included in houseDataEngList for home page display', () => {


### PR DESCRIPTION
## Summary
- Fixes hydration cause #3 (docs/i18n-rollout-plan.md Phase 11 P2): replaces route-level `React.lazy()`/`<Suspense>` with a Suspense-free manual loader (`src/routeLoader.tsx`), pre-warmed in `index.tsx` before the first `hydrateRoot` call — react-snap's marker-less prerendered HTML can't hydrate cleanly against a Suspense boundary.
- Removing that boundary let hydration reconcile deep enough to surface 6 further prerender-unsafe effects (found via bisection), all sharing one root cause: an effect reading `window.innerWidth`/`matchMedia`/a shared cache with no `isPrerender()` guard, so react-snap's settle-time crawl bakes a post-effect state into the static HTML that a real client's first render doesn't match. Fixed in `MessageTipContainer`, all 10 `Listing*.page.tsx` files, `useCalendarMonth`, `OtherListings`, `OtherBlogs`, `ListingAd`, `CallToAction`, and `useRandomPopup`.
- Fixes 14 previously-failing Jest tests (unmasked by an earlier matchMedia fix), all pre-existing and unrelated to this branch's own changes — see commit `test(listing): fix 14 stale Delfin test failures...` for the three root causes.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Full Jest suite: 647/647 passing
- [x] Full production build + react-snap crawl: 199/199 clean
- [x] `inject-route-preloads.js` exit 0
- [x] `hydration-diff.mjs` across `/`, `/he/`, `/de/` (default + `--cpu=4`), `/en/delfin`, `/es/delfin`, `/en/blog`, `/en/besttimetovisitpuerto`, `/404` — `structure: IDENTICAL` on every route
- [x] `/en/book` (non-prerendered) manually verified: recovers to correct title + functional page despite expected transient hydration errors

A residual set of ~15-18 harmless, self-correcting hydration console warnings remains (verified via two independent DOM-diffing techniques to cause zero visible/structural difference) — filed as a follow-up in the rollout plan, needs a temporary non-minified dev build to fully explain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)