### PR TITLE
Add contextual internal links across blogs and listings

### DIFF
--- a/src/i18n/content/internalLinks.ts
+++ b/src/i18n/content/internalLinks.ts
@@ -1,0 +1,180 @@
+import type { Locale } from '../locales';
+import type { RouteKey } from '../../routes.config';
+
+/**
+ * Canonical anchor text for in-body contextual links from one blog/listing
+ * page to another (e.g. a listing's "two National Parks" paragraph linking
+ * to the Cahuita National Park guide). One label per target route, reused
+ * everywhere that target is linked to, rather than a bespoke translated
+ * field per source page — mirrors the reuse already present in blog.tsx
+ * (busLinkText/diyLinkText carry the same English/translated text in two
+ * unrelated articles).
+ *
+ * Only targets actually linked to from elsewhere need an entry here.
+ */
+const LABELS: Partial<Record<RouteKey, Record<Locale, string>>> = {
+  blogBushours: {
+    en: 'See the full MEPE bus schedule and stops →',
+    es: 'Ver el horario completo y las paradas del bus MEPE →',
+    de: 'Den kompletten MEPE-Busfahrplan und die Haltestellen ansehen →',
+    fr: 'Voir l’horaire complet et les arrêts du bus MEPE →',
+    it: 'Vedi l’orario completo e le fermate del bus MEPE →',
+    pt: 'Ver o horário completo e as paradas do ônibus MEPE →',
+    he: 'צפו בלוח הזמנים המלא ובתחנות של אוטובוס MEPE ←',
+    hi: 'MEPE बस का पूरा शेड्यूल और स्टॉप देखें →',
+    nl: 'Bekijk het volledige MEPE-busschema en de haltes →',
+  },
+  blogByplane: {
+    en: 'Read our guide to reaching Puerto Viejo by plane →',
+    es: 'Lee nuestra guía para llegar a Puerto Viejo en avión →',
+    de: 'Lies unseren Leitfaden, wie du Puerto Viejo mit dem Flugzeug erreichst →',
+    fr: 'Lisez notre guide pour rejoindre Puerto Viejo en avion →',
+    it: 'Leggi la nostra guida per raggiungere Puerto Viejo in aereo →',
+    pt: 'Leia o nosso guia para chegar a Puerto Viejo de avião →',
+    he: 'קראו את המדריך שלנו להגעה ל-Puerto Viejo במטוס ←',
+    hi: 'हवाई जहाज़ से Puerto Viejo पहुँचने की हमारी गाइड पढ़ें →',
+    nl: 'Lees onze gids om Puerto Viejo met het vliegtuig te bereiken →',
+  },
+  blogGandoca: {
+    en: 'See our full guide to getting to Gandoca-Manzanillo →',
+    es: 'Ver nuestra guía completa para llegar a Gandoca-Manzanillo →',
+    de: 'Zu unserem ausführlichen Führer, wie man nach Gandoca-Manzanillo kommt →',
+    fr: 'Voir notre guide complet pour se rendre à Gandoca-Manzanillo →',
+    it: 'Vedi la nostra guida completa per arrivare a Gandoca-Manzanillo →',
+    pt: 'Veja nosso guia completo para chegar a Gandoca-Manzanillo →',
+    he: 'למדריך המלא שלנו להגעה לגנדוקה-מנזנייו ←',
+    hi: 'गंदोका-मंज़ानियो तक पहुँचने की हमारी पूरी गाइड देखें →',
+    nl: 'Bekijk onze volledige gids om in Gandoca-Manzanillo te komen →',
+  },
+  blogGandocaRefuge: {
+    en: 'Explore our guide to the Gandoca-Manzanillo Wildlife Refuge →',
+    es: 'Explora nuestra guía del Refugio de Vida Silvestre Gandoca-Manzanillo →',
+    de: 'Entdecke unseren Guide zum Wildschutzgebiet Gandoca-Manzanillo →',
+    fr: 'Découvrez notre guide de la réserve faunique de Gandoca-Manzanillo →',
+    it: 'Scopri la nostra guida alla Riserva Naturale di Gandoca-Manzanillo →',
+    pt: 'Conheça nosso guia do Refúgio de Vida Silvestre Gandoca-Manzanillo →',
+    he: 'גלו את המדריך שלנו לשמורת הטבע גנדוקה-מנזנייו ←',
+    hi: 'गंदोका-मंज़ानियो वन्यजीव शरणस्थल की हमारी गाइड देखें →',
+    nl: 'Bekijk onze gids voor het Gandoca-Manzanillo Wildreservaat →',
+  },
+  blogCahuitapark: {
+    en: 'Read our full guide to Cahuita National Park →',
+    es: 'Lee nuestra guía completa del Parque Nacional Cahuita →',
+    de: 'Lies unseren vollständigen Guide zum Cahuita-Nationalpark →',
+    fr: 'Lisez notre guide complet du parc national de Cahuita →',
+    it: 'Leggi la nostra guida completa al Parco Nazionale di Cahuita →',
+    pt: 'Leia nosso guia completo do Parque Nacional Cahuita →',
+    he: 'קראו את המדריך המלא שלנו לפארק הלאומי קאהויטה ←',
+    hi: 'काहूइता नेशनल पार्क की हमारी पूरी गाइड पढ़ें →',
+    nl: 'Lees onze volledige gids voor het Cahuita National Park →',
+  },
+  blogBeaches: {
+    en: 'See our guide to Puerto Viejo’s best beaches →',
+    es: 'Ver nuestra guía de las mejores playas de Puerto Viejo →',
+    de: 'Sieh dir unseren Guide zu den besten Stränden von Puerto Viejo an →',
+    fr: 'Découvrez notre guide des plus belles plages de Puerto Viejo →',
+    it: 'Guarda la nostra guida alle spiagge più belle di Puerto Viejo →',
+    pt: 'Veja nosso guia das melhores praias de Puerto Viejo →',
+    he: 'צפו במדריך שלנו לחופים הטובים ביותר בפוארטו-בייחו ←',
+    hi: 'पुएर्तो वियेजो के सबसे अच्छे समुद्र तटों की हमारी गाइड देखें →',
+    nl: 'Bekijk onze gids voor de mooiste stranden van Puerto Viejo →',
+  },
+  blogBocas: {
+    en: 'Planning to cross into Panama? See our Bocas del Toro guide →',
+    es: '¿Planeas cruzar a Panamá? Consulta nuestra guía de Bocas del Toro →',
+    de: 'Planst du eine Reise nach Panama? Sieh dir unseren Bocas del Toro Guide an →',
+    fr: 'Vous prévoyez de passer au Panama ? Consultez notre guide de Bocas del Toro →',
+    it: 'Stai pensando di andare a Panama? Guarda la nostra guida a Bocas del Toro →',
+    pt: 'Planejando cruzar para o Panamá? Veja nosso guia de Bocas del Toro →',
+    he: 'מתכננים לחצות לפנמה? עיינו במדריך שלנו לבוקאס דל טורו ←',
+    hi: 'पनामा जाने की योजना बना रहे हैं? हमारी बोकास डेल टोरो गाइड देखें →',
+    nl: 'Ben je van plan naar Panama te reizen? Bekijk onze gids voor Bocas del Toro →',
+  },
+  blogIndigenous: {
+    en: 'Discover Bribri Indigenous culture near Puerto Viejo →',
+    es: 'Descubre la cultura indígena Bribri cerca de Puerto Viejo →',
+    de: 'Entdecke die indigene Bribri-Kultur in der Nähe von Puerto Viejo →',
+    fr: 'Découvrez la culture indigène Bribri près de Puerto Viejo →',
+    it: 'Scopri la cultura indigena Bribri vicino a Puerto Viejo →',
+    pt: 'Descubra a cultura indígena Bribri perto de Puerto Viejo →',
+    he: 'גלו את התרבות הילידית ברי-ברי ליד פוארטו-בייחו ←',
+    hi: 'पुएर्तो वियेजो के पास ब्रिब्री स्वदेशी संस्कृति की खोज करें →',
+    nl: 'Ontdek de inheemse Bribri-cultuur bij Puerto Viejo →',
+  },
+  blogHiddengems: {
+    en: 'Discover more hidden gems in Puerto Viejo →',
+    es: 'Descubre más lugares escondidos en Puerto Viejo →',
+    de: 'Entdecke weitere Geheimtipps in Puerto Viejo →',
+    fr: 'Découvrez d’autres trésors cachés à Puerto Viejo →',
+    it: 'Scopri altre gemme nascoste di Puerto Viejo →',
+    pt: 'Descubra mais tesouros escondidos em Puerto Viejo →',
+    he: 'גלו עוד פינות חמד נסתרות בפוארטו-בייחו ←',
+    hi: 'पुएर्तो वियेजो के और छिपे हुए रत्न खोजें →',
+    nl: 'Ontdek meer verborgen parels in Puerto Viejo →',
+  },
+  blogTenhours: {
+    en: 'See our ten-hour Cahuita day-trip itinerary →',
+    es: 'Ver nuestro itinerario de diez horas para un día en Cahuita →',
+    de: 'Sieh dir unseren Zehn-Stunden-Tagesausflug nach Cahuita an →',
+    fr: 'Découvrez notre itinéraire de dix heures pour une excursion à Cahuita →',
+    it: 'Guarda il nostro itinerario di dieci ore per una gita a Cahuita →',
+    pt: 'Veja nosso roteiro de dez horas para um bate-volta a Cahuita →',
+    he: 'צפו במסלול בן עשר השעות שלנו לטיול יום לקאהויטה ←',
+    hi: 'काहूइता की हमारी दस घंटे की दिन-यात्रा योजना देखें →',
+    nl: 'Bekijk onze tien uur durende dagtrip naar Cahuita →',
+  },
+  blogSanjoseOptions: {
+    en: 'Compare all the ways to get from San José to Puerto Viejo →',
+    es: 'Compara todas las formas de llegar de San José a Puerto Viejo →',
+    de: 'Vergleiche alle Möglichkeiten, von San José nach Puerto Viejo zu kommen →',
+    fr: 'Comparez tous les moyens de se rendre de San José à Puerto Viejo →',
+    it: 'Confronta tutti i modi per arrivare da San José a Puerto Viejo →',
+    pt: 'Compare todas as formas de ir de San José a Puerto Viejo →',
+    he: 'השוו בין כל הדרכים להגיע מסן חוזה לפוארטו-בייחו ←',
+    hi: 'सैन होज़े से पुएर्तो वियेजो पहुँचने के सभी तरीकों की तुलना करें →',
+    nl: 'Vergelijk alle manieren om van San José naar Puerto Viejo te reizen →',
+  },
+  blogWeather: {
+    en: 'Check the month-by-month weather guide →',
+    es: 'Consulta la guía del clima mes a mes →',
+    de: 'Sieh dir den Wetter-Guide Monat für Monat an →',
+    fr: 'Consultez le guide météo mois par mois →',
+    it: 'Consulta la guida meteo mese per mese →',
+    pt: 'Confira o guia do clima mês a mês →',
+    he: 'בדקו את מדריך מזג האוויר חודש אחר חודש ←',
+    hi: 'महीने-दर-महीने मौसम गाइड देखें →',
+    nl: 'Bekijk de maandelijkse weergids →',
+  },
+};
+
+/** Anchor text for an in-body link to `target`, in `locale` (falls back to English). */
+export function internalLinkLabel(target: RouteKey, locale: Locale): string {
+  const entry = LABELS[target];
+  if (!entry) {
+    throw new Error(`internalLinkLabel: no label registered for route "${target}"`);
+  }
+  return entry[locale] ?? entry.en;
+}
+
+/**
+ * Which in-depth guide each monthly weather post's "rainy day" activity list
+ * points readers to next — the activity that dominates that month's list
+ * (see rainyDayItems in blog.tsx's monthlyWeather data).
+ */
+export const RAINY_DAY_LINK_TARGET: Record<
+  'january' | 'february' | 'march' | 'april' | 'may' | 'june' | 'july' | 'august' | 'september' | 'october' | 'november' | 'december',
+  RouteKey
+> = {
+  january: 'blogBeaches',
+  february: 'blogIndigenous',
+  march: 'blogCahuitapark',
+  april: 'blogCahuitapark',
+  may: 'blogIndigenous',
+  june: 'blogGandocaRefuge',
+  july: 'blogBeaches',
+  august: 'blogIndigenous',
+  september: 'blogCahuitapark',
+  october: 'blogGandocaRefuge',
+  november: 'blogIndigenous',
+  december: 'blogBeaches',
+};

