### PR TITLE
fix(booking-api): stop compounding Smoobu 429s under concurrent calendar traffic

### DIFF
--- a/booking-api/package-lock.json
+++ b/booking-api/package-lock.json
@@ -8,8 +8,10 @@
       "name": "@kalawala/booking-api",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1039.0",
         "@aws-sdk/client-s3": "^3.1039.0",
         "@aws-sdk/client-secrets-manager": "^3.0.0",
+        "@aws-sdk/lib-dynamodb": "^3.1039.0",
         "@aws-sdk/s3-request-presigner": "^3.1039.0",
         "pg": "^8.20.0"
       },
@@ -228,6 +230,27 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1109.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1109.0.tgz",
+      "integrity": "sha512-X01HO3zd6gG1ug6EAfEYxH4VsMiOFWYlmL6/eW0zmbwOsOMlD55MzXTjDfZJKtB/HUZ8mWau+dgnolLZlRZ59w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/credential-provider-node": "^3.972.79",
+        "@aws-sdk/dynamodb-codec": "^3.973.42",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.28",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.1039.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1039.0.tgz",
@@ -397,28 +420,31 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.7.tgz",
-      "integrity": "sha512-YhRC90ofz5oolTJZlA8voU/oUrCB2azi8Usx51k8hhB5LpWbYQMMXKUqSqkoL0Cru+RQJgWTHpAfEDDIwfUhJw==",
+      "version": "3.977.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.7.tgz",
+      "integrity": "sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.22",
-        "@smithy/core": "^3.23.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/xml-builder": "^3.972.38",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/crc64-nvme": {
@@ -435,15 +461,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.33.tgz",
-      "integrity": "sha512-bJV7eViSJV6GSuuN+VIdNVPdwPsNSf75BiC2v5alPrjR/OCcqgKwSZInKbDFz9mNeizldsyf67jt6YSIiv53Cw==",
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.68.tgz",
+      "integrity": "sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -451,20 +477,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.35.tgz",
-      "integrity": "sha512-x/BQGEIdq0oI+4WxLjKmnQvT7CnF9r8ezdGt7wXwxb7ckHXQz0Zmgxt8v3Ne0JaT3R5YefmuybHX6E8EnsDXyA==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.70.tgz",
+      "integrity": "sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.25",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -472,24 +495,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.37.tgz",
-      "integrity": "sha512-eUTpmWfd/BKsq9medhCRcu+GRAhFP2Zrn7/2jKDHHOOjCkhrMoTp/t4cEthqFoG7gE0VGp5wUxrXTdvBCmSmJg==",
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.13.tgz",
+      "integrity": "sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
-        "@aws-sdk/credential-provider-env": "^3.972.33",
-        "@aws-sdk/credential-provider-http": "^3.972.35",
-        "@aws-sdk/credential-provider-login": "^3.972.37",
-        "@aws-sdk/credential-provider-process": "^3.972.33",
-        "@aws-sdk/credential-provider-sso": "^3.972.37",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.37",
-        "@aws-sdk/nested-clients": "^3.997.5",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/credential-provider-imds": "^4.2.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/credential-provider-env": "^3.972.68",
+        "@aws-sdk/credential-provider-http": "^3.972.70",
+        "@aws-sdk/credential-provider-login": "^3.972.75",
+        "@aws-sdk/credential-provider-process": "^3.972.68",
+        "@aws-sdk/credential-provider-sso": "^3.973.12",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.74",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -497,18 +519,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.37.tgz",
-      "integrity": "sha512-Ty68y8ISSC+g5Q3D0K8uAaoINwvfaOslnNpsF/LgVUxyosYXHawcK2yV4HLXDVugiTTYLQfJfcw0ce5meAGkKw==",
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.75.tgz",
+      "integrity": "sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
-        "@aws-sdk/nested-clients": "^3.997.5",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -516,22 +536,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.38.tgz",
-      "integrity": "sha512-BQ9XYnBDVxR2HuV5huXYQYF/PZMTsY+EnwfGnCU2cA8Zw63XpkOtPY8WqiMIZMQCrKPQQEiFURS/o9CIolRLqg==",
+      "version": "3.972.79",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.79.tgz",
+      "integrity": "sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.33",
-        "@aws-sdk/credential-provider-http": "^3.972.35",
-        "@aws-sdk/credential-provider-ini": "^3.972.37",
-        "@aws-sdk/credential-provider-process": "^3.972.33",
-        "@aws-sdk/credential-provider-sso": "^3.972.37",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.37",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/credential-provider-imds": "^4.2.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/credential-provider-env": "^3.972.68",
+        "@aws-sdk/credential-provider-http": "^3.972.70",
+        "@aws-sdk/credential-provider-ini": "^3.973.13",
+        "@aws-sdk/credential-provider-process": "^3.972.68",
+        "@aws-sdk/credential-provider-sso": "^3.973.12",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.74",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -539,16 +558,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.33.tgz",
-      "integrity": "sha512-yfjGksI9WQbdMObb0VeLXqzTLI+a0qXLJT9gCDiv0+X/xjPpI3mTz6a5FibrhpuEKIe0gSgvs3MaoFZy5cx4WA==",
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.68.tgz",
+      "integrity": "sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -556,18 +574,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.37.tgz",
-      "integrity": "sha512-fpwE+20ntpp3i9Xb9vUuQfXLDKYHH+5I2V+ZG96SX1nBzrruhy10RXDgmN7t1etOz3c55stlA3TeQASUA451NQ==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.12.tgz",
+      "integrity": "sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
-        "@aws-sdk/nested-clients": "^3.997.5",
-        "@aws-sdk/token-providers": "3.1039.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/token-providers": "3.1108.0",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -575,21 +592,67 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.37.tgz",
-      "integrity": "sha512-aryawqyebf+3WhAFNHfF62rekFpYtVcVN7dQ89qnAWsa4n5hJst8qBG6gXC24WHtW7Nnhkf9ScYnjwo0Brn3bw==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.74.tgz",
+      "integrity": "sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
-        "@aws-sdk/nested-clients": "^3.997.5",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.42.tgz",
+      "integrity": "sha512-EJjm82YDsWjN991merbDHEprA1s8OYPRtPYaMD57MvilZeCJ4lMAld/gZGFpVN6d1dmYoh4DKTFlWJVfmfMhcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.10.tgz",
+      "integrity": "sha512-xL5sogJajtyGU8p/pA2e8P6dQqs0P6wj2FtBNcZ5VxyBovpoxghKi9hPEkjx+THZijgGW9fOP9EsHDcraSxF8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.1109.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1109.0.tgz",
+      "integrity": "sha512-xP+iKnjU1eYT3+RqjXum5bz9qLs0SKpcEjXzb11ck7U7l4M0Cv4w1tGCUF7kdvmPc+sR2jSlT6fwDkKuB6+svQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/util-dynamodb": "^3.996.8",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1109.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
@@ -604,6 +667,22 @@
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.28.tgz",
+      "integrity": "sha512-T4F2dZRK80PyigacWVH2Garx6x3oH24tfOZxsv8zLqha+0K0zBS4GvbnFTgHTVjAdJGAYisxQHD/TNDJh+Up/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.10",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -768,49 +847,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.5.tgz",
-      "integrity": "sha512-jGFr6DxtcMTmzOkG/a0jCZYv4BBDmeNYVeO+/memSoDkYCJu4Y58xviYmzwJfYyIVSts+X/BVjJm1uGBnwHEMg==",
+      "version": "3.997.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.42.tgz",
+      "integrity": "sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.7",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.37",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.24",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.23",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.17",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
-        "@smithy/middleware-serde": "^4.2.20",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.49",
-        "@smithy/util-defaults-mode-node": "^4.2.54",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.44",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -853,16 +901,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.24.tgz",
-      "integrity": "sha512-amP7tLikppN940wbBFISYqiuzVmpzMS9U3mcgtmVLjX4fdWI/SNCvrXv6ZxfVzTT4cT0rPKOLhFah2xLwzREWw==",
+      "version": "3.996.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.44.tgz",
+      "integrity": "sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.36",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -870,17 +916,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1039.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1039.0.tgz",
-      "integrity": "sha512-NMSFL2HwkAOoCeLCQiqoOq5pT3vVbSjww2QZTuYgYknVwhhv125PSDzZIcL5EYnlxuPWjEOdauZK+FspkZDVdw==",
+      "version": "3.1108.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1108.0.tgz",
+      "integrity": "sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.7",
-        "@aws-sdk/nested-clients": "^3.997.5",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -888,12 +933,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "version": "3.974.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.3.tgz",
+      "integrity": "sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -910,6 +955,21 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.8.tgz",
+      "integrity": "sha512-zg9Scj7J5MCQS4XeEkvKwPN6Crw3oYjFBICxfPpcrIurEKhckL1o/Co8cNKC2WxsYwKmaywFTB8cxpmJqSUx5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1108.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
@@ -993,14 +1053,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
-      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.38.tgz",
+      "integrity": "sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@nodable/entities": "2.1.0",
-        "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.2",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1994,18 +2052,6 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2100,20 +2146,12 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.17",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
-      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.32.0.tgz",
+      "integrity": "sha512-NAiCSC78fzbNIEWoheoF74Ob5ZorLijCHpMY26Fqvqg/+9LuyIqMfHDg2p8Yk1rqOyowtiL3y7WX0AW+teL6zw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
+        "@smithy/types": "^4.17.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2121,15 +2159,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
-      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.0.tgz",
+      "integrity": "sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2207,15 +2243,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.17",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
-      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.0.tgz",
+      "integrity": "sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/querystring-builder": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2403,14 +2437,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
-      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.10.0.tgz",
+      "integrity": "sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/querystring-builder": "^4.2.14",
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2496,18 +2529,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
-      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.0.tgz",
+      "integrity": "sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2533,9 +2561,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
-      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.0.tgz",
+      "integrity": "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3945,43 +3973,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-xml-builder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
-      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.6.2",
-        "xml-naming": "^0.3.0"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
-      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -5154,6 +5145,15 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5230,6 +5230,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -5346,21 +5352,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-expression-matcher": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
-      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-absolute": {
@@ -5943,18 +5934,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6413,21 +6392,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/xml-naming": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
-      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/xtend": {

