### PR TITLE
fix(footer): trim blog list & make section titles readable

### DIFF
--- a/src/components/Footer/Footer.component.tsx
+++ b/src/components/Footer/Footer.component.tsx
@@ -10,9 +10,25 @@ interface IFooter {
   locale: Locale;
 }
 
+// A curated handful of evergreen guides for the footer. BLOG_ARTICLES holds 26
+// entries (including 13 month-by-month weather posts) — far too many to list in
+// the footer. Keep this to the highest-value, non-redundant guides.
+const FOOTER_GUIDE_ROUTE_KEYS = [
+  'blogBeaches',
+  'blogCahuitapark',
+  'blogBesttime',
+  'blogHiddengems',
+  'blogTwodays',
+  'blogGandoca',
+];
+
 const Footer: React.FC<IFooter> = ({ locale }) => {
   const m = getMessages(locale);
   const bookPath = bookingPath(locale);
+
+  const footerGuides = FOOTER_GUIDE_ROUTE_KEYS.map((routeKey) =>
+    BLOG_ARTICLES.find((article) => article.routeKey === routeKey),
+  ).filter((article): article is (typeof BLOG_ARTICLES)[number] => Boolean(article));
 
   return (
     <footer className="site-footer">
@@ -38,7 +54,7 @@ const Footer: React.FC<IFooter> = ({ locale }) => {
               {/* Locale-keyed DATA, not chrome: title reuses the Phase-8-translated
                   blog.tsx heading for this article; path comes straight from
                   routes.config.ts. Both resolve per-locale, not just en/es. */}
-              {BLOG_ARTICLES.map((article) => (
+              {footerGuides.map((article) => (
                 <li key={article.key}>
                   <Link to={pathForKey(article.routeKey, locale)}>
                     {blogArticleHeading(article.routeKey, locale)}

--- a/src/components/Footer/Footer.style.scss
+++ b/src/components/Footer/Footer.style.scss
@@ -33,8 +33,11 @@
   }
 
   .footer-col {
+    // Global `_typography.scss` sets `h4 { color: $kalawala-text-gray !important }`
+    // (near-black), which would render these section titles unreadable on the dark
+    // green footer. Override with matching specificity + !important to force white.
     h4 {
-      color: #fff;
+      color: #fff !important;
       font-size: 15px;
       font-weight: 700;
       letter-spacing: 0.04em;


### PR DESCRIPTION
## What & why
The site footer had two issues:

1. **Too many blog titles.** The *Travel Guides* column mapped over the entire `BLOG_ARTICLES` array — 26 entries, 13 of which are month-by-month weather posts (`weatherJan`…`weatherDec`). This dominated the footer. Curated it down to 6 evergreen guides (beaches, Cahuita park, best time to visit, hidden gems, two days, Gandoca-Manzanillo).
2. **Unreadable section titles.** The four `<h4>` column titles rendered near-black (`#171717`) on the dark-green footer, because the global `_typography.scss` rule `h4 { color: $kalawala-text-gray !important }` overrode `Footer.style.scss`'s intended white. Fixed by overriding with matching specificity + `!important` (`.site-footer .footer-col h4 { color:#fff !important }`).

## Changes
- `Footer.component.tsx` — add `FOOTER_GUIDE_ROUTE_KEYS` curated subset; render those instead of all `BLOG_ARTICLES`. Titles/paths still resolve per-locale via `blogArticleHeading` / `pathForKey`.
- `Footer.style.scss` — force white section titles to beat the global `!important`.

## Verification
- `tsc --noEmit` passes.
- Rendered the real footer markup against the actual compiled SCSS **plus** the global `h4 !important` rule: all four titles now render white on the dark green, and Travel Guides shows 6 links.

<img width="500" alt="footer after fix" src="verified locally" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)