--- a/src/pages/Blog/Components/MonthlyWeatherArticle.tsx
+++ b/src/pages/Blog/Components/MonthlyWeatherArticle.tsx
@@ -15,6 +15,7 @@ import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { pathForKey, RouteKey } from "../../../routes.config";
 import { monthlyWeatherContent, MonthKey } from "../../../i18n/content/blog";
+import { internalLinkLabel, RAINY_DAY_LINK_TARGET } from "../../../i18n/content/internalLinks";
 
 interface IMonthlyWeatherArticle {
     /** Which month's content to render. */
@@ -37,6 +38,7 @@ const MonthlyWeatherArticle: FC<IMonthlyWeatherArticle> = ({ month, routeKey, sl
     const locale = useLocale();
     const m = useMessages();
     const content = monthlyWeatherContent(month, locale);
+    const rainyDayLinkTarget = RAINY_DAY_LINK_TARGET[month];
 
     useEffect(() => {
         window.scrollTo(0, 0);
@@ -128,6 +130,9 @@ const MonthlyWeatherArticle: FC<IMonthlyWeatherArticle> = ({ month, routeKey, sl
                         <ul>
                             {content.rainyDayItems.map((item, i) => <li key={i}>{item}</li>)}
                         </ul>
+                        <p>
+                            <Link to={pathForKey(rainyDayLinkTarget, locale)}><strong>{internalLinkLabel(rainyDayLinkTarget, locale)}</strong></Link>
+                        </p>
                         <br />
 
                         <h2>{content.crowdsHeading}</h2>

--- a/src/pages/Blog/staticPages/BestTimeToVisitPuerto.tsx
+++ b/src/pages/Blog/staticPages/BestTimeToVisitPuerto.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { Col, Row } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../../Listing/Listing.style.scss';
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import ContactUs from "../../../components/ContactUs/ContactUs.component";
@@ -12,6 +13,8 @@ import { generalPuertoViejoRecommendations } from "../../../utils/constants";
 import { useLocale, useMessages } from "../../../i18n";
 import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { bestTimeToVisitContent } from "../../../i18n/content/blog";
 
 const HERO_IMAGE = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d2/Lim%C3%B3n_Province%2C_Puerto_Viejo_de_Talamanca%2C_Costa_Rica_-_panoramio_%281%29.jpg/1280px-Lim%C3%B3n_Province%2C_Puerto_Viejo_de_Talamanca%2C_Costa_Rica_-_panoramio_%281%29.jpg?20170313071619";
@@ -112,6 +115,9 @@ const BestTimeToVisitPuerto = () => {
                         <ul>
                             {content.bestTimeListItems.map((item, i) => <li key={i}>{item}</li>)}
                         </ul>
+                        <p>
+                            <Link to={pathForKey('blogWeather', locale)}><strong>{internalLinkLabel('blogWeather', locale)}</strong></Link>
+                        </p>
 
                         <br />
 

--- a/src/pages/Blog/staticPages/BocasDelToro.tsx
+++ b/src/pages/Blog/staticPages/BocasDelToro.tsx
@@ -14,6 +14,7 @@ import { useLocale, useMessages } from "../../../i18n";
 import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { bocasDelToroContent } from "../../../i18n/content/blog";
 
 const HERO_IMAGE = "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/Lim%C3%B3n_Province%2C_Sixaola%2C_Costa_Rica_-_panoramio_%282%29.jpg/960px-Lim%C3%B3n_Province%2C_Sixaola%2C_Costa_Rica_-_panoramio_%282%29.jpg";
@@ -151,6 +152,9 @@ const BocasDelToro = () => {
 
                         <h2>{content.shuttleHeading}</h2>
                         {content.shuttleParagraphs.map((p, i) => <p key={i}>{p}</p>)}
+                        <p>
+                            <Link to={pathForKey('blogCahuitapark', locale)}><strong>{internalLinkLabel('blogCahuitapark', locale)}</strong></Link>
+                        </p>
                         <br />
                         <div style={{ overflowX: 'auto', marginBottom: '20px' }}>
                             <table style={{ width: '100%', borderCollapse: 'collapse', border: '1px solid #ddd' }}>

--- a/src/pages/Blog/staticPages/BusHours.tsx
+++ b/src/pages/Blog/staticPages/BusHours.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { Col, Row } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../../Listing/Listing.style.scss';
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import ContactUs from "../../../components/ContactUs/ContactUs.component";
@@ -12,6 +13,8 @@ import { generalPuertoViejoRecommendations } from "../../../utils/constants";
 import { useLocale, useMessages } from "../../../i18n";
 import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { busHoursContent, BusHoursContent } from "../../../i18n/content/blog";
 
 const HERO_IMAGE = "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/Lim%C3%B3n_Province%2C_Sixaola%2C_Costa_Rica_-_panoramio_%282%29.jpg/960px-Lim%C3%B3n_Province%2C_Sixaola%2C_Costa_Rica_-_panoramio_%282%29.jpg";
@@ -145,6 +148,9 @@ const BusHours = () => {
                         <ul>
                             {content.destinations.map((d) => <li key={d}><strong>{d.split(' - ')[0]}</strong> - {d.split(' - ')[1]}</li>)}
                         </ul>
+                        <p>
+                            <Link to={pathForKey('blogCahuitapark', locale)}><strong>{internalLinkLabel('blogCahuitapark', locale)}</strong></Link>
+                        </p>
                         <br />
                         <h3><strong>{content.schedulesHeading}</strong></h3>
                         <br />
@@ -175,6 +181,9 @@ const BusHours = () => {
                             ['Puerto Viejo → Manzanillo', ['7:40 AM', '8:10 AM', '9:40 AM', '11:40 AM', '1:40 PM', '4:40 PM', '6:40 PM']],
                             ['Manzanillo → Puerto Viejo', ['5:00 AM', '6:30 AM', '8:00 AM', '10:00 AM', '10:30 AM', '12:30 PM', '1:30 PM', '3:30 PM', '4:00 PM', '5:00 PM']],
                         ]} />
+                        <p>
+                            <Link to={pathForKey('blogGandocaRefuge', locale)}><strong>{internalLinkLabel('blogGandocaRefuge', locale)}</strong></Link>
+                        </p>
                         <br />
                         <h4><strong>{content.sixaolaHeading}</strong></h4>
                         <p>{content.sixaolaIntro}</p>
@@ -187,6 +196,10 @@ const BusHours = () => {
                                 ['6:30 AM', '7:30 AM', '8:30 AM', '9:30 AM', '10:30 AM', '11:30 AM', '12:30 PM', '1:30 PM', '2:30 PM', '3:30 PM', '4:30 PM', '5:30 PM', '6:30 PM', '7:30 PM', '8:15 PM'],
                                 ['6:30 AM', '8:30 AM', '10:30 AM', '12:30 PM', '2:30 PM', '4:30 PM', '6:30 PM', '8:15 PM']],
                         ]} />
+                        <p>
+                            <Link to={pathForKey('blogBocas', locale)}><strong>{internalLinkLabel('blogBocas', locale)}</strong></Link>
+                        </p>
+                        <br />
                     {/* Why Stay With Us Component - after main content, before OtherBlogs */}
                     <div style={{ maxWidth: 1000 }}>
                         <WhyStayWithUs

--- a/src/pages/Blog/staticPages/CahuitaPark.tsx
+++ b/src/pages/Blog/staticPages/CahuitaPark.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { Col, Row } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../../Listing/Listing.style.scss';
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import ContactUs from "../../../components/ContactUs/ContactUs.component";
@@ -12,6 +13,8 @@ import { generalPuertoViejoRecommendations } from "../../../utils/constants";
 import { useLocale, useMessages } from "../../../i18n";
 import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { cahuitaParkContent } from "../../../i18n/content/blog";
 
 const HERO_IMAGE = "https://upload.wikimedia.org/wikipedia/commons/thumb/1/11/Cahuita_national_park%2C_Costa_Rica.jpg/1280px-Cahuita_national_park%2C_Costa_Rica.jpg?20090819063715";
@@ -75,6 +78,9 @@ const CahuitaPark = () => {
                     <div className="description" style={{ maxWidth: 1000, }}>
 
                         {content.introParagraphs.map((p, i) => <p key={i}>{p}</p>)}
+                        <p>
+                            <Link to={pathForKey('blogTenhours', locale)}><strong>{internalLinkLabel('blogTenhours', locale)}</strong></Link>
+                        </p>
 
                         <br />
                         <h3><strong>{content.enterHeading}</strong></h3>

--- a/src/pages/Blog/staticPages/GandocaManzanilloRefuge.tsx
+++ b/src/pages/Blog/staticPages/GandocaManzanilloRefuge.tsx
@@ -14,6 +14,7 @@ import { useLocale, useMessages } from "../../../i18n";
 import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { gandocaRefugeContent } from "../../../i18n/content/blog";
 
 const HERO_IMAGE = "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/Lim%C3%B3n_Province%2C_Sixaola%2C_Costa_Rica_-_panoramio_%282%29.jpg/960px-Lim%C3%B3n_Province%2C_Sixaola%2C_Costa_Rica_-_panoramio_%282%29.jpg";
@@ -76,6 +77,9 @@ const GandocaManzanilloRefuge = () => {
                         <h2>{content.beachesHeading}</h2>
                         <p>{content.beachesParagraphs[0]}</p>
                         <p>{content.beachesParagraphs[1]}</p>
+                        <p>
+                            <Link to={pathForKey('blogBeaches', locale)}><strong>{internalLinkLabel('blogBeaches', locale)}</strong></Link>
+                        </p>
                         <br />
 
                         <h2>{content.thingsHeading}</h2>

--- a/src/pages/Blog/staticPages/GettingToGandoca.tsx
+++ b/src/pages/Blog/staticPages/GettingToGandoca.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { cdnImage, cdnSrcSet } from '../../../utils/imageCdn';
 import { Col, Row } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../../Listing/Listing.style.scss';
 
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
@@ -14,6 +15,8 @@ import { generalPuertoViejoRecommendations } from "../../../utils/constants";
 import { useLocale, useMessages } from "../../../i18n";
 import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { gettingToGandocaContent } from "../../../i18n/content/blog";
 
 // Matches the real "gettingtogandoca" thumbnail in assets/blogs/blogs.ts and
@@ -126,6 +129,10 @@ const GettingToGandoca = () => {
                                 </tbody>
                             </table>
                         </div>
+                        <p>
+                            <Link to={pathForKey('blogBushours', locale)}><strong>{internalLinkLabel('blogBushours', locale)}</strong></Link>
+                        </p>
+                        <br />
                         {/* Why Stay With Us Component - after main content, before OtherBlogs */}
                         <div style={{ maxWidth: 1000 }}>
                             <WhyStayWithUs
@@ -143,6 +150,10 @@ const GettingToGandoca = () => {
                         <br />
                         <h3><strong>{content.conclusionHeading}</strong></h3>
                         <p>{content.conclusionParagraph1}</p>
+                        <br />
+                        <p>
+                            <Link to={pathForKey('blogGandocaRefuge', locale)}><strong>{internalLinkLabel('blogGandocaRefuge', locale)}</strong></Link>
+                        </p>
                         <br />
                         <p>{content.conclusionParagraph2}</p>
                     </div>

--- a/src/pages/Blog/staticPages/IndigenousTravel.tsx
+++ b/src/pages/Blog/staticPages/IndigenousTravel.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { Col, Row } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../../Listing/Listing.style.scss';
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import ContactUs from "../../../components/ContactUs/ContactUs.component";
@@ -12,6 +13,8 @@ import { generalPuertoViejoRecommendations } from "../../../utils/constants";
 import { useLocale, useMessages } from "../../../i18n";
 import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { indigenousTravelContent } from "../../../i18n/content/blog";
 
 const HERO_IMAGE = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Palenque_bribri._Costa_Rica.jpg/960px-Palenque_bribri._Costa_Rica.jpg";
@@ -81,6 +84,10 @@ const IndigenousTravel = () => {
                         <br />
 
                         <p>{content.introParagraph}</p>
+                        <p>
+                            <Link to={pathForKey('blogBeaches', locale)}><strong>{internalLinkLabel('blogBeaches', locale)}</strong></Link>
+                        </p>
+                        <br />
                         {/* Stay Recommendation Component - positioned in middle of article */}
                         <StayRecommendation
                             title={content.stayRecommendationTitle}

--- a/src/pages/Blog/staticPages/PuertoHiddenGems.tsx
+++ b/src/pages/Blog/staticPages/PuertoHiddenGems.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { Col, Row } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../../Listing/Listing.style.scss';
 
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
@@ -13,6 +14,8 @@ import WhyStayWithUs from "../../../components/WhyStayWithUs/WhyStayWithUs.compo
 import { useLocale, useMessages } from "../../../i18n";
 import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { puertoHiddenGemsContent, HiddenGemSection } from "../../../i18n/content/blog";
 
 const HERO_IMAGE = "https://upload.wikimedia.org/wikipedia/commons/thumb/7/7f/Puerto_Viejo_de_Talamanca%2C_Costa_Rica_2012.JPG/960px-Puerto_Viejo_de_Talamanca%2C_Costa_Rica_2012.JPG?20120902175205";
@@ -114,6 +117,13 @@ const PuertoHiddenGems = () => {
                         {content.sections.slice(0, 6).map((section, i) => (
                             <Section key={i} section={section} />
                         ))}
+                        <p>
+                            <Link to={pathForKey('blogBeaches', locale)}><strong>{internalLinkLabel('blogBeaches', locale)}</strong></Link>
+                        </p>
+                        <p>
+                            <Link to={pathForKey('blogGandocaRefuge', locale)}><strong>{internalLinkLabel('blogGandocaRefuge', locale)}</strong></Link>
+                        </p>
+                        <br />
 
                         {/* Why Stay With Us Component - after main content, before OtherBlogs */}
                         <div style={{ maxWidth: 1000 }}>

--- a/src/pages/Blog/staticPages/PuertoViejoBeaches.tsx
+++ b/src/pages/Blog/staticPages/PuertoViejoBeaches.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { Col, Row } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../../Listing/Listing.style.scss';
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
 import ContactUs from "../../../components/ContactUs/ContactUs.component";
@@ -12,6 +13,8 @@ import { generalPuertoViejoRecommendations } from "../../../utils/constants";
 import { useLocale, useMessages } from "../../../i18n";
 import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { beachesContent } from "../../../i18n/content/blog";
 
 const HERO_IMAGE = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d2/Lim%C3%B3n_Province%2C_Puerto_Viejo_de_Talamanca%2C_Costa_Rica_-_panoramio_%281%29.jpg/1280px-Lim%C3%B3n_Province%2C_Puerto_Viejo_de_Talamanca%2C_Costa_Rica_-_panoramio_%281%29.jpg?20170313071619";
@@ -67,6 +70,9 @@ const PuertoViejoBeaches = () => {
                         {content.beaches.map((b) => (
                             <p key={b.name}><strong>{b.name}.</strong> {b.description}</p>
                         ))}
+                        <p>
+                            <Link to={pathForKey('blogGandocaRefuge', locale)}><strong>{internalLinkLabel('blogGandocaRefuge', locale)}</strong></Link>
+                        </p>
                         <br />
 
                         <StayRecommendation title={content.stayRecommendationTitle} properties={generalPuertoViejoRecommendations(locale)} />

--- a/src/pages/Blog/staticPages/PuertoViejoByPlane.tsx
+++ b/src/pages/Blog/staticPages/PuertoViejoByPlane.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { cdnImage, cdnSrcSet } from '../../../utils/imageCdn';
 import { Col, Row } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../../Listing/Listing.style.scss';
 
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
@@ -14,6 +15,8 @@ import { generalPuertoViejoRecommendations } from "../../../utils/constants";
 import { useLocale, useMessages } from "../../../i18n";
 import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { puertoViejoByPlaneContent } from "../../../i18n/content/blog";
 
 // The pre-merge English page pointed this at a placeholder id
@@ -98,6 +101,10 @@ const PuertoViejoByPlane = () => {
                                 <br />
                             </React.Fragment>
                         ))}
+                        <p>
+                            <Link to={pathForKey('blogBushours', locale)}><strong>{internalLinkLabel('blogBushours', locale)}</strong></Link>
+                        </p>
+                        <br />
 
                         {/* Why Stay With Us Component - after main content, before OtherBlogs */}
                         <div style={{ maxWidth: 1000 }}>
@@ -113,6 +120,10 @@ const PuertoViejoByPlane = () => {
                                 <br />
                             </React.Fragment>
                         ))}
+                        <p>
+                            <Link to={pathForKey('blogSanjoseOptions', locale)}><strong>{internalLinkLabel('blogSanjoseOptions', locale)}</strong></Link>
+                        </p>
+                        <br />
                     </div>
 
 

--- a/src/pages/Blog/staticPages/TenHoursInPuerto.tsx
+++ b/src/pages/Blog/staticPages/TenHoursInPuerto.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { cdnImage, cdnSrcSet } from '../../../utils/imageCdn';
 import { Col, Row } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../../Listing/Listing.style.scss';
 
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
@@ -14,6 +15,8 @@ import { cahuitaAreaRecommendations } from "../../../utils/constants";
 import { useLocale, useMessages } from "../../../i18n";
 import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { tenHoursInPuertoContent } from "../../../i18n/content/blog";
 
 const HERO_IMAGE =
@@ -83,6 +86,13 @@ const TenHoursInPuerto = () => {
                                 <br />
                             </React.Fragment>
                         ))}
+                        <p>
+                            <Link to={pathForKey('blogBushours', locale)}><strong>{internalLinkLabel('blogBushours', locale)}</strong></Link>
+                        </p>
+                        <p>
+                            <Link to={pathForKey('blogCahuitapark', locale)}><strong>{internalLinkLabel('blogCahuitapark', locale)}</strong></Link>
+                        </p>
+                        <br />
 
                         {/* Stay Recommendation Component - positioned in middle of article */}
                         <StayRecommendation

--- a/src/pages/Blog/staticPages/TravellingToPuerto.tsx
+++ b/src/pages/Blog/staticPages/TravellingToPuerto.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { cdnImage, cdnSrcSet } from '../../../utils/imageCdn';
 import { Col, Row } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../../Listing/Listing.style.scss';
 
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
@@ -14,6 +15,8 @@ import { generalPuertoViejoRecommendations } from "../../../utils/constants";
 import { useLocale, useMessages } from "../../../i18n";
 import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { travellingToPuertoContent } from "../../../i18n/content/blog";
 
 const HERO_IMAGE =
@@ -83,6 +86,10 @@ const TravellingToPuerto = () => {
                                 <br />
                             </React.Fragment>
                         ))}
+                        <p>
+                            <Link to={pathForKey('blogBushours', locale)}><strong>{internalLinkLabel('blogBushours', locale)}</strong></Link>
+                        </p>
+                        <br />
 
                         {/* Stay Recommendation Component - positioned in middle of article */}
                         <StayRecommendation
@@ -97,6 +104,10 @@ const TravellingToPuerto = () => {
                                 <br />
                             </React.Fragment>
                         ))}
+                        <p>
+                            <Link to={pathForKey('blogSanjoseOptions', locale)}><strong>{internalLinkLabel('blogSanjoseOptions', locale)}</strong></Link>
+                        </p>
+                        <br />
                     </div>
 
                     {/* Why Stay With Us Component - after main content, before OtherBlogs */}

--- a/src/pages/Blog/staticPages/TwoDaysInPV.tsx
+++ b/src/pages/Blog/staticPages/TwoDaysInPV.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { cdnImage, cdnSrcSet } from '../../../utils/imageCdn';
 import { Col, Row } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../../Listing/Listing.style.scss';
 
 import FixedNavigation from "../../../components/FixedNavigation/FixedNavigation.component";
@@ -14,6 +15,8 @@ import WhyStayWithUs from "../../../components/WhyStayWithUs/WhyStayWithUs.compo
 import { useLocale, useMessages } from "../../../i18n";
 import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { twoDaysInPVContent } from "../../../i18n/content/blog";
 
 const HERO_IMAGE =
@@ -92,6 +95,10 @@ const TwoDaysInPV = () => {
                                 <br />
                             </React.Fragment>
                         ))}
+                        <p>
+                            <Link to={pathForKey('blogBeaches', locale)}><strong>{internalLinkLabel('blogBeaches', locale)}</strong></Link>
+                        </p>
+                        <br />
 
                         {/* Why Stay With Us Component - after main content, before OtherBlogs */}
                         <div style={{ maxWidth: 1000 }}>

--- a/src/pages/Blog/staticPages/WeatherPuertoViejo.tsx
+++ b/src/pages/Blog/staticPages/WeatherPuertoViejo.tsx
@@ -14,6 +14,7 @@ import { useLocale, useMessages } from "../../../i18n";
 import { homePath } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
 import { pathForKey, RouteKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { weatherHubContent } from "../../../i18n/content/blog";
 
 const HERO_IMAGE = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d2/Lim%C3%B3n_Province%2C_Puerto_Viejo_de_Talamanca%2C_Costa_Rica_-_panoramio_%281%29.jpg/1280px-Lim%C3%B3n_Province%2C_Puerto_Viejo_de_Talamanca%2C_Costa_Rica_-_panoramio_%281%29.jpg?20170313071619";
@@ -153,6 +154,12 @@ const WeatherPuertoViejo = () => {
                         <ul>
                             {content.rainyListItems.map((item, i) => <li key={i}>{item}</li>)}
                         </ul>
+                        <p>
+                            <Link to={pathForKey('blogIndigenous', locale)}><strong>{internalLinkLabel('blogIndigenous', locale)}</strong></Link>
+                        </p>
+                        <p>
+                            <Link to={pathForKey('blogCahuitapark', locale)}><strong>{internalLinkLabel('blogCahuitapark', locale)}</strong></Link>
+                        </p>
                         <br />
 
                         {/* Why Stay With Us Component - after main content, before OtherBlogs */}

--- a/src/pages/Listing/staticPages/ListingAreka.page.tsx
+++ b/src/pages/Listing/staticPages/ListingAreka.page.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Col, Row, Button } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../Listing.style.scss'
 import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
@@ -20,6 +21,8 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 import { useLocale, useMessages } from "../../../i18n";
 import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { listingContent } from "../../../i18n/content/listings";
 import { vacationRentalJsonLd } from "../../../i18n/structuredData";
 import { houseDataByLangCode } from "../../../utils/constants";
@@ -117,6 +120,12 @@ const ListingAreka = () => {
                             const withBreak = typeof paragraph === 'string';
                             return <p key={i}>{text}{withBreak && <br />}</p>;
                         })}
+                        <p>
+                            <Link to={pathForKey('blogBeaches', locale)}><strong>{internalLinkLabel('blogBeaches', locale)}</strong></Link>
+                        </p>
+                        <p>
+                            <Link to={pathForKey('blogCahuitapark', locale)}><strong>{internalLinkLabel('blogCahuitapark', locale)}</strong></Link>
+                        </p>
                     </div>
 
                     <GuestReviews propertyKey="AREKA" locale={locale} />

--- a/src/pages/Listing/staticPages/ListingDelfin.page.tsx
+++ b/src/pages/Listing/staticPages/ListingDelfin.page.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Col, Row, Button } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../Listing.style.scss'
 import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
