### PR TITLE
feat(booking): auto-search when a shared link already has both dates

### DIFF
--- a/src/pages/Booking.page.test.tsx
+++ b/src/pages/Booking.page.test.tsx
@@ -342,6 +342,25 @@ test('language switcher toggles booking routes and preserves search query state'
   expect(activeSlide().getByLabelText('Huéspedes')).toHaveValue(4);
 });
 
+test('auto-searches when a shared link already carries arrival and departure dates', async () => {
+  mockJsonResponse({ ...spanishSearchResult, language: 'en' });
+
+  renderBookingPage('/en/book?arrivalDate=2099-07-10&departureDate=2099-07-14');
+
+  await screen.findByText('Casa Geco');
+
+  const [, request] = (global.fetch as jest.Mock).mock.calls[0];
+  expect(JSON.parse(request.body)).toMatchObject({ arrivalDate: '2099-07-10', departureDate: '2099-07-14' });
+});
+
+test('does not auto-search when a shared link is missing one of the dates', () => {
+  global.fetch = jest.fn() as typeof fetch;
+
+  renderBookingPage('/en/book?arrivalDate=2099-07-10');
+
+  expect(global.fetch).not.toHaveBeenCalled();
+});
+
 test('builds Spanish listing links from the property slug and opens them in a new tab', async () => {
   mockJsonResponse({
     bookingSessionId: '3d0f8ac0-5c30-4b09-bb49-12fd1df120f1',

--- a/src/pages/Booking.page.tsx
+++ b/src/pages/Booking.page.tsx
@@ -340,14 +340,16 @@ const BookingPage = () => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [arrivalDate, departureDate, guests, language, strings, executeRecaptcha]);
 
-  // Auto-search when arriving from BookingSearchWidget with autoSearch=true
+  // Auto-search when arriving from BookingSearchWidget with autoSearch=true, or
+  // when a guest opens a shared link that already carries both dates.
   const autoSearchFiredRef = React.useRef(false);
   React.useEffect(() => {
     if (autoSearchFiredRef.current) return;
     // A resumed deposit already owns the wizard; a stale autoSearch in the URL
     // (e.g. from the back button) must not overwrite it with a fresh search.
     if (resumedDeposit) return;
-    if (searchParams.get('autoSearch') !== 'true') return;
+    const hasSharedDates = Boolean(searchParams.get('arrivalDate') && searchParams.get('departureDate'));
+    if (searchParams.get('autoSearch') !== 'true' && !hasSharedDates) return;
     if (!arrivalDate || !departureDate) return;
     if (isPayPalReturnRoute || isConfirmationRoute) return;
     autoSearchFiredRef.current = true;


### PR DESCRIPTION
## Summary
- Links carrying `arrivalDate`/`departureDate` query params already pre-filled the booking form, but the search only ran automatically when an internal `autoSearch=true` flag (set only by the on-site search widget) was also present.
- A plain link shared with just the two dates — the natural way someone would copy a URL out of the address bar — left the recipient looking at a pre-filled form they still had to submit manually.
- `Booking.page.tsx`'s auto-search effect now also fires when both date params are present on load, in addition to the existing `autoSearch=true` widget case. A link with only one of the two dates still requires a manual submit.

## Test plan
- [x] `Booking.page.test.tsx` — added coverage for auto-search firing on a shared link with both dates, and not firing when only one date is present
- [x] Full `Booking.page.test.tsx` suite (34 tests) passes
- [x] `tsc --noEmit` clean
- [x] `eslint` on changed files shows only pre-existing findings unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DPRgZKNyD8u15bsPCkuPH