--- a/booking-api/package.json
+++ b/booking-api/package.json
@@ -19,6 +19,9 @@
     "testEnvironment": "node",
     "testMatch": [
       "<rootDir>/src/**/*.test.ts"
+    ],
+    "setupFilesAfterEnv": [
+      "<rootDir>/src/testSetup.ts"
     ]
   },
   "engines": {
@@ -34,8 +37,10 @@
     "ts-jest": "^29.4.9"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.1039.0",
     "@aws-sdk/client-s3": "^3.1039.0",
     "@aws-sdk/client-secrets-manager": "^3.0.0",
+    "@aws-sdk/lib-dynamodb": "^3.1039.0",
     "@aws-sdk/s3-request-presigner": "^3.1039.0",
     "pg": "^8.20.0"
   },

--- a/booking-api/src/cacheFactory.ts
+++ b/booking-api/src/cacheFactory.ts
@@ -2,15 +2,20 @@
  * Cache adapter factory for the Kalawala booking API.
  *
  * Reads the CACHE_BACKEND environment variable to determine which backend to
- * use.  When running in staging (ElastiCache disabled) the Lambda environment
- * sets CACHE_BACKEND=memory; production sets CACHE_BACKEND=redis.
+ * use. `dynamodb` is the real shared-cache backend — a DynamoDB table visible
+ * to every concurrently warm Lambda execution environment, not just the one
+ * handling the current request (see dynamoCacheAdapter.ts). `redis` predates
+ * that and is a stub that logs a warning and falls back to memory; it is kept
+ * only so an old CACHE_BACKEND=redis env var doesn't hard-fail. `memory`
+ * (the default) is a single execution environment's in-Lambda cache only.
  *