@@ -20,6 +21,8 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 import { useLocale, useMessages } from "../../../i18n";
 import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { listingContent } from "../../../i18n/content/listings";
 import { vacationRentalJsonLd } from "../../../i18n/structuredData";
 import { houseDataByLangCode } from "../../../utils/constants";
@@ -118,6 +121,12 @@ const ListingDelfin = () => {
                             const withBreak = typeof paragraph === 'string';
                             return <p key={i}>{text}{withBreak && <br />}</p>;
                         })}
+                        <p>
+                            <Link to={pathForKey('blogCahuitapark', locale)}><strong>{internalLinkLabel('blogCahuitapark', locale)}</strong></Link>
+                        </p>
+                        <p>
+                            <Link to={pathForKey('blogBushours', locale)}><strong>{internalLinkLabel('blogBushours', locale)}</strong></Link>
+                        </p>
                     </div>
 
                     <GuestReviews propertyKey="DELFINES" locale={locale} />

--- a/src/pages/Listing/staticPages/ListingGeco.page.tsx
+++ b/src/pages/Listing/staticPages/ListingGeco.page.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Col, Row, Button } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../Listing.style.scss'
 import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
@@ -21,6 +22,8 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 import { useLocale, useMessages } from "../../../i18n";
 import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { listingContent } from "../../../i18n/content/listings";
 import { vacationRentalJsonLd } from "../../../i18n/structuredData";
 import { houseDataByLangCode } from "../../../utils/constants";
