### PR TITLE
fix(booking): resume the SINPE deposit step after the payment round-trip (#308)

### DIFF
--- a/src/pages/Booking.page.test.tsx
+++ b/src/pages/Booking.page.test.tsx
@@ -1043,6 +1043,31 @@ function fillGuestDetails() {
   fireEvent.click(screen.getByLabelText('I accept the booking terms.'));
 }
 
+test('a persisted deposit hold is resumed on mount after the SINPE round-trip (#308)', async () => {
+  // The guest left to pay and came back to a fresh page — no search runs, but the
+  // hold was stashed in localStorage, so the timer, bank details and receipt
+  // upload must all reappear.
+  window.localStorage.setItem('kalawala_deposit_checkout', JSON.stringify(DEPOSIT_HOLD_FIXTURE));
+
+  renderBookingPage();
+
+  await screen.findByText('KWL-DEP12345');
+  expect(screen.getByText('8772 7355')).toBeInTheDocument();
+  expect(screen.getByText('Upload only the receipt for this deposit. Any other picture will cancel your reservation automatically.')).toBeInTheDocument();
+});
+
+test('an expired persisted deposit hold is not resumed (#308)', async () => {
+  const expired = { ...DEPOSIT_HOLD_FIXTURE, booking: { ...DEPOSIT_HOLD_FIXTURE.booking, hold: { status: 'active', expiresAt: '2000-01-01T00:00:00Z' } } };
+  window.localStorage.setItem('kalawala_deposit_checkout', JSON.stringify(expired));
+
+  renderBookingPage();
+
+  // Falls back to the ordinary search entry point; the dead hold is gone.
+  expect(await screen.findByRole('button', { name: /search availability/i })).toBeInTheDocument();
+  expect(screen.queryByText('KWL-DEP12345')).not.toBeInTheDocument();
+  expect(window.localStorage.getItem('kalawala_deposit_checkout')).toBeNull();
+});
+
 test('deposit checkout collects guest details and creates a real hold', async () => {
   mockJsonResponses([{ body: SEARCH_RESULT_FIXTURE }, { body: DEPOSIT_HOLD_FIXTURE }]);
 

--- a/src/pages/Booking.page.tsx
+++ b/src/pages/Booking.page.tsx
@@ -122,6 +122,7 @@ interface StoredPayPalCheckout {
 }
 
 const paypalCheckoutStorageKey = 'kalawala_paypal_checkout';
+const depositCheckoutStorageKey = 'kalawala_deposit_checkout';
 const bookingConfirmationStorageKey = 'kalawala_booking_confirmation';
 const bookingConfirmationTrackedPrefix = 'kalawala_booking_confirmation_tracked_';
 const portalAutoLoginKey = 'kalawala_portal_autologin';
@@ -181,19 +182,31 @@ const BookingPage = () => {
   const formStartTrackedRef = React.useRef(false);
   const paymentStartTrackedRef = React.useRef<string | null>(null);
   const today = React.useMemo(() => getCostaRicaToday(), []);
+  // A guest who left to pay by SINPE and comes back (tab reload, back button, or
+  // reopening the site) would otherwise land on a blank search — the deposit
+  // step is in-memory only. Rehydrate it from localStorage so the timer, bank
+  // details and receipt upload are all still there (#308). Never on the PayPal
+  // return/confirmation routes, which own the wizard. Read once via a ref so the
+  // decision is stable across renders.
+  const resumedDepositRef = React.useRef<DepositHoldResponse | null>();
+  if (resumedDepositRef.current === undefined) {
+    resumedDepositRef.current = (isPayPalReturnRoute || isConfirmationRoute) ? null : readDepositCheckoutState();
+  }
+  const resumedDeposit = resumedDepositRef.current;
+
   const [arrivalDate, setArrivalDate] = React.useState(() => getInitialArrivalDate(searchParams.get('arrivalDate'), today));
   const [departureDate, setDepartureDate] = React.useState(() => getInitialDepartureDate(searchParams.get('departureDate'), searchParams.get('arrivalDate'), today));
   const [guests, setGuests] = React.useState(() => getInitialGuestCount(searchParams.get('guests')));
   // Set when the guest arrived from a listing page. It only promotes that home
   // to the top of the results — the search itself stays portfolio-wide.
   const [featuredSlug] = React.useState(() => sanitiseSlug(searchParams.get('property')));
-  const [result, setResult] = React.useState<BookingSearchResponse | null>(null);
+  const [result, setResult] = React.useState<BookingSearchResponse | null>(() => resumedDeposit ? searchResultFromHold(resumedDeposit) : null);
   const [error, setError] = React.useState<string | null>(null);
   const [depositHandoff, setDepositHandoff] = React.useState<DepositHandoffResponse | null>(null);
   const [depositError, setDepositError] = React.useState<string | null>(null);
   const [depositLoadingPropertyId, setDepositLoadingPropertyId] = React.useState<string | null>(null);
-  const [depositProperty, setDepositProperty] = React.useState<BookingAvailableProperty | null>(null);
-  const [depositHoldResponse, setDepositHoldResponse] = React.useState<DepositHoldResponse | null>(null);
+  const [depositProperty, setDepositProperty] = React.useState<BookingAvailableProperty | null>(() => resumedDeposit ? depositPropertyFromHold(resumedDeposit) : null);
+  const [depositHoldResponse, setDepositHoldResponse] = React.useState<DepositHoldResponse | null>(resumedDeposit ?? null);
   const [isCreatingDepositHold, setIsCreatingDepositHold] = React.useState(false);
   const [receiptState, setReceiptState] = React.useState<DepositReceiptState>({ status: 'idle' });
   const [checkoutProperty, setCheckoutProperty] = React.useState<BookingAvailableProperty | null>(null);
@@ -233,6 +246,18 @@ const BookingPage = () => {
   }, [isConfirmationRoute, bookingConfirmation, isPayPalReturnRoute, depositProperty, checkoutProperty, result]);
 
   React.useEffect(() => { window.scrollTo({ top: 0, behavior: 'smooth' }); }, [wizardStep]);
+
+  // Once the deposit hold expires it is released server-side, so drop the
+  // persisted copy — a later reload should not resume a dead hold (#308).
+  React.useEffect(() => {
+    const expiresAt = depositHoldResponse?.booking.hold.expiresAt;
+    if (!expiresAt) return;
+    const ms = Date.parse(expiresAt) - Date.now();
+    if (!Number.isFinite(ms)) return;
+    if (ms <= 0) { clearDepositCheckoutState(); return; }
+    const id = window.setTimeout(() => clearDepositCheckoutState(), ms);
+    return () => window.clearTimeout(id);
+  }, [depositHoldResponse]);
 
   const updateBookingQuery = React.useCallback((updates: Record<string, string | number>) => {
     const nextParams = new URLSearchParams(searchParams.toString());
@@ -319,6 +344,9 @@ const BookingPage = () => {
   const autoSearchFiredRef = React.useRef(false);
   React.useEffect(() => {
     if (autoSearchFiredRef.current) return;
+    // A resumed deposit already owns the wizard; a stale autoSearch in the URL
+    // (e.g. from the back button) must not overwrite it with a fresh search.
+    if (resumedDeposit) return;
     if (searchParams.get('autoSearch') !== 'true') return;
     if (!arrivalDate || !departureDate) return;
     if (isPayPalReturnRoute || isConfirmationRoute) return;
@@ -370,6 +398,8 @@ const BookingPage = () => {
     try {
       const response = await createDepositHold({ quoteId: result.quoteId, bookingSessionId: result.bookingSessionId, propertyId: depositProperty.propertyId, language, guest: { firstName: holdForm.firstName, lastName: holdForm.lastName, email: holdForm.email, phone: holdForm.phone, country: holdForm.country, message: holdForm.message }, portalPassword: holdForm.portalPassword, termsAccepted: holdForm.termsAccepted, ...(nonRefundable ? { nonRefundable: true } : {}), ...(withPet ? { withPet: true } : {}) });
       setDepositHoldResponse(response);
+      // Stash the whole hold so the SINPE round-trip can rebuild this step (#308).
+      persistDepositCheckoutState(response);
       // The booking is not confirmed yet, but the guest will need these to log in
       // once staff verify the transfer.
       if (response.booking?.reservationPublicId) { savePortalCredentials(response.booking.reservationPublicId, holdForm.portalPassword); }
@@ -420,7 +450,7 @@ const BookingPage = () => {
     setHoldFieldErrors((c) => { const n = { ...c }; Object.keys(updates).forEach((k) => { delete n[k]; }); return n; });
   };
 
-  const handleBackToResults = () => { setCheckoutProperty(null); setHoldError(null); setHoldResponse(null); setHoldFieldErrors({}); setPayPalOrderError(null); setHoldCaptchaRequired(false); setDepositError(null); setDepositProperty(null); setDepositHoldResponse(null); setReceiptState({ status: 'idle' }); };
+  const handleBackToResults = () => { setCheckoutProperty(null); setHoldError(null); setHoldResponse(null); setHoldFieldErrors({}); setPayPalOrderError(null); setHoldCaptchaRequired(false); setDepositError(null); setDepositProperty(null); setDepositHoldResponse(null); setReceiptState({ status: 'idle' }); clearDepositCheckoutState(); };
   const handleBackToSearch = () => { setResult(null); setError(null); handleBackToResults(); };
 
   const handleCreatePayPalHold = async (event: React.FormEvent, captchaTokenOverride?: string) => {
@@ -1251,6 +1281,43 @@ function confirmedBookingPath(language: BookingLanguage): string { return pathFo
 function persistPayPalCheckoutState(state: StoredPayPalCheckout): void { try { window.sessionStorage.setItem(paypalCheckoutStorageKey, JSON.stringify(state)); } catch { /* non-critical */ } }
 function readPayPalCheckoutState(): StoredPayPalCheckout | null { try { const raw = window.sessionStorage.getItem(paypalCheckoutStorageKey); if (!raw) return null; const p = JSON.parse(raw) as Partial<StoredPayPalCheckout>; if (typeof p.bookingSessionId !== 'string' || typeof p.paypalOrderId !== 'string' || (p.language !== 'en' && p.language !== 'es')) return null; return { bookingSessionId: p.bookingSessionId, paypalOrderId: p.paypalOrderId, reservationPublicId: typeof p.reservationPublicId === 'string' ? p.reservationPublicId : undefined, language: p.language }; } catch { return null; } }
 function clearPayPalCheckoutState(bookingSessionId: string): void { try { const s = readPayPalCheckoutState(); if (!s || s.bookingSessionId === bookingSessionId) window.sessionStorage.removeItem(paypalCheckoutStorageKey); } catch { /* non-critical */ } }
+// Deposit/SINPE resume (#308). Unlike PayPal there is no redirect back, so the
+// guest returns by reopening the site — which tears down the tab. localStorage
+// (not sessionStorage) is what survives that, and the depositAccessToken it
+// carries is good for 24h, so the whole DepositHoldResponse is stashed and the
+// deposit step is rebuilt from it on the next mount.
+function persistDepositCheckoutState(state: DepositHoldResponse): void { try { window.localStorage.setItem(depositCheckoutStorageKey, JSON.stringify(state)); } catch { /* non-critical */ } }
+function clearDepositCheckoutState(): void { try { window.localStorage.removeItem(depositCheckoutStorageKey); } catch { /* non-critical */ } }
+function readDepositCheckoutState(): DepositHoldResponse | null {
+  try {
+    const raw = window.localStorage.getItem(depositCheckoutStorageKey);
+    if (!raw) return null;
+    const p = JSON.parse(raw) as DepositHoldResponse;
+    const expiresAt = p?.booking?.hold?.expiresAt;
+    const expiresAtMs = typeof expiresAt === 'string' ? Date.parse(expiresAt) : NaN;
+    // A malformed entry, or a hold whose timer has run out (released server-side),
+    // is not resumable — drop it so it doesn't linger and resume a dead hold.
+    if (!p?.booking?.bookingSessionId || !p.booking.reservationPublicId || !p.booking.property?.propertyId || !p.bankInfo || typeof p.depositAccessToken !== 'string' || !Number.isFinite(expiresAtMs) || expiresAtMs <= Date.now()) {
+      clearDepositCheckoutState();
+      return null;
+    }
+    return p;
+  } catch { return null; }
+}
+/** The result card the deposit panel needs, rebuilt from a persisted hold. */
+function depositPropertyFromHold(hold: DepositHoldResponse): BookingAvailableProperty {
+  const p = hold.booking.property;
+  return { propertyId: p.propertyId, slug: p.slug, listingUrl: p.listingUrl, name: p.name, guestCapacity: p.guestCapacity, thumbnailUrl: p.thumbnailUrl, amenities: p.amenities, price: hold.booking.price };
+}
+/**
+ * Just enough BookingSearchResponse to drive the deposit panel (it only reads
+ * the dates). There is no live search behind a resumed hold, and the held view
+ * never re-submits, so quoteId is deliberately empty.
+ */
+function searchResultFromHold(hold: DepositHoldResponse): BookingSearchResponse {
+  const b = hold.booking;
+  return { bookingSessionId: b.bookingSessionId, quoteId: '', quoteExpiresAt: b.hold.expiresAt, arrivalDate: b.arrivalDate, departureDate: b.departureDate, guests: b.guests, language: b.language, resultsCount: 1, properties: [depositPropertyFromHold(hold)], availabilityWarnings: [] };
+}
 function persistBookingConfirmationState(state: PayPalCaptureResponse): void { try { window.sessionStorage.setItem(bookingConfirmationStorageKey, JSON.stringify(state)); } catch { /* non-critical */ } }
 function readBookingConfirmationState(): PayPalCaptureResponse | null { try { const raw = window.sessionStorage.getItem(bookingConfirmationStorageKey); if (!raw) return null; const p = JSON.parse(raw) as PayPalCaptureResponse; if (!p?.booking?.reservationPublicId || !p.booking.bookingSessionId || p.booking.status !== 'booking_confirmed' || !p.payment?.paypalOrderId) return null; return p; } catch { return null; } }
 function maybeTrackBookingConfirmation(result: PayPalCaptureResponse): void { const property = result.booking.property; const price = result.booking.price; if (!property?.propertyId || !property.slug || !property.name || !price?.currency || typeof price.totalAmountCents !== 'number') return; trackBookingConfirmed({ reservation_id: result.booking.reservationPublicId, property_id: property.propertyId, property_slug: property.slug, property_name: property.name, value_cents: price.totalAmountCents, currency: price.currency, arrival_date: result.booking.arrivalDate, departure_date: result.booking.departureDate, payment_method: 'paypal', language: result.booking.language }); }


### PR DESCRIPTION
Closes Taiga #308 — SINPE round-trip restarts the session and the hold blocks rebooking.

## What
The deposit checkout — timer, bank/SINPE details, receipt upload — lived only in React state. A guest who left to pay by SINPE and came back (tab reload, back button, or reopening the site) landed on a blank search with no way back to the timer, while their own still-active hold blocked a fresh booking.

## How
Mirror the PayPal persistence, but in `localStorage` (it survives the tab teardown a banking-app switch causes, and the `depositAccessToken` is good for 24h): stash the hold on creation and rebuild the deposit step from it on the next mount. A resumed hold suppresses any stale `autoSearch` in the URL; an expired or malformed entry is dropped rather than resumed, and the persisted copy is cleared on "back to results" and when the hold's timer runs out.

## Scope
Client-only (as agreed): this restores the guest's access to **their own** hold. Making a guest's own hold reusable server-side — so a full-storage-loss return doesn't hit the overlap guard / Smoobu `property_no_longer_available` — is a deliberate follow-up worth a separate ticket.

## Verify
- Typecheck + Booking.page suite (32 tests) pass, including 2 new cases: a valid persisted hold resumes on mount (timer + bank details + upload reappear), and an expired hold is not resumed and is cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)