### PR TITLE
feat(booking): cap the listing guest picker at the home's max occupancy (#309)

### DIFF
--- a/src/components/BookingSearchWidget/BookingSearchWidget.component.tsx
+++ b/src/components/BookingSearchWidget/BookingSearchWidget.component.tsx
@@ -4,7 +4,7 @@ import { Button, Form, Spinner } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCalendarDays, faUser, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 import CalendarWithPriceDots from '../CalendarWithPriceDots';
-import { MAX_PORTFOLIO_GUESTS } from '../../utils/constants';
+import { MAX_PORTFOLIO_GUESTS, PROPERTY_CAPACITY } from '../../utils/constants';
 import { getCostaRicaToday, nightsBetween } from '../../utils/dates';
 import './BookingSearchWidget.style.scss';
 import type { Locale } from '../../i18n';
@@ -36,6 +36,8 @@ const strings = {
     decreaseGuests: 'Decrease guests',
     increaseGuests: 'Increase guests',
     maxGuests: 'Our largest home sleeps {max}. Message us for bigger groups.',
+    maxGuestsListing: 'This home sleeps up to {max}.',
+    searchAllHomes: 'Search all our homes for a bigger group.',
     arrivalRequired: 'Please select a check-in date.',
     departureRequired: 'Please select a check-out date.',
     departureTooEarly: 'Check-out must be after check-in.',
@@ -53,6 +55,8 @@ const strings = {
     decreaseGuests: 'Menos huéspedes',
     increaseGuests: 'Más huéspedes',
     maxGuests: 'Nuestra casa más grande aloja a {max}. Escríbenos para grupos mayores.',
+    maxGuestsListing: 'Esta casa aloja hasta {max}.',
+    searchAllHomes: 'Busca en todas nuestras casas para un grupo más grande.',
     arrivalRequired: 'Selecciona una fecha de llegada.',
     departureRequired: 'Selecciona una fecha de salida.',
     departureTooEarly: 'La salida debe ser después de la llegada.',
@@ -73,10 +77,20 @@ const BookingSearchWidget: React.FC<BookingSearchWidgetProps> = ({
   const s = strings[lang];
   const today = useMemo(() => getCostaRicaToday(), []);
 
+  // On a listing page the guest picker must not exceed that home's own capacity
+  // (#309) — you can't book Villa Mar (sleeps 2) for six. The portfolio-wide
+  // hero has no single home, so it keeps the portfolio-wide max.
+  const listingCapacity = apartmentSlug ? PROPERTY_CAPACITY[apartmentSlug]?.maxGuests : undefined;
+  const guestCap = listingCapacity ?? MAX_PORTFOLIO_GUESTS;
+  // Only a home strictly smaller than the biggest one should send guests to the
+  // full-portfolio search for a bigger group — the largest home has no bigger
+  // sibling to offer.
+  const showListingHint = listingCapacity !== undefined && listingCapacity < MAX_PORTFOLIO_GUESTS;
+
   const [arrivalDate, setArrivalDate] = useState('');
   const [departureDate, setDepartureDate] = useState('');
   const [guests, setGuests] = useState(() =>
-    Math.min(Math.max(1, defaultGuests), MAX_PORTFOLIO_GUESTS)
+    Math.min(Math.max(1, defaultGuests), guestCap)
   );
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -285,8 +299,8 @@ const BookingSearchWidget: React.FC<BookingSearchWidgetProps> = ({
               variant="outline-secondary"
               size="sm"
               aria-label={s.increaseGuests}
-              onClick={() => setGuests((g) => Math.min(MAX_PORTFOLIO_GUESTS, g + 1))}
-              disabled={guests >= MAX_PORTFOLIO_GUESTS}
+              onClick={() => setGuests((g) => Math.min(guestCap, g + 1))}
+              disabled={guests >= guestCap}
             >
               +
             </Button>
@@ -306,9 +320,29 @@ const BookingSearchWidget: React.FC<BookingSearchWidgetProps> = ({
         </Button>
 
         {/* Full-width row so it never disturbs the alignment of the fields above. */}
-        {guests >= MAX_PORTFOLIO_GUESTS && (
+        {guests >= guestCap && (
           <p className="booking-search-widget__hint" aria-live="polite">
-            {s.maxGuests.replace('{max}', String(MAX_PORTFOLIO_GUESTS))}
+            {showListingHint ? (
+              <>
+                {s.maxGuestsListing.replace('{max}', String(guestCap))}{' '}
+                {/* A real href keeps middle/modifier-click working; plain clicks
+                    take the SPA route to the portfolio search, where the
+                    over-capacity flow already surfaces homes that fit. */}
+                <a
+                  href={bookingPath(locale)}
+                  className="booking-search-widget__hint-link"
+                  onClick={(e) => {
+                    if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+                    e.preventDefault();
+                    navigate(bookingPath(locale));
+                  }}
+                >
+                  {s.searchAllHomes}
+                </a>
+              </>
+            ) : (
+              s.maxGuests.replace('{max}', String(guestCap))
+            )}
           </p>
         )}
       </Form>

--- a/src/components/BookingSearchWidget/BookingSearchWidget.guestCap.test.tsx
+++ b/src/components/BookingSearchWidget/BookingSearchWidget.guestCap.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Guest picker capping (#309).
+ *
+ * On a listing page the picker must not exceed that home's own capacity — you
+ * can't book Villa Mar (sleeps 2) for six. The portfolio-wide hero keeps the
+ * portfolio max. The calendar is stubbed here so these tests stay about the
+ * guest control alone and make no rate request.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import BookingSearchWidget from './BookingSearchWidget.component';
+
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() }, capture: jest.fn() }));
+jest.mock('../CalendarWithPriceDots', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+function renderWidget(props: Partial<React.ComponentProps<typeof BookingSearchWidget>> = {}) {
+  return render(
+    <MemoryRouter>
+      <BookingSearchWidget locale="en" {...props} />
+    </MemoryRouter>
+  );
+}
+
+describe('BookingSearchWidget guest cap', () => {
+  test('a listing caps the picker at its own max occupancy', () => {
+    // Villa Mar sleeps 2; defaultGuests comes from the listing's guestNumber.
+    renderWidget({ variant: 'sidebar', apartmentSlug: 'VillaMar', defaultGuests: 2 });
+
+    expect(screen.getByText('2')).toBeInTheDocument();
+    // Already at the home's max, so the increment is disabled — no way to reach 3.
+    expect(screen.getByRole('button', { name: 'Increase guests' })).toBeDisabled();
+  });
+
+  test('stepping down then up never exceeds the listing max', () => {
+    renderWidget({ variant: 'sidebar', apartmentSlug: 'VillaMar', defaultGuests: 2 });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Decrease guests' }));
+    expect(screen.getByText('1')).toBeInTheDocument();
+
+    const increase = screen.getByRole('button', { name: 'Increase guests' });
+    fireEvent.click(increase);
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(increase).toBeDisabled();
+  });
+
+  test('a capped listing points bigger groups at the full-portfolio search', () => {
+    renderWidget({ variant: 'sidebar', apartmentSlug: 'VillaMar', defaultGuests: 2 });
+
+    expect(screen.getByText('This home sleeps up to 2.')).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: 'Search all our homes for a bigger group.' });
+    expect(link).toHaveAttribute('href', expect.stringContaining('book'));
+  });
+
+  test('the portfolio hero is not capped to a single home', () => {
+    // No apartmentSlug: the picker spans the whole portfolio, so the largest
+    // home (> 2 guests) is reachable and the listing-specific hint is absent.
+    renderWidget();
+
+    expect(screen.getByRole('button', { name: 'Increase guests' })).toBeEnabled();
+    expect(screen.queryByText(/This home sleeps up to/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/BookingSearchWidget/BookingSearchWidget.style.scss
+++ b/src/components/BookingSearchWidget/BookingSearchWidget.style.scss
@@ -231,6 +231,18 @@
     text-align: start;
   }
 
+  &__hint-link {
+    color: $kalawala-dark-green;
+    font-weight: 600;
+    text-decoration: underline;
+
+    &:hover,
+    &:focus-visible {
+      color: $kalawala-dark-green;
+      text-decoration: underline;
+    }
+  }
+
   &__guest-count {
     font-size: 16px;
     font-weight: 600;


### PR DESCRIPTION
Closes Taiga #309 — "from single listing search you should only be able to put max occupancy as number of guests".

## What
On a listing page the guest stepper was bounded by `MAX_PORTFOLIO_GUESTS` (the biggest home in the portfolio), so you could ask Villa Mar — which sleeps 2 — for six guests and only discover the mismatch after searching.

## How
- The widget derives its cap from `PROPERTY_CAPACITY[apartmentSlug]` when tied to a single home; the portfolio-wide hero keeps the portfolio max.
- When a smaller home is maxed out, the hint points bigger groups at the full-portfolio search, where the existing over-capacity flow already surfaces homes that fit — covering the "show other houses that can accommodate" half of the ticket.

## Verify
- Typecheck + widget tests pass, including 4 new cases (cap enforced, step-down-then-up stays within cap, capped listing shows the portfolio-search link, hero is uncapped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)