@@ -119,6 +122,12 @@ const ListingGeco = () => {
                             const withBreak = typeof paragraph === 'string';
                             return <p key={i}>{text}{withBreak && <br />}</p>;
                         })}
+                        <p>
+                            <Link to={pathForKey('blogCahuitapark', locale)}><strong>{internalLinkLabel('blogCahuitapark', locale)}</strong></Link>
+                        </p>
+                        <p>
+                            <Link to={pathForKey('blogBushours', locale)}><strong>{internalLinkLabel('blogBushours', locale)}</strong></Link>
+                        </p>
                     </div>
 
                     <GuestReviews propertyKey="GECO" locale={locale} />

--- a/src/pages/Listing/staticPages/ListingGiulia.page.tsx
+++ b/src/pages/Listing/staticPages/ListingGiulia.page.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Col, Row, Button } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../Listing.style.scss'
 import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
@@ -20,6 +21,8 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 import { useLocale, useMessages } from "../../../i18n";
 import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { listingContent } from "../../../i18n/content/listings";
 import { vacationRentalJsonLd } from "../../../i18n/structuredData";
 import { houseDataByLangCode } from "../../../utils/constants";
@@ -115,6 +118,12 @@ const ListingGiulia = () => {
                             const withBreak = typeof paragraph === 'string';
                             return <p key={i}>{text}{withBreak && <br />}</p>;
                         })}
