### PR TITLE
fix(booking): apply the non-refundable discount on the SINPE/deposit path (#307)

### DIFF
--- a/booking-api/src/depositHolds.ts
+++ b/booking-api/src/depositHolds.ts
@@ -37,14 +37,17 @@ export async function handleCreateDepositHold(
   return createSmoobuBackedHold(
     {
       paymentMethod: "manual_deposit",
-      // Deposit bookings are always on the flexible rate. The non-refundable
-      // discount is tied to immediate PayPal capture.
-      ratePlan: "flexible",
+      // Deposit bookings honour whichever rate the guest picked — flexible by
+      // default, or the non-refundable rate (10% off via the #norefundallowed
+      // re-quote) when selected. Previously the deposit path forced flexible, so
+      // a guest who chose non-refundable and paid by SINPE silently lost the
+      // discount they were shown (#307).
+      ratePlan: holdRequest.nonRefundable ? "non_refundable" : "flexible",
       idempotencyScope: DEPOSIT_HOLD_IDEMPOTENCY_SCOPE,
       ttlMsFor: (session) => depositHoldTtlMs(deposit.holdTtlHours, session.arrivalDate),
       noticePrefix: "Kalawala manual deposit hold.",
       noticeCaveat: "Awaiting bank transfer / SINPE. Not confirmed until staff verify the deposit.",
-      allowNonRefundable: false,
+      allowNonRefundable: true,
       async finalize({ session, property, config: cfg, request: req }) {
         const { portalSessionSecret } = await cfg.secrets.getSecrets();
 

--- a/booking-api/src/holds.test.ts
+++ b/booking-api/src/holds.test.ts
@@ -982,6 +982,58 @@ test("POST /api/holds records a pet on the booking and on the Smoobu notice", as
   expect(storedSession).toMatchObject({ status: "hold_active", hasPet: true });
 });
 
+test("POST /api/holds applies the non-refundable discount via #norefundallowed and records it on the reservation (#307)", async () => {
+  const fetchFn = jest.fn(async (url: string | URL, init?: RequestInit) => {
+    const pathname = new URL(url.toString()).pathname;
+    if (pathname === "/booking/checkApartmentAvailability") {
+      // The #norefundallowed code is what actually discounts the rate; Smoobu
+      // returns 10% off (510 -> 459) only when it is present on the re-quote.
+      const reqBody = init?.body ? JSON.parse(init.body as string) : {};
+      const price = reqBody.discountCode === "#norefundallowed" ? 459 : 510;
+      return jsonResponse({
+        availableApartments: [301061],
+        prices: { "301061": { price, currency: "USD" } },
+        errorMessages: {},
+      });
+    }
+    if (pathname === "/api/reservations") {
+      return jsonResponse({ id: 987654 });
+    }
+    return jsonResponse({ detail: "unexpected" }, { status: 500 });
+  });
+  global.fetch = fetchFn as typeof fetch;
+  const handler = createBookingApiHandler(config);
+
+  const searchBody = JSON.parse((await handler(makeSearchEvent())).body);
+  const response = await handler(
+    makeHoldEvent({
+      quoteId: searchBody.quoteId,
+      bookingSessionId: searchBody.bookingSessionId,
+      propertyId: searchBody.properties[0].propertyId,
+      paymentMethod: "paypal",
+      guest: { firstName: "Ana", lastName: "Mora", email: "ana@example.com" },
+      portalPassword: "correct horse battery staple",
+      termsAccepted: true,
+      nonRefundable: true,
+    })
+  );
+
+  expect(response.statusCode).toBe(200);
+
+  // The hold re-quote carried the discount code...
+  const [, recheckInit] = fetchFn.mock.calls[1];
+  expect(JSON.parse(recheckInit?.body as string).discountCode).toBe("#norefundallowed");
+
+  // ...the reservation Smoobu records the discounted price and says why.
+  const [, reservationInit] = fetchFn.mock.calls[2];
+  const reservationPayload = JSON.parse(reservationInit?.body as string);
+  expect(reservationPayload.price).toBe(459);
+  expect(reservationPayload.notice).toContain("Non-refundable rate (#norefundallowed)");
+
+  // ...and the charged total on the booking is the discounted one.
+  expect(JSON.parse(response.body).booking.price.totalAmountCents).toBe(45900);
+});
+
 test("POST /api/holds rejects a pet on a home that does not accept pets", async () => {
   const fetchFn = jest.fn(async (url: string | URL) => {
     const pathname = new URL(url.toString()).pathname;

--- a/booking-api/src/holds.ts
+++ b/booking-api/src/holds.ts
@@ -956,6 +956,7 @@ export async function createSmoobuBackedHold(
       noticePrefix: flavour.noticePrefix,
       noticeCaveat: flavour.noticeCaveat,
       withPet,
+      nonRefundable: holdRequest.nonRefundable === true,
     });
     const payloadHash = hashJson(reservationPayload);
 
@@ -1293,6 +1294,7 @@ function buildSmoobuHoldPayload(input: {
   noticePrefix: string;
   noticeCaveat: string;
   withPet: boolean;
+  nonRefundable: boolean;
 }) {
   return {
     arrivalDate: input.session.arrivalDate,
@@ -1310,7 +1312,8 @@ function buildSmoobuHoldPayload(input: {
       input.expiresAt,
       input.noticePrefix,
       input.noticeCaveat,
-      input.withPet
+      input.withPet,
+      input.nonRefundable
     ),
     adults: input.session.guests,
     children: 0,
@@ -1330,9 +1333,16 @@ function buildSmoobuNotice(
   expiresAt: string,
   noticePrefix: string,
   noticeCaveat: string,
-  withPet: boolean
+  withPet: boolean,
+  nonRefundable: boolean
 ): string {
-  const parts = [`${noticePrefix} Quote ${session.quoteId}. Hold expires ${expiresAt}. ${noticeCaveat}`];
+  // Spelled out on the reservation so staff confirming a SINPE/bank transfer see
+  // that the (already-discounted) price is the non-refundable rate, computed via
+  // the #norefundallowed code at quote time — not an underpayment (#307).
+  const rateNote = nonRefundable
+    ? " Non-refundable rate (#norefundallowed): 10% discount already applied to the price above."
+    : "";
+  const parts = [`${noticePrefix} Quote ${session.quoteId}. Hold expires ${expiresAt}. ${noticeCaveat}${rateNote}`];
 
   // Ahead of the free-text guest note: housekeeping reads this line off the
   // Smoobu reservation, so it must not be buried under a long message.

--- a/booking-api/src/validation.test.ts
+++ b/booking-api/src/validation.test.ts
@@ -556,3 +556,14 @@ test("validateDepositHoldRequest: carries tracking through the deposit checkout"
 
   expect(result.tracking).toEqual({ gaClientId: "abc.def" });
 });
+
+test("validateDepositHoldRequest: honours the non-refundable rate on the deposit path (#307)", () => {
+  const { paymentMethod: _paymentMethod, ...depositBody } = validHold;
+
+  // A guest who picked the non-refundable rate keeps it when paying by SINPE;
+  // previously the deposit path forced flexible and silently dropped the choice.
+  expect(validateDepositHoldRequest({ ...depositBody, nonRefundable: true }).nonRefundable).toBe(true);
+  // Default and unset stay flexible.
+  expect(validateDepositHoldRequest(depositBody).nonRefundable).toBe(false);
+  expect(validateDepositHoldRequest({ ...depositBody, nonRefundable: false }).nonRefundable).toBe(false);
+});

--- a/booking-api/src/validation.ts
+++ b/booking-api/src/validation.ts
@@ -188,10 +188,10 @@ export function validateHoldRequest(value: unknown): HoldRequest {
 }
 
 /**
- * Deposit holds take the same shape as PayPal holds minus the payment method and
- * rate options: the deposit path is always the flexible rate, and the discount
- * code is tied to immediate card capture. A pet travels with the guest whichever
- * way they pay, so `withPet` is accepted here too.
+ * Deposit holds take the same shape as PayPal holds minus the payment method.
+ * The rate options travel with the guest whichever way they pay: `withPet`, and
+ * `nonRefundable` — a guest who picks the non-refundable rate keeps its 10%
+ * discount when paying by SINPE/transfer, not only via PayPal (#307).
  */
 export function validateDepositHoldRequest(value: unknown): HoldRequest {
   const body = assertJsonObject(value);
@@ -222,7 +222,7 @@ export function validateDepositHoldRequest(value: unknown): HoldRequest {
     portalPassword,
     termsAccepted: true,
     marketingConsent: body.marketingConsent === true,
-    nonRefundable: false,
+    nonRefundable: body.nonRefundable === true,
     withPet: body.withPet === true,
     ...(parseTrackingIdentifiers(body.tracking) ? { tracking: parseTrackingIdentifiers(body.tracking) } : {}),
   };

--- a/src/pages/Booking.page.tsx
+++ b/src/pages/Booking.page.tsx
@@ -368,7 +368,7 @@ const BookingPage = () => {
     persistPortalAutoLogin(holdForm.portalPassword);
     setIsCreatingDepositHold(true);
     try {
-      const response = await createDepositHold({ quoteId: result.quoteId, bookingSessionId: result.bookingSessionId, propertyId: depositProperty.propertyId, language, guest: { firstName: holdForm.firstName, lastName: holdForm.lastName, email: holdForm.email, phone: holdForm.phone, country: holdForm.country, message: holdForm.message }, portalPassword: holdForm.portalPassword, termsAccepted: holdForm.termsAccepted, ...(withPet ? { withPet: true } : {}) });
+      const response = await createDepositHold({ quoteId: result.quoteId, bookingSessionId: result.bookingSessionId, propertyId: depositProperty.propertyId, language, guest: { firstName: holdForm.firstName, lastName: holdForm.lastName, email: holdForm.email, phone: holdForm.phone, country: holdForm.country, message: holdForm.message }, portalPassword: holdForm.portalPassword, termsAccepted: holdForm.termsAccepted, ...(nonRefundable ? { nonRefundable: true } : {}), ...(withPet ? { withPet: true } : {}) });
       setDepositHoldResponse(response);
       // The booking is not confirmed yet, but the guest will need these to log in
       // once staff verify the transfer.
@@ -531,7 +531,7 @@ const BookingPage = () => {
             {/* Step 3: Checkout / Deposit */}
             <div className={`booking-wizard-slide${wizardStep === 'checkout' || wizardStep === 'deposit' ? ' booking-wizard-slide--active' : stepIndex(wizardStep) > 2 ? ' booking-wizard-slide--left' : ' booking-wizard-slide--right'}`} aria-hidden={wizardStep !== 'checkout' && wizardStep !== 'deposit'}>
               <Row className="justify-content-center"><Col lg={8} xl={7}>
-                {result && depositProperty && <DepositCheckoutPanel result={result} property={depositProperty} strings={strings} language={language} withPet={withPet} form={holdForm} fieldErrors={holdFieldErrors} holdError={depositError} holdResponse={depositHoldResponse} isCreatingHold={isCreatingDepositHold} receiptState={receiptState} onChange={updateHoldForm} onSubmit={handleCreateDepositHold} onUploadReceipt={handleUploadReceipt} onBack={handleBackToResults} />}
+                {result && depositProperty && <DepositCheckoutPanel result={result} property={depositProperty} strings={strings} language={language} withPet={withPet} nonRefundable={nonRefundable} form={holdForm} fieldErrors={holdFieldErrors} holdError={depositError} holdResponse={depositHoldResponse} isCreatingHold={isCreatingDepositHold} receiptState={receiptState} onChange={updateHoldForm} onSubmit={handleCreateDepositHold} onUploadReceipt={handleUploadReceipt} onBack={handleBackToResults} />}
                 {result && checkoutProperty && <PayPalCheckoutPanel result={result} property={checkoutProperty} strings={strings} language={language} withPet={withPet} nonRefundable={nonRefundable} form={holdForm} fieldErrors={holdFieldErrors} holdError={holdError} holdResponse={holdResponse} paypalOrderError={paypalOrderError} isCreatingHold={isCreatingHold} isCreatingPayPalOrder={isCreatingPayPalOrder} onChange={updateHoldForm} onSubmit={handleCreatePayPalHold} onCreatePayPalOrder={handleCreatePayPalOrder} holdCaptchaRequired={holdCaptchaRequired} onBack={handleBackToResults} />}
               </Col></Row>
             </div>
@@ -938,7 +938,7 @@ const BookingConfirmationPanel = ({ result, strings, language, onManageBooking }
  * This replaces the old contact-only handoff, which told guests to get in touch
  * and reserved nothing.
  */
-const DepositCheckoutPanel = ({ result, property, strings, language, withPet, form, fieldErrors, holdError, holdResponse, isCreatingHold, receiptState, onChange, onSubmit, onUploadReceipt, onBack }: { result: BookingSearchResponse; property: BookingAvailableProperty; strings: BookingStrings; language: BookingLanguage; withPet: boolean; form: PayPalHoldFormState; fieldErrors: Record<string, string>; holdError: string | null; holdResponse: DepositHoldResponse | null; isCreatingHold: boolean; receiptState: DepositReceiptState; onChange: (u: Partial<PayPalHoldFormState>) => void; onSubmit: (e: React.FormEvent) => void; onUploadReceipt: (file: File) => void; onBack: () => void }) => {
+const DepositCheckoutPanel = ({ result, property, strings, language, withPet, nonRefundable, form, fieldErrors, holdError, holdResponse, isCreatingHold, receiptState, onChange, onSubmit, onUploadReceipt, onBack }: { result: BookingSearchResponse; property: BookingAvailableProperty; strings: BookingStrings; language: BookingLanguage; withPet: boolean; nonRefundable: boolean; form: PayPalHoldFormState; fieldErrors: Record<string, string>; holdError: string | null; holdResponse: DepositHoldResponse | null; isCreatingHold: boolean; receiptState: DepositReceiptState; onChange: (u: Partial<PayPalHoldFormState>) => void; onSubmit: (e: React.FormEvent) => void; onUploadReceipt: (file: File) => void; onBack: () => void }) => {
   const price = property.price ?? holdResponse?.booking.price;
   const bankInfo = holdResponse?.bankInfo;
 
@@ -953,7 +953,7 @@ const DepositCheckoutPanel = ({ result, property, strings, language, withPet, fo
 
       <div className="booking-checkout-panel__summary" aria-label={strings.checkoutSummary}>
         <div><span>{strings.depositContextTitle}</span><strong>{property.name}</strong><small>{strings.depositDates(formatDate(result.arrivalDate, language), formatDate(result.departureDate, language))}</small></div>
-        {price && <CheckoutPrice price={price} strings={strings} language={language} nonRefundablePreview={false} finalOverrideCents={holdResponse?.booking.price?.totalAmountCents} />}
+        {price && <CheckoutPrice price={price} strings={strings} language={language} nonRefundablePreview={nonRefundable && !holdResponse} finalOverrideCents={holdResponse?.booking.price?.totalAmountCents} />}
         {withPet && <div><span>{strings.petSummaryLabel}</span><strong><FontAwesomeIcon icon={faPaw} /> {strings.petSummaryValue}</strong></div>}
       </div>
 

--- a/src/services/BookingApi.service.ts
+++ b/src/services/BookingApi.service.ts
@@ -104,10 +104,11 @@ export interface CreatePayPalHoldRequest {
 }
 
 /**
- * Same shape as a PayPal hold minus the rate options — deposit is always
- * flexible. A pet travels with the guest either way, so `withPet` stays.
+ * Same shape as a PayPal hold, minus the PayPal-only captcha step. The rate
+ * options (`nonRefundable`, `withPet`) travel with the guest whichever way they
+ * pay, so a non-refundable rate keeps its discount on the SINPE path too (#307).
  */
-export type CreateDepositHoldRequest = Omit<CreatePayPalHoldRequest, 'nonRefundable'>;
+export type CreateDepositHoldRequest = Omit<CreatePayPalHoldRequest, 'captchaToken'>;
 
 export interface DepositBankInfo {
   sinpePhone: string;
@@ -644,6 +645,7 @@ export async function createDepositHold(request: CreateDepositHoldRequest): Prom
       marketingConsent: request.marketingConsent === true,
       // Re-sent because the guest may have accepted the cookie banner after searching.
       ...buildTrackingPayload(),
+      ...(request.nonRefundable ? { nonRefundable: true } : {}),
       ...(request.withPet ? { withPet: true } : {}),
     }),
   });


### PR DESCRIPTION
Closes Taiga #307 — "flexible booking does not actually work / the price does not include it".

## Root cause
A guest who picked the non-refundable rate saw the 10%-off price in the results, but if they paid by SINPE/bank transfer the discount silently vanished. The deposit path hardcoded the flexible rate end to end: the request type `Omit`'d `nonRefundable`, the client never sent it, the validator forced it to `false`, and the hold flavour set `ratePlan: "flexible"` with `allowNonRefundable: false`. So the price they were shown did not include the rate they chose.

## Fix
Thread the guest's rate choice through the deposit path, mirroring PayPal:
- client sends `nonRefundable` and shows the discounted preview in the deposit summary until the hold's real (Smoobu-priced) total overrides it;
- the validator keeps the flag instead of forcing `false`;
- the deposit hold flavour derives its `ratePlan` from the request and allows the non-refundable re-quote, so the charged total matches what was shown.

The flexible (default) path is unchanged. Cancellation terms follow the rate, as they already do for PayPal.

> **Note for review:** this intentionally reverses the previous "deposit is always flexible" decision (the discount was tied to immediate PayPal capture). Per product direction the discount should stick whichever way the guest pays. If instead the intent is to *hide* the toggle on the deposit path, say so and I'll flip the approach.

## Verify
- Frontend + booking-api typecheck; full booking-api suite (502 tests) + Booking.page (30) pass; added a validation test asserting the deposit path now honours `nonRefundable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)