### PR TITLE
fix(listing): render other-homes with the home-page HomeCard (#310)

### DIFF
--- a/src/pages/Listing/components/OtherListings/OtherListings.component.tsx
+++ b/src/pages/Listing/components/OtherListings/OtherListings.component.tsx
@@ -1,146 +1,73 @@
-import React, { FC, useEffect, useRef, useState, useCallback, useMemo } from "react";
+import React, { FC, useMemo } from "react";
 import './OtherListings.style.scss'
 import { ListingType } from "../../../../utils/types";
-import { useNavigate } from "react-router-dom";
 import { useLocale, useMessages } from "../../../../i18n";
-import { pathForKey, routeKeyForSlug } from "../../../../routes.config";
-import { isPrerender } from "../../../../utils/isPrerender";
+import { houseDataByLangCode } from "../../../../utils/constants";
+import HomeCard from "../../../../components/OurHomes/Components/HomeCard.component";
 
 interface IOtherListings {
     currentListing: string
     listings: ListingType[]
 }
 
-/**
- * PHASE 3a merged the Spanish copy into this one. Three of the divergences were
- * not translation, and each is resolved deliberately:
- *
- * 1. **Memoisation.** Spanish wrapped the resize handler and the filtering in
- *    useCallback/useMemo; English used plain functions. Merged onto the memoised
- *    version. This changes re-render cost on English pages, not their output —
- *    so it is invisible to a prerender diff and is called out here instead.
- *
- * 2. **Name normalisation.** `currentListing` is the page's houseLangCode, so it
- *    carries the locale suffix ("GecoES") while `homesSnippet` names do not
- *    ("Geco"). English compared them raw, which was only ever correct because
- *    English has no suffix — the same code on a Spanish page would have listed
- *    the current property among the "other" ones. `baseName` strips the suffix
- *    from both sides, which is right in every locale.
- *
- * 3. **Route building.** English navigated to `/Geco`, Spanish appended or
- *    preserved "ES" with a substring test. Both are now the same expression:
- *    base name looked up in routes.config.ts + the current locale (PHASE 4).
- *
- * The Spanish copy also used `name.replace('ES', '')`, which is unanchored and
- * would eat "ES" from the middle of a name. `baseName` anchors to the end. No
- * current property name trips the difference, but "Esmeralda" would have.
- *
- * `NamSnippetES` in constants.ts now produces the same result as `NamSnippet`
- * and is redundant. It is left alone here — deleting it belongs with PHASE 3b,
- * when the Spanish listing pages that reference it are merged away.
- */
-
 /** The property name without its locale suffix: "PlumeriaES" -> "Plumeria". */
 const baseName = (name: string) => name.replace(/ES$/, '')
 
+/** Snippet display name -> houseLangCode / route slug: "Villa Mar" -> "VillaMar". */
+const langCodeForName = (name: string) => baseName(name).replace(/\s/g, "")
+
+/**
+ * The "other homes" block on a listing page now renders the same HomeCard the
+ * home page uses (issue #310) instead of the old bespoke background-image tiles,
+ * so the two sections read as one system.
+ *
+ * The blocker was data: HomeCard needs guestNumber / parking / houseLangCode,
+ * but a ListingType snippet only carries { name, mainImage }. We resolve the
+ * full house record from the snippet name via houseDataByLangCode — the same
+ * lookup OurOtherHomes uses. Entries with no matching record are dropped rather
+ * than rendered half-populated (the old code likewise no-op'd navigation when
+ * routeKeyForSlug found nothing).
+ *
+ * This version renders deterministically, so — unlike the previous windowWidth-
+ * driven layout — it needs no isPrerender guard to avoid a hydration mismatch.
+ */
 const OtherListings: FC<IOtherListings> = ({ currentListing, listings }) => {
-    // Seeded null, not window.innerWidth — react-snap's puppeteer viewport at
-    // prerender time and a real visitor's viewport at hydration time are
-    // different numbers, and isMobile below drives the layout class, so
-    // reading the width during render produces a hydration mismatch. Null means
-    // "not measured yet"; the effect below fills it in after mount.
-    const [windowWidth, setWindowWidth] = useState<number | null>(null)
-    const navigate = useNavigate()
-    const gridRef = useRef<HTMLDivElement>(null)
     const locale = useLocale()
     const m = useMessages()
 
-    const handleResize = useCallback(() => {
-        setWindowWidth(window.innerWidth)
-    }, [])
-
-    useEffect(() => {
-        // react-snap's crawl gives this effect time to settle before it
-        // captures the page, so without this guard windowWidth gets seeded
-        // from the crawl's own (mobile) viewport and bakes that layoutClass
-        // into the static HTML — mismatching a real client's null-seeded
-        // first render at any other viewport. Same pattern as isScreenSmall
-        // in the listing pages and MessageTipContainer's windowWidth; see
-        // docs/i18n-rollout-plan.md Phase 11 P2.
-        if (isPrerender()) return
-        handleResize() // real width, read only after mount
-        window.addEventListener("resize", handleResize)
-        return () => window.removeEventListener("resize", handleResize)
-    }, [handleResize])
-
-    // Only horizontally-scrollable in the 'mobile-scroll' layout. Chromium
-    // redirects a vertical wheel gesture into horizontal scroll on any
-    // horizontally-overflowing element, which made the page feel stuck.
-    useEffect(() => {
-        const grid = gridRef.current
-        if (!grid) return
-
-        const onWheel = (e: WheelEvent) => {
-            if (!grid.classList.contains('mobile-scroll')) return
-            if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return
-            if (grid.scrollWidth <= grid.clientWidth) return
-            e.preventDefault()
-            grid.scrollLeft += e.deltaY
-        }
-
-        grid.addEventListener('wheel', onWheel, { passive: false })
-        return () => grid.removeEventListener('wheel', onWheel)
-    }, [])
-
-    const otherListings = useMemo(
-        () => listings.filter(listing => baseName(listing.name) !== baseName(currentListing)),
+    const cards = useMemo(
+        () => listings
+            .filter(listing => baseName(listing.name) !== baseName(currentListing))
+            .map(({ name, mainImage }) => {
+                const houseLangCode = langCodeForName(name)
+                const houseData = houseDataByLangCode(houseLangCode)
+                return houseData ? { name: baseName(name), mainImage, houseLangCode, houseData } : null
+            })
+            .filter((card): card is NonNullable<typeof card> => card !== null),
         [listings, currentListing]
     )
 
-    const handleListingClick = useCallback((name: string) => {
-        const routeName = baseName(name).replace(/\s/g, "")
-        const key = routeKeyForSlug(routeName)
-        if (!key) return
-        navigate(pathForKey(key, locale))
-    }, [navigate, locale])
-
-    const layoutClass = useMemo(() => {
-        const isMobile = windowWidth !== null && windowWidth <= 1199
-        const listingCount = otherListings.length
-
-        if (listingCount === 0) return 'no-listings'
-        if (listingCount === 1) return 'single-listing'
-        if (isMobile && listingCount <= 2) return 'mobile-grid'
-        if (isMobile) return 'mobile-scroll'
-        return 'desktop-grid'
-    }, [windowWidth, otherListings.length])
-
-    if (otherListings.length === 0) {
+    if (cards.length === 0) {
         return null
     }
 
     return (
-        <div className="other-listings-container">
+        // `about` activates the shared card-surface styling (`.about .block …` in
+        // HomeCard.style.scss), exactly as OurHomes' <section className="… about">
+        // does on the home page — that's what makes these cards match.
+        <div className="other-listings-container about">
             <h2 className="other-listings-header">{m.sections.otherListingsHeading}</h2>
-            <div
-                className={`other-listings-grid ${layoutClass}`}
-                ref={gridRef}
-            >
-                {otherListings.map(({ name, mainImage }) => (
-                    <div
-                        key={name}
-                        className="listing-card"
-                        style={{ backgroundImage: `url(${mainImage})` }}
-                        onClick={() => handleListingClick(name)}
-                        onKeyDown={(e) => e.key === 'Enter' && handleListingClick(name)}
-                        role="button"
-                        tabIndex={0}
-                        aria-label={m.property.viewListing(baseName(name))}
-                    >
-                        <div className="listing-card-overlay">
-                            <h3 className="listing-card-title">{baseName(name)}</h3>
-                        </div>
-                    </div>
+            <div className="homes-grid">
+                {cards.map(({ name, mainImage, houseLangCode, houseData }) => (
+                    <HomeCard
+                        key={houseLangCode}
+                        name={name}
+                        guestNumber={houseData.guestNumber}
+                        hasFencedParking={houseData.parking}
+                        image={mainImage}
+                        houseLangCode={houseLangCode}
+                        locale={locale}
+                    />
                 ))}
             </div>
         </div>

--- a/src/pages/Listing/components/OtherListings/OtherListings.style.scss
+++ b/src/pages/Listing/components/OtherListings/OtherListings.style.scss
@@ -1,6 +1,10 @@
 @use '../../../../styles/mixins';
 @import '../../../../styles/styles.scss';
 
+// The cards themselves reuse HomeCard (issue #310) — their look comes from
+// HomeCard.style.scss via the `.about` wrapper + `.homes-grid` container. Only
+// the section shell (heading + centring) lives here now.
+
 .other-listings-container {
     display: flex;
     flex-direction: column;
@@ -18,126 +22,9 @@
     margin-top: 0;
 }
 
-.other-listings-grid {
-    width: 100%;
-    max-width: 1200px;
-    
-    &.single-listing {
-        display: flex;
-        justify-content: center;
-        
-        .listing-card {
-            width: 280px;
-        }
-    }
-    
-    &.desktop-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-        gap: 20px;
-        justify-items: center;
-    }
-    
-    &.mobile-grid {
-        display: grid;
-        grid-template-columns: repeat(2, 1fr);
-        gap: 15px;
-        padding: 0 10px;
-    }
-    
-    &.mobile-scroll {
-        display: flex;
-        overflow-x: auto;
-        gap: 15px;
-        padding: 0 10px 10px;
-        scroll-behavior: smooth;
-        -webkit-overflow-scrolling: touch;
-        
-        // Hide scrollbar but keep functionality
-        scrollbar-width: none; // Firefox
-        -ms-overflow-style: none; // IE and Edge
-        
-        &::-webkit-scrollbar {
-            display: none; // Chrome, Safari, Opera
-        }
-        
-        .listing-card {
-            flex: 0 0 200px;
-        }
-    }
-}
-
-.listing-card {
-    background-color: rgb(25, 136, 136);
-    height: 200px;
-    width: 250px;
-    border-radius: 8px;
-    border: 3px solid $primary-color;
-    background-size: cover;
-    background-position: center;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    position: relative;
-    overflow: hidden;
-    
-    &:hover {
-        transform: translateY(-8px);
-        box-shadow: 0 15px 30px rgba(0, 0, 0, 0.4);
-    }
-    
-    &:focus {
-        outline: 2px solid $primary-color;
-        outline-offset: 2px;
-    }
-}
-
-.listing-card-overlay {
-    position: absolute;
-    bottom: 0;
-    inset-inline-start: 0;
-    inset-inline-end: 0;
-    background: linear-gradient(transparent, rgba(0, 0, 0, 0.9));
-    padding: 20px 15px 15px;
-}
-
-.listing-card-title {
-    color: #fff !important;
-    -webkit-text-fill-color: #fff;
-    text-shadow: none;
-    font-size: 16px;
-    font-weight: 600;
-    margin: 0;
-    line-height: 1.3;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
 @media (max-width: 768px) {
     .other-listings-header {
         font-size: 16px;
         margin-bottom: 20px;
-    }
-    
-    .other-listings-grid {
-        &.mobile-grid {
-            grid-template-columns: 1fr;
-            
-            .listing-card {
-                width: 100%;
-                max-width: 300px;
-                justify-self: center;
-            }
-        }
-    }
-    
-    .listing-card {
-        height: 180px;
-    }
-    
-    .listing-card-title {
-        font-size: 14px;
     }
 }


### PR DESCRIPTION
Closes Taiga #310 — "other homes in listing page rework".

## What
The "other homes" block on a listing page used bespoke background-image tiles (`.listing-card`) that looked nothing like the home-page cards. It now reuses `HomeCard` directly, so both sections read as one system (image + amenity row + "View home →" CTA).

## How
- `HomeCard` needs `guestNumber`/`parking`/`houseLangCode`, which a `ListingType` snippet (`{ name, mainImage }`) doesn't carry, so each entry is resolved to its full house record via `houseDataByLangCode` (the same lookup `OurOtherHomes` uses).
- The `.about` wrapper + `.homes-grid` container bring the shared card-surface styling from `HomeCard.style.scss` for free.
- Drops the `windowWidth`-driven layout classes and the wheel-scroll handler — the new markup renders deterministically, so it no longer needs an `isPrerender` guard to avoid a hydration mismatch. Most of `OtherListings.style.scss` is now dead and removed.

## Verify
- Typecheck + all 56 listing tests pass (Delfin suites fully mock `OtherListings`, so its internals are free to change).
- Rendered the Geco listing page in the dev server: the section now shows `HomeCard`s (guest count + "View home →").

🤖 Generated with [Claude Code](https://claude.com/claude-code)