+                        <p>
+                            <Link to={pathForKey('blogBeaches', locale)}><strong>{internalLinkLabel('blogBeaches', locale)}</strong></Link>
+                        </p>
+                        <p>
+                            <Link to={pathForKey('blogCahuitapark', locale)}><strong>{internalLinkLabel('blogCahuitapark', locale)}</strong></Link>
+                        </p>
                     </div>
 
                     <GuestReviews propertyKey="GIULIA" locale={locale} />

--- a/src/pages/Listing/staticPages/ListingPappagallo.page.tsx
+++ b/src/pages/Listing/staticPages/ListingPappagallo.page.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Col, Row, Button } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../Listing.style.scss'
 import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
@@ -20,6 +21,8 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 import { useLocale, useMessages } from "../../../i18n";
 import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { listingContent } from "../../../i18n/content/listings";
 import { vacationRentalJsonLd } from "../../../i18n/structuredData";
 import { houseDataByLangCode } from "../../../utils/constants";
@@ -116,6 +119,12 @@ const ListingPappagallo = () => {
                             const withBreak = typeof paragraph === 'string';
                             return <p key={i}>{text}{withBreak && <br />}</p>;
                         })}
+                        <p>
+                            <Link to={pathForKey('blogCahuitapark', locale)}><strong>{internalLinkLabel('blogCahuitapark', locale)}</strong></Link>
+                        </p>
+                        <p>
+                            <Link to={pathForKey('blogBushours', locale)}><strong>{internalLinkLabel('blogBushours', locale)}</strong></Link>
+                        </p>
                     </div>
 
                     <GuestReviews propertyKey="PAPPAGALLO" locale={locale} />