- * The module-level singleton for the memory backend survives Lambda warm
- * starts, so cached entries are reused across invocations of the same
- * execution environment (Requirement 4.5).
+ * The module-level singletons survive Lambda warm starts, so cached entries
+ * (and, for `dynamodb`, the underlying client connection) are reused across
+ * invocations of the same execution environment (Requirement 4.5).
  */
 
 import { CacheAdapter, MemoryCache, createMemoryCache } from "./memoryCache";
+import { DynamoCacheAdapter } from "./dynamoCacheAdapter";
 
 // ---------------------------------------------------------------------------
 // TTL scopes (seconds)
@@ -38,10 +43,13 @@ export const TTL_SCOPES: Record<string, number> = {
  * Defaults to `'memory'` when the variable is absent or set to an
  * unrecognised value.
  */
-export function getCacheBackend(): "redis" | "memory" {
+export function getCacheBackend(): "redis" | "memory" | "dynamodb" {
   const raw = process.env.CACHE_BACKEND;
   if (raw === "redis") {
     return "redis";
+  }
+  if (raw === "dynamodb") {
+    return "dynamodb";
   }
   return "memory";
 }
@@ -135,6 +143,13 @@ class RedisAdapter implements CacheAdapter {
  */
 let memoryCacheSingleton: MemoryCache | null = null;
 
+/**
+ * Singleton DynamoCacheAdapter instance (and thus its underlying DynamoDB
+ * client) — same warm-start-persistence reasoning as memoryCacheSingleton.
+ */
+let dynamoCacheSingleton: DynamoCacheAdapter | null = null;
+let warnedDynamoMisconfigured = false;
+
 // ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
@@ -142,10 +157,11 @@ let memoryCacheSingleton: MemoryCache | null = null;
 /**
  * Returns a `CacheAdapter` for the requested backend.
  *
- * @param backend     - `'memory'` for the in-Lambda LRU cache or `'redis'`
- *                      for the Redis adapter.
+ * @param backend     - `'memory'` for the in-Lambda LRU cache, `'dynamodb'`
+ *                      for the shared DynamoDB-backed cache, or `'redis'` for
+ *                      the (stubbed, falls back to memory) Redis adapter.
  * @param redisConfig - Optional Redis connection overrides (host, port,
- *                      secretName).  Ignored when `backend = 'memory'`.
+ *                      secretName).  Ignored except when `backend = 'redis'`.
  *
  * @example
  * ```ts
@@ -153,11 +169,11 @@ let memoryCacheSingleton: MemoryCache | null = null;
  * const cache = createCacheAdapter(getCacheBackend());
  *
  * // Explicit backend selection:
- * const cache = createCacheAdapter('memory');
+ * const cache = createCacheAdapter('dynamodb');
  * ```
  */
 export function createCacheAdapter(
-  backend: "redis" | "memory",
+  backend: "redis" | "memory" | "dynamodb",
   redisConfig?: RedisConfig
 ): CacheAdapter {
   if (backend === "memory") {
@@ -165,6 +181,27 @@ export function createCacheAdapter(
       memoryCacheSingleton = createMemoryCache();
     }
     return memoryCacheSingleton;
+  }
+
+  if (backend === "dynamodb") {
+    const tableName = process.env.CACHE_TABLE_NAME;
+    if (!tableName) {
+      if (!warnedDynamoMisconfigured) {
+        console.warn(
+          "[DynamoCacheAdapter] CACHE_TABLE_NAME is not configured — falling back to in-memory cache."
+        );
+        warnedDynamoMisconfigured = true;
+      }
+      if (!memoryCacheSingleton) {
+        memoryCacheSingleton = createMemoryCache();
+      }
+      return memoryCacheSingleton;
+    }
+
+    if (!dynamoCacheSingleton) {
+      dynamoCacheSingleton = new DynamoCacheAdapter({ tableName });
+    }
+    return dynamoCacheSingleton;
   }
 
   // Redis backend — a new adapter instance per call is fine because the

--- a/booking-api/src/dynamoCacheAdapter.test.ts
+++ b/booking-api/src/dynamoCacheAdapter.test.ts
@@ -1,0 +1,184 @@
+import { DynamoCacheAdapter, DynamoCommandClient } from "./dynamoCacheAdapter";
+
+/**
+ * A minimal fake standing in for DynamoDBDocumentClient. Records every
+ * command's constructor name + input so assertions can check what was sent
+ * without depending on the AWS SDK's internal command shapes, and drives
+ * responses from an in-memory table so get/set/del/scan behave like the
+ * real thing.
+ */
+function makeFakeClient() {
+  const table = new Map<string, { value: string; expires_at: number }>();
+  const calls: Array<{ name: string; input: Record<string, unknown> }> = [];
+
+  const client: DynamoCommandClient = {
+    async send(command: unknown) {
+      const { constructor, input } = command as {
+        constructor: { name: string };
+        input: Record<string, unknown>;
+      };
+      calls.push({ name: constructor.name, input });
+
+      switch (constructor.name) {
+        case "GetCommand": {
+          const key = (input.Key as { cache_key: string }).cache_key;
+          const item = table.get(key);
+          return { Item: item ? { cache_key: key, ...item } : undefined };
+        }
+        case "PutCommand": {
+          const item = input.Item as { cache_key: string; value: string; expires_at: number };
+          table.set(item.cache_key, { value: item.value, expires_at: item.expires_at });
+          return {};
+        }
+        case "DeleteCommand": {
+          const key = (input.Key as { cache_key: string }).cache_key;
+          table.delete(key);
+          return {};
+        }
+        case "ScanCommand": {
+          const prefix = (input.ExpressionAttributeValues as { ":prefix"?: string } | undefined)?.[
+            ":prefix"
+          ];
+          const items = Array.from(table.keys())
+            .filter((key) => !prefix || key.startsWith(prefix))
+            .map((cache_key) => ({ cache_key }));
+          return { Items: items };
+        }
+        case "BatchWriteCommand": {
+          const requestItems = input.RequestItems as Record<
+            string,
+            Array<{ DeleteRequest: { Key: { cache_key: string } } }>
+          >;
+          for (const requests of Object.values(requestItems)) {
+            for (const request of requests) {
+              table.delete(request.DeleteRequest.Key.cache_key);
+            }
+          }
+          return {};
+        }
+        default:
+          throw new Error(`Unhandled command in fake DynamoDB client: ${constructor.name}`);
+      }
+    },
+  };
+
+  return { client, table, calls };
+}
+
+function makeAdapter(startMs = 1_700_000_000_000) {
+  const { client, table, calls } = makeFakeClient();
+  let now = startMs;
+  const adapter = new DynamoCacheAdapter({
+    tableName: "kalawala-test-booking-cache",
+    client,
+    now: () => now,
+  });
+  return { adapter, table, calls, advance: (ms: number) => { now += ms; } };
+}
+
+describe("DynamoCacheAdapter — get on non-existent key", () => {
+  it("returns null for a key that was never set", async () => {
+    const { adapter } = makeAdapter();
+    expect(await adapter.get("missing-key")).toBeNull();
+  });
+});
+
+describe("DynamoCacheAdapter — set then get", () => {
+  it("returns the stored value immediately after set", async () => {
+    const { adapter } = makeAdapter();
+    await adapter.set("301061:2026-06", '{"month":"2026-06"}', 300);
+    expect(await adapter.get("301061:2026-06")).toBe('{"month":"2026-06"}');
+  });
+
+  it("is visible to a second adapter instance sharing the same table — the whole point of a shared cache", async () => {
+    const { client } = makeFakeClient();
+    let now = 0;
+    const writer = new DynamoCacheAdapter({ tableName: "t", client, now: () => now });
+    const reader = new DynamoCacheAdapter({ tableName: "t", client, now: () => now });
+
+    await writer.set("shared-key", "shared-value", 60);
+    expect(await reader.get("shared-key")).toBe("shared-value");
+  });
+});
+
+describe("DynamoCacheAdapter — TTL expiry", () => {
+  it("returns the value before the TTL elapses", async () => {
+    const { adapter, advance } = makeAdapter();
+    await adapter.set("key", "value", 300);
+    advance(299_000);
+    expect(await adapter.get("key")).toBe("value");
+  });
+
+  it("returns null once the TTL elapses, even though DynamoDB's own TTL sweep hasn't deleted the item yet", async () => {
+    const { adapter, table, advance } = makeAdapter();
+    await adapter.set("key", "value", 300);
+    advance(300_001);
+
+    expect(await adapter.get("key")).toBeNull();
+    // The item is still physically in the table — expiry is enforced by the
+    // read path, not by waiting on DynamoDB's background TTL sweep.
+    expect(table.has("key")).toBe(true);
+  });
+});
+
+describe("DynamoCacheAdapter — del", () => {
+  it("removes a previously set key", async () => {
+    const { adapter } = makeAdapter();
+    await adapter.set("key", "value", 60);
+    await adapter.del("key");
+    expect(await adapter.get("key")).toBeNull();
+  });
+
+  it("is a no-op for a key that was never set", async () => {
+    const { adapter } = makeAdapter();
+    await expect(adapter.del("never-set")).resolves.toBeUndefined();
+  });
+});
+
+describe("DynamoCacheAdapter — invalidateByPrefix", () => {
+  it("deletes only keys matching the prefix and reports the count", async () => {
+    const { adapter } = makeAdapter();
+    await adapter.set("301061:2026-06", "june", 300);
+    await adapter.set("301061:2026-07", "july", 300);
+    await adapter.set("301064:2026-06", "other-apartment", 300);
+
+    const count = await adapter.invalidateByPrefix("301061:");
+
+    expect(count).toBe(2);
+    expect(await adapter.get("301061:2026-06")).toBeNull();
+    expect(await adapter.get("301061:2026-07")).toBeNull();
+    expect(await adapter.get("301064:2026-06")).toBe("other-apartment");
+  });
+
+  it("clears every entry when the prefix is empty", async () => {
+    const { adapter } = makeAdapter();
+    await adapter.set("a", "1", 60);
+    await adapter.set("b", "2", 60);
+
+    const count = await adapter.invalidateByPrefix("");
+
+    expect(count).toBe(2);
+    expect(await adapter.get("a")).toBeNull();
+    expect(await adapter.get("b")).toBeNull();
+  });
+
+  it("returns 0 when nothing matches", async () => {
+    const { adapter } = makeAdapter();
+    await adapter.set("301061:2026-06", "june", 300);
+
+    expect(await adapter.invalidateByPrefix("no-such-prefix:")).toBe(0);
+  });
+
+  it("batches deletes past the 25-item BatchWriteItem limit", async () => {
+    const { adapter, calls } = makeAdapter();
+    for (let i = 0; i < 30; i += 1) {
+      await adapter.set(`bulk:${i}`, String(i), 300);
+    }
+
+    const count = await adapter.invalidateByPrefix("bulk:");
+
+    expect(count).toBe(30);
+    const batchWrites = calls.filter((call) => call.name === "BatchWriteCommand");
+    expect(batchWrites).toHaveLength(2);
+  });
+});

--- a/booking-api/src/dynamoCacheAdapter.ts
+++ b/booking-api/src/dynamoCacheAdapter.ts
@@ -1,0 +1,121 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  BatchWriteCommand,
+  DeleteCommand,
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  ScanCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { CacheAdapter } from "./memoryCache";
+
+// BatchWriteItem accepts at most 25 requests per call.
+const BATCH_WRITE_LIMIT = 25;
+
+/** The subset of DynamoDBDocumentClient this adapter needs — narrowed so tests can inject a fake. */
+export interface DynamoCommandClient {
+  send(command: unknown): Promise<Record<string, unknown>>;
+}
+
+export interface DynamoCacheAdapterOptions {
+  tableName: string;
+  client?: DynamoCommandClient;
+  now?: () => number;
+}
+
+/**
+ * TTL cache backed by a DynamoDB table, shared across every concurrently
+ * warm Lambda execution environment — unlike MemoryCache, which is scoped to
+ * a single instance. This is what actually stops a traffic burst from
+ * turning "1 Smoobu call per (property, month) per 5 minutes" into one call
+ * per concurrently warm instance.
+ *
+ * DynamoDB's own TTL attribute deletes expired items on a best-effort
+ * background sweep (AWS documents up to ~48h of lag), so it only bounds
+ * storage growth — every read also checks `expires_at` itself and treats a
+ * stale-but-not-yet-swept item as a miss.
+ */
+export class DynamoCacheAdapter implements CacheAdapter {
+  private readonly client: DynamoCommandClient;
+  private readonly tableName: string;
+  private readonly now: () => number;
+
+  constructor(options: DynamoCacheAdapterOptions) {
+    this.tableName = options.tableName;
+    this.client = options.client ?? DynamoDBDocumentClient.from(new DynamoDBClient({}));
+    this.now = options.now ?? Date.now;
+  }
+
+  async get(key: string): Promise<string | null> {
+    const result = await this.client.send(
+      new GetCommand({ TableName: this.tableName, Key: { cache_key: key } })
+    );
+
+    const item = result.Item as { value?: unknown; expires_at?: unknown } | undefined;
+    if (!item || typeof item.value !== "string") {
+      return null;
+    }
+
+    if (typeof item.expires_at === "number" && item.expires_at * 1_000 <= this.now()) {
+      return null;
+    }
+
+    return item.value;
+  }
+
+  async set(key: string, value: string, ttlSeconds: number): Promise<void> {
+    const expiresAt = Math.floor(this.now() / 1_000) + ttlSeconds;
+
+    await this.client.send(
+      new PutCommand({
+        TableName: this.tableName,
+        Item: { cache_key: key, value, expires_at: expiresAt },
+      })
+    );
+  }
+
+  async del(key: string): Promise<void> {
+    await this.client.send(new DeleteCommand({ TableName: this.tableName, Key: { cache_key: key } }));
+  }
+
+  async invalidateByPrefix(prefix: string): Promise<number> {
+    let invalidated = 0;
+    let exclusiveStartKey: Record<string, unknown> | undefined;
+
+    do {
+      const scanResult = await this.client.send(
+        new ScanCommand({
+          TableName: this.tableName,
+          ProjectionExpression: "cache_key",
+          // An empty prefix means "clear everything" — no filter needed.
+          FilterExpression: prefix ? "begins_with(cache_key, :prefix)" : undefined,
+          ExpressionAttributeValues: prefix ? { ":prefix": prefix } : undefined,
+          ExclusiveStartKey: exclusiveStartKey,
+        })
+      );
+
+      const keys = ((scanResult.Items ?? []) as Array<{ cache_key: string }>).map((item) => item.cache_key);
+      if (keys.length > 0) {
+        await this.batchDelete(keys);
+        invalidated += keys.length;
+      }
+
+      exclusiveStartKey = scanResult.LastEvaluatedKey as Record<string, unknown> | undefined;
+    } while (exclusiveStartKey);
+
+    return invalidated;
+  }
+
+  private async batchDelete(keys: string[]): Promise<void> {
+    for (let i = 0; i < keys.length; i += BATCH_WRITE_LIMIT) {
+      const chunk = keys.slice(i, i + BATCH_WRITE_LIMIT);
+      await this.client.send(
+        new BatchWriteCommand({
+          RequestItems: {
+            [this.tableName]: chunk.map((cache_key) => ({ DeleteRequest: { Key: { cache_key } } })),
+          },
+        })
+      );
+    }
+  }
+}

--- a/booking-api/src/memoryCache.test.ts
+++ b/booking-api/src/memoryCache.test.ts
@@ -233,6 +233,45 @@ describe('cacheFactory — warm-start singleton', () => {
       delete process.env.CACHE_BACKEND;
     }
   });
+
+  it('getCacheBackend returns "dynamodb" when CACHE_BACKEND=dynamodb', () => {
+    const original = process.env.CACHE_BACKEND;
+    process.env.CACHE_BACKEND = 'dynamodb';
+    expect(getCacheBackend()).toBe('dynamodb');
+    if (original !== undefined) {
+      process.env.CACHE_BACKEND = original;
+    } else {
+      delete process.env.CACHE_BACKEND;
+    }
+  });
+
+  it('createCacheAdapter("dynamodb") falls back to the memory singleton when CACHE_TABLE_NAME is unset', () => {
+    const originalTable = process.env.CACHE_TABLE_NAME;
+    delete process.env.CACHE_TABLE_NAME;
+
+    const fallback = createCacheAdapter('dynamodb');
+    const memory = createCacheAdapter('memory');
+    expect(fallback).toBe(memory);
+
+    if (originalTable !== undefined) {
+      process.env.CACHE_TABLE_NAME = originalTable;
+    }
+  });
+
+  it('createCacheAdapter("dynamodb") returns the same object reference on repeated calls once configured', () => {
+    const originalTable = process.env.CACHE_TABLE_NAME;
+    process.env.CACHE_TABLE_NAME = 'kalawala-test-booking-cache';
+
+    const first = createCacheAdapter('dynamodb');
+    const second = createCacheAdapter('dynamodb');
+    expect(first).toBe(second);
+
+    if (originalTable !== undefined) {
+      process.env.CACHE_TABLE_NAME = originalTable;
+    } else {
+      delete process.env.CACHE_TABLE_NAME;
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/booking-api/src/smoobuClient.ts
+++ b/booking-api/src/smoobuClient.ts
@@ -16,6 +16,25 @@ const DEFAULT_SMOOBU_CONFIG: SmoobuClientConfig = {
 
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
 
+/**
+ * When Smoobu 429s, this is the one thing that's supposed to stop the next
+ * request from immediately hitting it again. It has to live at module scope,
+ * not on a SmoobuClient instance: every route handler calls
+ * `createSmoobuClient()` fresh per invocation (see below), so an instance
+ * field would be discarded the moment the request that observed the 429
+ * finished — the very next request, even on the same warm Lambda, would have
+ * no idea a rate limit window was active. Module scope survives across
+ * invocations for the life of the execution environment, which is what
+ * actually lets concurrent/rapid requests back off together instead of each
+ * independently re-triggering the limit.
+ */
+let sharedRateLimitBlockedUntilMs = 0;
+
+/** Test seam — clears the shared rate-limit window between test cases. */
+export function resetSmoobuRateLimitState(): void {
+  sharedRateLimitBlockedUntilMs = 0;
+}
+
 type FetchFn = (input: string | URL, init?: RequestInit) => Promise<Response>;
 type SleepFn = (ms: number) => Promise<void>;
 
@@ -83,7 +102,6 @@ export class SmoobuClient {
   private readonly sleep: SleepFn;
   private readonly now: () => number;
   private readonly nonceFn: () => string;
-  private rateLimitBlockedUntilMs = 0;
 
   constructor(options: SmoobuClientOptions) {
     const apiKey = options.apiKey.trim();
@@ -357,14 +375,14 @@ export class SmoobuClient {
       return;
     }
 
-    this.rateLimitBlockedUntilMs = Math.max(
-      this.rateLimitBlockedUntilMs,
+    sharedRateLimitBlockedUntilMs = Math.max(
+      sharedRateLimitBlockedUntilMs,
       this.now() + rateLimit.retryAfterSeconds * 1_000
     );
   }
 
   private async waitForKnownRateLimitWindow(): Promise<void> {
-    const delayMs = this.rateLimitBlockedUntilMs - this.now();
+    const delayMs = sharedRateLimitBlockedUntilMs - this.now();
     if (delayMs <= 0) {
       return;
     }

--- a/booking-api/src/testSetup.ts
+++ b/booking-api/src/testSetup.ts
@@ -1,0 +1,10 @@
+import { resetSmoobuRateLimitState } from "./smoobuClient";
+
+// The Smoobu rate-limit backoff window lives at module scope (see
+// smoobuClient.ts) so it survives across Lambda invocations within a warm
+// execution environment. In tests, all test cases in a file share that same
+// module instance, so a 429 simulated in one test would otherwise leak into
+// every later test in the file and make them wait out a stale backoff window.
+afterEach(() => {
+  resetSmoobuRateLimitState();
+});

--- a/infra/dynamodb.tf
+++ b/infra/dynamodb.tf
@@ -1,0 +1,85 @@
+##############################################################################
+# dynamodb.tf — shared TTL cache for the booking API.
+#
+# booking-api/src/memoryCache.ts's in-Lambda cache is scoped to a single
+# execution environment: under concurrent traffic (a burst of guests
+# browsing calendars around the same time), each concurrently warm Lambda
+# instance has its own empty cache and independently re-fetches Smoobu on a
+# miss, which is what was compounding into Smoobu 429s. This table gives
+# every instance the same cache instead.
+#
+# On-demand billing rather than ElastiCache/Redis: this workload (a handful
+# of properties x a dozen months of calendar rates, occasional availability
+# lookups) is a few cents/month here versus a $12-25+/month always-on node,
+# with no VPC networking or client library required. See
+# booking-api/src/dynamoCacheAdapter.ts.
+##############################################################################
+
+resource "aws_dynamodb_table" "booking_cache" {
+  name         = "${var.project}-${var.environment}-booking-cache"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "cache_key"
+
+  attribute {
+    name = "cache_key"
+    type = "S"
+  }
+
+  # DynamoDB's TTL sweep is best-effort (AWS documents up to ~48h of lag), so
+  # it only bounds storage growth — DynamoCacheAdapter checks expiry itself
+  # on every read and never relies on the item having actually been deleted.
+  ttl {
+    attribute_name = "expires_at"
+    enabled        = true
+  }
+
+  tags = {
+    Name = "${var.project}-${var.environment}-booking-cache"
+  }
+}
+
+# Gateway endpoint: free, and keeps cache reads/writes (the hottest path in
+# the API) off the fck-nat instance's link instead of adding load to the
+# thing that's already the shared egress point for everything else.
+resource "aws_vpc_endpoint" "dynamodb" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [aws_route_table.private.id]
+
+  tags = {
+    Name = "${var.project}-${var.environment}-dynamodb-endpoint"
+  }
+}
+
+data "aws_iam_policy_document" "lambda_cache_access" {
+  statement {
+    sid    = "AllowBookingCacheReadWrite"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem",
+      "dynamodb:Scan",
+      "dynamodb:BatchWriteItem",
+    ]
+
+    resources = [aws_dynamodb_table.booking_cache.arn]
+  }
+}
+
+resource "aws_iam_policy" "lambda_cache_access" {
+  name        = "${var.project}-${var.environment}-lambda-cache-access"
+  description = "Allows Lambda functions to read/write the shared booking-cache DynamoDB table."
+  policy      = data.aws_iam_policy_document.lambda_cache_access.json
+
+  tags = {
+    Name = "${var.project}-${var.environment}-lambda-cache-access-policy"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_cache_access" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = aws_iam_policy.lambda_cache_access.arn
+}

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -182,10 +182,14 @@ locals {
     # so this reproduces the same invoke_url without the cycle.
     DEPOSIT_STAFF_CONFIRM_BASE_URL = "https://${aws_api_gateway_rest_api.main.id}.execute-api.${data.aws_region.current.name}.amazonaws.com/${var.environment}"
 
-    # In-Lambda TTL cache (src/memoryCache.ts). There is no Redis client in
-    # booking-api's dependencies — src/cacheFactory.ts:71 RedisAdapter is a
-    # stub — so "redis" is not a usable value here. See cacheFactory.getCacheBackend().
-    CACHE_BACKEND = "memory"
+    # Shared TTL cache — a DynamoDB table (dynamodb.tf), visible to every
+    # concurrently warm Lambda instance, not just the one in-Lambda memory
+    # cache (src/memoryCache.ts) that used to serve each request. There is no
+    # Redis client in booking-api's dependencies — cacheFactory.ts's
+    # RedisAdapter is a stub — so "redis" is not a usable value here. See
+    # cacheFactory.getCacheBackend().
+    CACHE_BACKEND    = "dynamodb"
+    CACHE_TABLE_NAME = aws_dynamodb_table.booking_cache.name
 
     SES_CONFIG_SET    = aws_ses_configuration_set.booking.name
     SES_FROM_ADDRESS  = local.ses_from_email

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -242,3 +242,8 @@ output "payment_reconciliation_lambda_name" {
   description = "Scheduled worker that resolves PayPal payments whose webhook was missed."
   value       = aws_lambda_function.payment_reconciliation.function_name
 }
+
+output "booking_cache_table_name" {
+  description = "DynamoDB table backing the shared booking-api cache (calendar rates, availability)."
+  value       = aws_dynamodb_table.booking_cache.name
+}

--- a/src/components/CalendarWithPriceDots/CalendarWithPriceDots.test.tsx
+++ b/src/components/CalendarWithPriceDots/CalendarWithPriceDots.test.tsx
@@ -158,13 +158,16 @@ describe('CalendarWithPriceDots', () => {
     mockFetchByMonth();
 
     render(<CalendarWithPriceDots apartmentSlug="Geco" language="en" />);
-    await screen.findByRole('img', { name: /June 1,/ });
+    // The fetch trigger is debounced, so the placeholder ("Unavailable") label
+    // renders before the real price data does — wait for the priced label to
+    // be sure the June request actually landed before navigating away.
+    await screen.findByRole('img', { name: /June 1, \$90\.00, low price, 2-night minimum/ });
 
     fireEvent.click(screen.getByRole('button', { name: 'Next month' }));
     await screen.findByRole('img', { name: /July 1, \$150\.00, average price/ });
 
     fireEvent.click(screen.getByRole('button', { name: 'Previous month' }));
-    await screen.findByRole('img', { name: /June 1,/ });
+    await screen.findByRole('img', { name: /June 1, \$90\.00, low price, 2-night minimum/ });
 
     const fetchedUrls = (global.fetch as jest.Mock).mock.calls.map(([url]) => url);
     expect(fetchedUrls).toEqual([
@@ -315,7 +318,9 @@ describe('CalendarWithPriceDots', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getAllByRole('img', { name: /June 1,/ })).toHaveLength(2);
+      expect(
+        screen.getAllByRole('img', { name: /June 1, \$90\.00, low price, 2-night minimum/ })
+      ).toHaveLength(2);
     });
 
     expect((global.fetch as jest.Mock).mock.calls).toHaveLength(1);

--- a/src/hooks/useCalendarMonth.ts
+++ b/src/hooks/useCalendarMonth.ts
@@ -9,6 +9,12 @@ interface UseCalendarMonthResult {
   hasError: boolean;
 }
 
+// A guest flipping quickly through months (or the anchor/anchorNext pair
+// re-firing as a check-in candidate changes) would otherwise send one real
+// request per month they passed through. Waiting for a short pause means
+// only the month they actually land on gets fetched.
+const FETCH_DEBOUNCE_MS = 200;
+
 /**
  * Loads one month of calendar rates through the shared cache.
  *
@@ -55,25 +61,28 @@ export function useCalendarMonth(
     setLoadingKey(key);
     setErrorKey(null);
 
-    loadCalendarMonth(apartmentSlug, month, language)
-      .then(() => {
-        if (!isCancelled) {
-          markLoaded();
-        }
-      })
-      .catch(() => {
-        if (!isCancelled) {
-          setErrorKey(key);
-        }
-      })
-      .finally(() => {
-        if (!isCancelled) {
-          setLoadingKey((current) => (current === key ? null : current));
-        }
-      });
+    const timer = setTimeout(() => {
+      loadCalendarMonth(apartmentSlug, month, language)
+        .then(() => {
+          if (!isCancelled) {
+            markLoaded();
+          }
+        })
+        .catch(() => {
+          if (!isCancelled) {
+            setErrorKey(key);
+          }
+        })
+        .finally(() => {
+          if (!isCancelled) {
+            setLoadingKey((current) => (current === key ? null : current));
+          }
+        });
+    }, FETCH_DEBOUNCE_MS);
 
     return () => {
       isCancelled = true;
+      clearTimeout(timer);
     };
   }, [apartmentSlug, month, language, enabled, key]);
 


### PR DESCRIPTION
## Summary

- The Smoobu rate-limit backoff window lived on a `SmoobuClient` instance recreated per request by every route handler, so a 429's backoff was discarded the instant that request finished — the next request (even the same warm Lambda, same millisecond) had zero memory of it and hit Smoobu again immediately. Moved to module scope so it's actually shared across requests within a warm execution environment.
- Replaced the per-Lambda-instance memory cache with a shared DynamoDB table (`infra/dynamodb.tf`, `booking-api/src/dynamoCacheAdapter.ts`, pay-per-request billing) so concurrent warm Lambda instances stop each independently re-fetching Smoobu on a cache miss for data another instance already has cached. Falls back to the existing in-memory cache if `CACHE_TABLE_NAME` is ever unset.
- Debounced the frontend calendar month fetch trigger (`useCalendarMonth.ts`) so rapid month navigation settles on the final month instead of firing one request per month passed through.

## Infra changes (reviewed via `terraform validate`/`fmt` locally, not applied)

- New `aws_dynamodb_table.booking_cache` (on-demand billing, TTL on `expires_at`) + a free VPC Gateway Endpoint for DynamoDB + an IAM policy scoped to just that table, attached to the existing shared Lambda execution role.
- `CACHE_BACKEND` flipped from `"memory"` to `"dynamodb"` for all Lambdas; `CACHE_TABLE_NAME` added.

This is the first infra change this repo has made to provision a new AWS resource in a while — worth a look at the `terraform plan` this PR triggers before merging.

## Test plan

- [x] `booking-api`: 518 tests passing, `npm run typecheck` clean
- [x] frontend: 781 tests passing, `tsc --noEmit` clean
- [x] `terraform fmt -check` / `terraform validate` clean (no AWS credentials used — validation only)
- [ ] Review the CI-posted `terraform plan` output before merging (creates a new DynamoDB table + VPC endpoint + IAM policy, changes Lambda env vars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLcEMAc4Zw4UnXgKipUJqg