--- a/src/pages/Listing/staticPages/ListingPlumeria.page.tsx
+++ b/src/pages/Listing/staticPages/ListingPlumeria.page.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Col, Row, Button } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../Listing.style.scss'
 import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
@@ -20,6 +21,8 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 import { useLocale, useMessages } from "../../../i18n";
 import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { listingContent } from "../../../i18n/content/listings";
 import { vacationRentalJsonLd } from "../../../i18n/structuredData";
 import { houseDataByLangCode } from "../../../utils/constants";
@@ -115,6 +118,12 @@ const ListingPlumeria = () => {
                             const withBreak = typeof paragraph === 'string';
                             return <p key={i}>{text}{withBreak && <br />}</p>;
                         })}
+                        <p>
+                            <Link to={pathForKey('blogBeaches', locale)}><strong>{internalLinkLabel('blogBeaches', locale)}</strong></Link>
+                        </p>
+                        <p>
+                            <Link to={pathForKey('blogCahuitapark', locale)}><strong>{internalLinkLabel('blogCahuitapark', locale)}</strong></Link>
+                        </p>
                     </div>
 
                     <GuestReviews propertyKey="PLUMERIA" locale={locale} />

--- a/src/pages/Listing/staticPages/ListingRana.page.tsx
+++ b/src/pages/Listing/staticPages/ListingRana.page.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Col, Row, Button } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../Listing.style.scss'
 import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
@@ -20,6 +21,8 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 import { useLocale, useMessages } from "../../../i18n";
 import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { listingContent } from "../../../i18n/content/listings";
 import { vacationRentalJsonLd } from "../../../i18n/structuredData";
 import { houseDataByLangCode } from "../../../utils/constants";
@@ -117,6 +120,12 @@ const ListingRana = () => {
                             const withBreak = typeof paragraph === 'string';
                             return <p key={i}>{text}{withBreak && <br />}</p>;
                         })}
+                        <p>
+                            <Link to={pathForKey('blogCahuitapark', locale)}><strong>{internalLinkLabel('blogCahuitapark', locale)}</strong></Link>
+                        </p>
+                        <p>
+                            <Link to={pathForKey('blogBushours', locale)}><strong>{internalLinkLabel('blogBushours', locale)}</strong></Link>
+                        </p>
                     </div>
 
                     <GuestReviews propertyKey="RANA" locale={locale} />

--- a/src/pages/Listing/staticPages/ListingTucano.page.tsx
+++ b/src/pages/Listing/staticPages/ListingTucano.page.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Col, Row, Button } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../Listing.style.scss'
 import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
@@ -20,6 +21,8 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 import { useLocale, useMessages } from "../../../i18n";
 import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { listingContent } from "../../../i18n/content/listings";
 import { vacationRentalJsonLd } from "../../../i18n/structuredData";
 import { houseDataByLangCode } from "../../../utils/constants";
@@ -116,6 +119,12 @@ const ListingTucano = () => {
                             const withBreak = typeof paragraph === 'string';
                             return <p key={i}>{text}{withBreak && <br />}</p>;
                         })}
+                        <p>
+                            <Link to={pathForKey('blogCahuitapark', locale)}><strong>{internalLinkLabel('blogCahuitapark', locale)}</strong></Link>
+                        </p>
+                        <p>
+                            <Link to={pathForKey('blogBushours', locale)}><strong>{internalLinkLabel('blogBushours', locale)}</strong></Link>
+                        </p>
                     </div>
 
                     <GuestReviews propertyKey="TUCANO" locale={locale} />

--- a/src/pages/Listing/staticPages/ListingVillaCoral.page.tsx
+++ b/src/pages/Listing/staticPages/ListingVillaCoral.page.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Col, Row, Button } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../Listing.style.scss'
 import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
@@ -20,6 +21,8 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 import { useLocale, useMessages } from "../../../i18n";
 import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { listingContent } from "../../../i18n/content/listings";
 import { vacationRentalJsonLd } from "../../../i18n/structuredData";
 import { houseDataByLangCode } from "../../../utils/constants";
@@ -123,6 +126,12 @@ const ListingVillaCoral = () => {
                             const withBreak = typeof paragraph === 'string';
                             return <p key={i}>{text}{withBreak && <br />}</p>;
                         })}
+                        <p>
+                            <Link to={pathForKey('blogBeaches', locale)}><strong>{internalLinkLabel('blogBeaches', locale)}</strong></Link>
+                        </p>
+                        <p>
+                            <Link to={pathForKey('blogBushours', locale)}><strong>{internalLinkLabel('blogBushours', locale)}</strong></Link>
+                        </p>
                     </div>
 
                     <GuestReviews propertyKey="VILLA CORAL" locale={locale} />

--- a/src/pages/Listing/staticPages/ListingVillaMar.page.tsx
+++ b/src/pages/Listing/staticPages/ListingVillaMar.page.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Col, Row, Button } from "react-bootstrap";
+import { Link } from "react-router-dom";
 import '../Listing.style.scss'
 import OtherListings from "../components/OtherListings/OtherListings.component";
 import BookingSearchWidget from "../../../components/BookingSearchWidget/BookingSearchWidget.component";
@@ -20,6 +21,8 @@ import GuestReviews from "../../../components/GuestReviews/GuestReviews.componen
 import { useLocale, useMessages } from "../../../i18n";
 import { localeSuffix } from "../../../i18n/paths";
 import { canonicalUrl, hreflangLinks } from "../../../i18n/seo";
+import { pathForKey } from "../../../routes.config";
+import { internalLinkLabel } from "../../../i18n/content/internalLinks";
 import { listingContent } from "../../../i18n/content/listings";
 import { vacationRentalJsonLd } from "../../../i18n/structuredData";
 import { houseDataByLangCode } from "../../../utils/constants";
@@ -123,6 +126,12 @@ const ListingVillaMar = () => {
                             const withBreak = typeof paragraph === 'string';
                             return <p key={i}>{text}{withBreak && <br />}</p>;
                         })}
+                        <p>
+                            <Link to={pathForKey('blogBeaches', locale)}><strong>{internalLinkLabel('blogBeaches', locale)}</strong></Link>
+                        </p>
+                        <p>
+                            <Link to={pathForKey('blogBushours', locale)}><strong>{internalLinkLabel('blogBushours', locale)}</strong></Link>
+                        </p>
                     </div>
 
                     <GuestReviews propertyKey="VILLA MAR" locale={locale} />


### PR DESCRIPTION
## Summary
- Audited all 27 blog posts and 10 listing pages for in-body internal-linking opportunities (no page previously had contextual links beyond the bottom-of-page card carousels).
- Added `src/i18n/content/internalLinks.ts`: a shared, pre-translated (9 locales) anchor-text label per target route, reused wherever that target is linked to — avoids duplicating translated fields into every content object for a link that already exists elsewhere.
- Wired links into 14 blog posts (blog↔blog), all 12 monthly weather posts (via one shared-component edit + a month→route map), and all 10 listing pages (listing→blog), following the site's existing `<Link to={pathForKey(...)}>` convention.

## Not included
Skipped adding "sister property" links between listings that share near-identical marketing copy (Pappagallo/Tucano, Areka/Giulia/Plumeria, VillaCoral/VillaMar) — no listing's own text confirms the underlying relationship (same building, etc.) as fact, so asserting it in guest-facing copy felt like a content risk rather than a straightforward link. Flagging for the listing owner to confirm before adding.

## Test plan
- [x] `tsc --noEmit` passes with no errors
- [x] No duplicate imports introduced
- [ ] Visual smoke test of a few updated pages (blog + listing) in a running dev server
- [ ] Spot-check non-English locales render the new link text correctly (RTL for Hebrew in particular)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLcEMAc4Zw4UnXgKipUJqg